### PR TITLE
Implement xa11y workspace structure with cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,169 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  # Core crate tests — run on all platforms (platform-agnostic)
+  test-core:
+    name: Core Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-core-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-core-
+
+      - name: Build xa11y-core
+        run: cargo build -p xa11y-core
+
+      - name: Test xa11y-core
+        run: cargo test -p xa11y-core --verbose
+
+  # Platform-specific integration tests
+  test-linux:
+    name: Linux Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install AT-SPI2 dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            at-spi2-core \
+            libatspi2.0-dev \
+            libdbus-1-dev \
+            pkg-config
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: linux-cargo-integ-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            linux-cargo-integ-
+
+      - name: Build all crates
+        run: cargo build --workspace
+
+      - name: Run all tests
+        run: cargo test --workspace --verbose
+
+  test-macos:
+    name: macOS Integration Tests
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: macos-cargo-integ-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            macos-cargo-integ-
+
+      - name: Build all crates
+        run: cargo build --workspace
+
+      - name: Run all tests
+        run: cargo test --workspace --verbose
+
+  test-windows:
+    name: Windows Integration Tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: windows-cargo-integ-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            windows-cargo-integ-
+
+      - name: Build all crates
+        run: cargo build --workspace
+
+      - name: Run all tests
+        run: cargo test --workspace --verbose
+
+  # Lint and format check
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install AT-SPI2 dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            at-spi2-core \
+            libatspi2.0-dev \
+            libdbus-1-dev \
+            pkg-config
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: linux-cargo-lint-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            linux-cargo-lint-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy (all crates)
+        run: cargo clippy --workspace -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target
+Cargo.lock
+*.swp
+*.swo
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+[workspace]
+resolver = "2"
+members = [
+    "xa11y-core",
+    "xa11y-macos",
+    "xa11y-windows",
+    "xa11y-linux",
+    "xa11y",
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/xa11y/xa11y"
+
+[workspace.dependencies]
+xa11y-core = { path = "xa11y-core" }
+thiserror = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/xa11y-core/Cargo.toml
+++ b/xa11y-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "xa11y-core"
+description = "Core types, traits, and selectors for xa11y cross-platform accessibility"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/xa11y-core/src/action.rs
+++ b/xa11y-core/src/action.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+
+/// Normalized enum of interactions that can be performed on accessibility elements.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Action {
+    /// Click / tap / invoke
+    Press,
+    /// Set keyboard focus
+    Focus,
+    /// Set text content or numeric value
+    SetValue,
+    /// Toggle CheckBox, Switch
+    Toggle,
+    /// Expand a collapsible element
+    Expand,
+    /// Collapse an expanded element
+    Collapse,
+    /// Selection in a list/table
+    Select,
+    /// Context menu / dropdown
+    ShowMenu,
+    /// Scroll element into visible area
+    ScrollIntoView,
+    /// Increment slider / spinner
+    Increment,
+    /// Decrement slider / spinner
+    Decrement,
+}
+
+/// Direction for scroll actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ScrollDirection {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+/// Data payload for actions that require additional parameters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ActionData {
+    /// String value for SetValue on text fields
+    Value(String),
+    /// Numeric value for SetValue on sliders
+    NumericValue(f64),
+    /// Scroll amount and direction
+    ScrollAmount {
+        direction: ScrollDirection,
+        amount: f64,
+    },
+    /// Point coordinates
+    Point { x: f64, y: f64 },
+}

--- a/xa11y-core/src/error.rs
+++ b/xa11y-core/src/error.rs
@@ -1,0 +1,44 @@
+use thiserror::Error;
+
+/// Result type for xa11y operations.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error types for xa11y operations.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Accessibility permissions not granted
+    #[error("accessibility permission denied: {0}")]
+    PermissionDenied(String),
+
+    /// Target application not found
+    #[error("application not found: {0}")]
+    AppNotFound(String),
+
+    /// Node not found in tree
+    #[error("node not found: {0}")]
+    NodeNotFound(u32),
+
+    /// Action not supported on this element
+    #[error("action not supported: {0}")]
+    ActionNotSupported(String),
+
+    /// Invalid selector syntax
+    #[error("invalid selector: {0}")]
+    InvalidSelector(String),
+
+    /// Operation timed out
+    #[error("operation timed out after {0:?}")]
+    Timeout(std::time::Duration),
+
+    /// Platform-specific error
+    #[error("platform error: {0}")]
+    Platform(String),
+
+    /// Element became stale (UI changed since snapshot)
+    #[error("element stale: node {0} no longer exists")]
+    StaleElement(u32),
+
+    /// Serialization/deserialization error
+    #[error("serialization error: {0}")]
+    Serialization(String),
+}

--- a/xa11y-core/src/event.rs
+++ b/xa11y-core/src/event.rs
@@ -1,0 +1,158 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::node::Node;
+use crate::provider::AppInfo;
+
+/// Categories of accessibility events, normalized across platforms.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EventKind {
+    /// An element gained keyboard focus.
+    FocusChanged,
+    /// An element's value changed (text content, slider position, etc.).
+    ValueChanged,
+    /// An element's name/label changed.
+    NameChanged,
+    /// A boolean state flag changed (enabled, checked, expanded, selected, busy, etc.).
+    StateChanged,
+    /// Children were added or removed from an element.
+    StructureChanged,
+    /// A new window was created.
+    WindowOpened,
+    /// A window was closed/destroyed.
+    WindowClosed,
+    /// A window was activated (brought to front / received focus).
+    WindowActivated,
+    /// A window was deactivated (lost focus to another window).
+    WindowDeactivated,
+    /// Selection changed in a list, table, or text.
+    SelectionChanged,
+    /// A menu was opened.
+    MenuOpened,
+    /// A menu was closed.
+    MenuClosed,
+    /// An alert or notification was posted.
+    Alert,
+}
+
+/// Individual state flags, for use in StateChanged events and filters.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum StateFlag {
+    Enabled,
+    Visible,
+    Focused,
+    Checked,
+    Selected,
+    Expanded,
+    Editable,
+    Required,
+    Busy,
+}
+
+/// An accessibility event delivered to subscribers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    /// What kind of event occurred.
+    pub kind: EventKind,
+    /// The application that produced this event.
+    pub app: AppInfo,
+    /// A snapshot of the element that triggered the event, if available.
+    pub target: Option<Node>,
+    /// For StateChanged events: which state flag changed.
+    pub state_flag: Option<StateFlag>,
+    /// For StateChanged events: the new value of the flag.
+    pub state_value: Option<bool>,
+    /// Monotonic timestamp (time since subscription started).
+    #[serde(with = "duration_millis")]
+    pub timestamp: Duration,
+}
+
+/// Filter to narrow which events are delivered.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EventFilter {
+    /// Which event kinds to subscribe to. Empty = all events.
+    pub kinds: Vec<EventKind>,
+    /// Only deliver events from elements matching this selector.
+    pub selector: Option<String>,
+    /// For StateChanged events: only these state flags.
+    pub state_flags: Vec<StateFlag>,
+}
+
+impl EventFilter {
+    /// Subscribe to all events from the target.
+    pub fn all() -> Self {
+        Self::default()
+    }
+
+    /// Subscribe to specific event kinds.
+    pub fn kinds(kinds: &[EventKind]) -> Self {
+        Self {
+            kinds: kinds.to_vec(),
+            ..Default::default()
+        }
+    }
+
+    /// Subscribe to events on elements matching a selector.
+    pub fn selector(selector: &str) -> Self {
+        Self {
+            selector: Some(selector.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Combine kind filter with selector filter.
+    pub fn new(kinds: &[EventKind], selector: Option<&str>) -> Self {
+        Self {
+            kinds: kinds.to_vec(),
+            selector: selector.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    /// Check if an event matches this filter.
+    pub fn matches(&self, event: &Event) -> bool {
+        if !self.kinds.is_empty() && !self.kinds.contains(&event.kind) {
+            return false;
+        }
+        if !self.state_flags.is_empty() {
+            if let Some(flag) = event.state_flag {
+                if !self.state_flags.contains(&flag) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+/// Desired element state for wait_for operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ElementState {
+    /// Wait until an element matching the selector exists in the tree.
+    Attached,
+    /// Wait until no element matches the selector.
+    Detached,
+    /// Wait until a matching element exists and is visible.
+    Visible,
+    /// Wait until a matching element is hidden or doesn't exist.
+    Hidden,
+    /// Wait until a matching element is enabled.
+    Enabled,
+}
+
+mod duration_millis {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_u64(d.as_millis() as u64)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+        let millis = u64::deserialize(d)?;
+        Ok(Duration::from_millis(millis))
+    }
+}

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -1,0 +1,20 @@
+pub mod action;
+pub mod error;
+pub mod event;
+pub mod node;
+pub mod provider;
+pub mod role;
+pub mod selector;
+pub mod tree;
+
+pub use action::{Action, ActionData, ScrollDirection};
+pub use error::{Error, Result};
+pub use event::{ElementState, Event, EventFilter, EventKind, StateFlag};
+pub use node::{Node, NodeId, NormalizedRect, RawPlatformData, Rect, StateSet, Toggled};
+pub use provider::{
+    AppInfo, AppTarget, EventProvider, EventReceiver, PermissionStatus, Provider, QueryOptions,
+    Subscription, WindowHandle,
+};
+pub use role::Role;
+pub use selector::Selector;
+pub use tree::Tree;

--- a/xa11y-core/src/node.rs
+++ b/xa11y-core/src/node.rs
@@ -1,0 +1,138 @@
+use serde::{Deserialize, Serialize};
+
+use crate::action::Action;
+use crate::role::Role;
+
+/// Unique identifier for a node within a snapshot (sequential, deterministic DFS order).
+pub type NodeId = u32;
+
+/// Screen-pixel bounding rectangle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+/// Bounding rectangle normalized to [0.0, 1.0] range relative to screen dimensions.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct NormalizedRect {
+    /// Left edge
+    pub x1: f64,
+    /// Top edge
+    pub y1: f64,
+    /// Right edge
+    pub x2: f64,
+    /// Bottom edge
+    pub y2: f64,
+}
+
+/// Tri-state toggle value for checkboxes and similar elements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Toggled {
+    Off,
+    On,
+    /// Indeterminate / tri-state
+    Mixed,
+}
+
+/// Boolean state flags for an accessibility element.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StateSet {
+    pub enabled: bool,
+    pub visible: bool,
+    pub focused: bool,
+    /// None = not checkable
+    pub checked: Option<Toggled>,
+    pub selected: bool,
+    /// None = not expandable
+    pub expanded: Option<bool>,
+    pub editable: bool,
+    /// Form field required
+    pub required: bool,
+    /// Async operation in progress
+    pub busy: bool,
+}
+
+impl Default for StateSet {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            visible: true,
+            focused: false,
+            checked: None,
+            selected: false,
+            expanded: None,
+            editable: false,
+            required: false,
+            busy: false,
+        }
+    }
+}
+
+/// Platform-specific raw data, for debugging and escape-hatch access.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RawPlatformData {
+    MacOS {
+        ax_role: String,
+        ax_subrole: Option<String>,
+        ax_identifier: Option<String>,
+    },
+    Windows {
+        control_type_id: i32,
+        automation_id: Option<String>,
+        class_name: Option<String>,
+    },
+    Linux {
+        atspi_role: String,
+        bus_name: String,
+        object_path: String,
+    },
+}
+
+/// A single element in the accessibility tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    /// Unique ID within a snapshot (sequential, deterministic DFS order)
+    pub id: NodeId,
+
+    /// Element role
+    pub role: Role,
+
+    /// Human-readable name (title, label)
+    pub name: Option<String>,
+
+    /// Current value (text content, slider position, etc.)
+    pub value: Option<String>,
+
+    /// Supplementary description (tooltip, help text)
+    pub description: Option<String>,
+
+    /// Bounding rectangle in screen pixels
+    pub bounds: Option<Rect>,
+
+    /// Bounding box normalized to [0.0, 1.0] relative to screen dimensions
+    pub bounds_normalized: Option<NormalizedRect>,
+
+    /// Available actions
+    pub actions: Vec<Action>,
+
+    /// Current state flags
+    pub states: StateSet,
+
+    /// Child node IDs (direct children only)
+    pub children: Vec<NodeId>,
+
+    /// Parent node ID (None for root)
+    pub parent: Option<NodeId>,
+
+    /// Depth in the tree (0 = root)
+    pub depth: u32,
+
+    /// Application name (useful when querying all apps)
+    pub app_name: Option<String>,
+
+    /// Platform-specific raw data (opt-in, for debugging)
+    pub raw: Option<RawPlatformData>,
+}

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -1,0 +1,159 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::action::{Action, ActionData};
+use crate::error::Result;
+use crate::event::{ElementState, Event, EventFilter};
+use crate::node::{Node, NodeId};
+use crate::role::Role;
+use crate::tree::Tree;
+
+/// Target application for accessibility queries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AppTarget {
+    /// Find application by name
+    ByName(String),
+    /// Find application by process ID
+    ByPid(u32),
+    /// Target a specific window by platform-specific handle
+    ByWindow(WindowHandle),
+}
+
+/// Platform-specific window handle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowHandle {
+    /// Platform-specific window identifier
+    pub id: u64,
+}
+
+/// Options controlling tree traversal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryOptions {
+    /// Maximum depth to traverse (0 = root only)
+    pub max_depth: u32,
+    /// Maximum number of elements to return
+    pub max_elements: u32,
+    /// Only include visible elements
+    pub visible_only: bool,
+    /// Filter to specific roles
+    pub roles: Option<Vec<Role>>,
+    /// Include platform-specific raw data
+    pub include_raw: bool,
+}
+
+impl Default for QueryOptions {
+    fn default() -> Self {
+        Self {
+            max_depth: u32::MAX,
+            max_elements: u32::MAX,
+            visible_only: false,
+            roles: None,
+            include_raw: false,
+        }
+    }
+}
+
+/// Information about a running application.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppInfo {
+    /// Application name
+    pub name: String,
+    /// Process ID
+    pub pid: u32,
+    /// Bundle identifier (macOS)
+    pub bundle_id: Option<String>,
+}
+
+/// Accessibility permission status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PermissionStatus {
+    /// Accessibility access is granted
+    Granted,
+    /// Accessibility access is denied
+    Denied {
+        /// Human-readable instructions for granting access
+        instructions: String,
+    },
+}
+
+/// Platform backend trait for accessing accessibility trees.
+pub trait Provider: Send + Sync {
+    /// Snapshot a specific application's accessibility tree.
+    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree>;
+
+    /// Snapshot all running applications (shallow).
+    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree>;
+
+    /// Perform an action on an element from the last snapshot.
+    fn perform_action(
+        &self,
+        node_id: NodeId,
+        action: Action,
+        data: Option<ActionData>,
+    ) -> Result<()>;
+
+    /// Check if accessibility permissions are granted.
+    fn check_permissions(&self) -> Result<PermissionStatus>;
+
+    /// List running applications with their PIDs.
+    fn list_apps(&self) -> Result<Vec<AppInfo>>;
+}
+
+/// Optional trait for backends that support event subscriptions.
+pub trait EventProvider: Provider {
+    /// Subscribe to events matching the given filter.
+    fn subscribe(&self, target: &AppTarget, filter: EventFilter) -> Result<Subscription>;
+
+    /// Wait for a single event matching the filter, with timeout.
+    fn wait_for_event(
+        &self,
+        target: &AppTarget,
+        filter: EventFilter,
+        timeout: Duration,
+    ) -> Result<Event>;
+
+    /// Wait for an element matching the selector to reach the desired state.
+    fn wait_for(
+        &self,
+        target: &AppTarget,
+        selector: &str,
+        state: ElementState,
+        timeout: Duration,
+    ) -> Result<Node>;
+}
+
+/// A live event subscription. Drop to unsubscribe.
+pub struct Subscription {
+    /// Receive events from this channel.
+    pub rx: EventReceiver,
+    /// Internal cancel handle
+    _cancel: Box<dyn Send>,
+}
+
+impl Subscription {
+    /// Create a new subscription with a receiver and cancel handle.
+    pub fn new(rx: EventReceiver, cancel: Box<dyn Send>) -> Self {
+        Self {
+            rx,
+            _cancel: cancel,
+        }
+    }
+}
+
+/// Platform-agnostic event receiver.
+pub struct EventReceiver {
+    inner: Box<dyn FnMut() -> Option<Event> + Send>,
+}
+
+impl EventReceiver {
+    /// Create a new event receiver from a polling function.
+    pub fn new(poll_fn: Box<dyn FnMut() -> Option<Event> + Send>) -> Self {
+        Self { inner: poll_fn }
+    }
+
+    /// Try to receive without blocking (returns None if no event ready).
+    pub fn try_recv(&mut self) -> Option<Event> {
+        (self.inner)()
+    }
+}

--- a/xa11y-core/src/role.rs
+++ b/xa11y-core/src/role.rs
@@ -1,0 +1,136 @@
+use serde::{Deserialize, Serialize};
+
+/// Normalized enum covering UI element types across all platforms.
+/// Derived from ARIA roles, scoped to roles commonly surfaced by real desktop applications.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Role {
+    Unknown,
+    Window,
+    Application,
+    Button,
+    CheckBox,
+    RadioButton,
+    /// Single-line text input
+    TextField,
+    /// Multi-line text input
+    TextArea,
+    /// Non-editable text / label
+    StaticText,
+    ComboBox,
+    List,
+    ListItem,
+    Menu,
+    MenuItem,
+    MenuBar,
+    Tab,
+    TabGroup,
+    Table,
+    TableRow,
+    TableCell,
+    Toolbar,
+    ScrollBar,
+    Slider,
+    Image,
+    Link,
+    /// Generic container
+    Group,
+    Dialog,
+    Alert,
+    ProgressBar,
+    TreeItem,
+    /// Web content area / document
+    WebArea,
+    Heading,
+    Separator,
+    SplitGroup,
+}
+
+impl Role {
+    /// Parse a role from a CSS-like selector string (snake_case).
+    pub fn from_selector(s: &str) -> Option<Self> {
+        match s {
+            "unknown" => Some(Role::Unknown),
+            "window" => Some(Role::Window),
+            "application" => Some(Role::Application),
+            "button" => Some(Role::Button),
+            "check_box" | "checkbox" => Some(Role::CheckBox),
+            "radio_button" => Some(Role::RadioButton),
+            "text_field" => Some(Role::TextField),
+            "text_area" => Some(Role::TextArea),
+            "static_text" => Some(Role::StaticText),
+            "combo_box" | "combobox" => Some(Role::ComboBox),
+            "list" => Some(Role::List),
+            "list_item" => Some(Role::ListItem),
+            "menu" => Some(Role::Menu),
+            "menu_item" => Some(Role::MenuItem),
+            "menu_bar" => Some(Role::MenuBar),
+            "tab" => Some(Role::Tab),
+            "tab_group" => Some(Role::TabGroup),
+            "table" => Some(Role::Table),
+            "table_row" => Some(Role::TableRow),
+            "table_cell" => Some(Role::TableCell),
+            "toolbar" => Some(Role::Toolbar),
+            "scroll_bar" => Some(Role::ScrollBar),
+            "slider" => Some(Role::Slider),
+            "image" => Some(Role::Image),
+            "link" => Some(Role::Link),
+            "group" => Some(Role::Group),
+            "dialog" => Some(Role::Dialog),
+            "alert" => Some(Role::Alert),
+            "progress_bar" => Some(Role::ProgressBar),
+            "tree_item" => Some(Role::TreeItem),
+            "web_area" => Some(Role::WebArea),
+            "heading" => Some(Role::Heading),
+            "separator" => Some(Role::Separator),
+            "split_group" => Some(Role::SplitGroup),
+            _ => None,
+        }
+    }
+
+    /// Returns the selector string for this role.
+    pub fn as_selector(&self) -> &'static str {
+        match self {
+            Role::Unknown => "unknown",
+            Role::Window => "window",
+            Role::Application => "application",
+            Role::Button => "button",
+            Role::CheckBox => "check_box",
+            Role::RadioButton => "radio_button",
+            Role::TextField => "text_field",
+            Role::TextArea => "text_area",
+            Role::StaticText => "static_text",
+            Role::ComboBox => "combo_box",
+            Role::List => "list",
+            Role::ListItem => "list_item",
+            Role::Menu => "menu",
+            Role::MenuItem => "menu_item",
+            Role::MenuBar => "menu_bar",
+            Role::Tab => "tab",
+            Role::TabGroup => "tab_group",
+            Role::Table => "table",
+            Role::TableRow => "table_row",
+            Role::TableCell => "table_cell",
+            Role::Toolbar => "toolbar",
+            Role::ScrollBar => "scroll_bar",
+            Role::Slider => "slider",
+            Role::Image => "image",
+            Role::Link => "link",
+            Role::Group => "group",
+            Role::Dialog => "dialog",
+            Role::Alert => "alert",
+            Role::ProgressBar => "progress_bar",
+            Role::TreeItem => "tree_item",
+            Role::WebArea => "web_area",
+            Role::Heading => "heading",
+            Role::Separator => "separator",
+            Role::SplitGroup => "split_group",
+        }
+    }
+}
+
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_selector())
+    }
+}

--- a/xa11y-core/src/selector.rs
+++ b/xa11y-core/src/selector.rs
@@ -1,0 +1,349 @@
+use crate::error::{Error, Result};
+use crate::node::Node;
+use crate::role::Role;
+
+/// A parsed CSS-like selector for querying accessibility tree nodes.
+#[derive(Debug, Clone)]
+pub struct Selector {
+    segments: Vec<SelectorSegment>,
+}
+
+/// A single segment in a selector chain.
+#[derive(Debug, Clone)]
+struct SelectorSegment {
+    role: Option<Role>,
+    attributes: Vec<AttributeMatcher>,
+    #[allow(dead_code)]
+    nth: Option<usize>,
+    #[allow(dead_code)]
+    combinator: Combinator,
+}
+
+/// How this segment relates to the previous one.
+#[derive(Debug, Clone, PartialEq)]
+enum Combinator {
+    /// First segment (no combinator)
+    None,
+    /// Direct child (`>`)
+    Child,
+    /// Any descendant (space)
+    Descendant,
+}
+
+/// An attribute match condition.
+#[derive(Debug, Clone)]
+struct AttributeMatcher {
+    attr: String,
+    op: MatchOp,
+    value: String,
+}
+
+/// Match operation for attribute selectors.
+#[derive(Debug, Clone)]
+enum MatchOp {
+    /// Exact match (`=`)
+    Exact,
+    /// Substring match (`*=`)
+    Contains,
+    /// Starts-with match (`^=`)
+    StartsWith,
+}
+
+impl Selector {
+    /// Parse a CSS-like selector string.
+    ///
+    /// Supported syntax:
+    /// - `button` — match by role
+    /// - `[name="Submit"]` — match by attribute (exact)
+    /// - `[name*="addr"]` — substring match (case-insensitive)
+    /// - `[name^="addr"]` — starts-with match
+    /// - `button[name="Submit"]` — role + attribute
+    /// - `toolbar > text_field` — direct child combinator
+    /// - `toolbar text_field` — descendant combinator
+    /// - `button:nth(2)` — nth match (1-based)
+    pub fn parse(input: &str) -> Result<Self> {
+        let input = input.trim();
+        if input.is_empty() {
+            return Err(Error::InvalidSelector("empty selector".into()));
+        }
+
+        let mut segments = Vec::new();
+        let mut remaining = input;
+        let mut next_combinator = Combinator::None;
+
+        while !remaining.is_empty() {
+            remaining = remaining.trim_start();
+            if remaining.is_empty() {
+                break;
+            }
+
+            // Check for child combinator
+            if remaining.starts_with('>') {
+                next_combinator = Combinator::Child;
+                remaining = remaining[1..].trim_start();
+                continue;
+            }
+
+            let (segment, rest) = Self::parse_segment(remaining, next_combinator)?;
+            segments.push(segment);
+            next_combinator = if rest.trim_start().starts_with('>') {
+                Combinator::None // Will be set on next iteration
+            } else if !rest.trim_start().is_empty() && !rest.trim_start().starts_with('>') {
+                Combinator::Descendant
+            } else {
+                Combinator::None
+            };
+            remaining = rest;
+        }
+
+        if segments.is_empty() {
+            return Err(Error::InvalidSelector("no valid segments".into()));
+        }
+
+        Ok(Selector { segments })
+    }
+
+    fn parse_segment(input: &str, combinator: Combinator) -> Result<(SelectorSegment, &str)> {
+        let mut role = None;
+        let mut attributes = Vec::new();
+        let mut nth = None;
+        let mut pos = 0;
+        let bytes = input.as_bytes();
+
+        // Parse role name (alphanumeric + underscore)
+        let role_start = pos;
+        while pos < bytes.len() && (bytes[pos].is_ascii_alphanumeric() || bytes[pos] == b'_') {
+            pos += 1;
+        }
+        if pos > role_start {
+            let role_str = &input[role_start..pos];
+            role = Some(
+                Role::from_selector(role_str)
+                    .ok_or_else(|| Error::InvalidSelector(format!("unknown role: {role_str}")))?,
+            );
+        }
+
+        // Parse attribute matchers [attr op "value"]
+        while pos < bytes.len() && bytes[pos] == b'[' {
+            pos += 1; // skip [
+            let attr_start = pos;
+            while pos < bytes.len()
+                && bytes[pos] != b'='
+                && bytes[pos] != b'*'
+                && bytes[pos] != b'^'
+                && bytes[pos] != b']'
+            {
+                pos += 1;
+            }
+            let attr = input[attr_start..pos].trim().to_string();
+
+            if pos >= bytes.len() || bytes[pos] == b']' {
+                // Presence check only - skip for now
+                if pos < bytes.len() {
+                    pos += 1;
+                }
+                continue;
+            }
+
+            let op = if bytes[pos] == b'*' {
+                pos += 1; // skip *
+                if pos < bytes.len() && bytes[pos] == b'=' {
+                    pos += 1;
+                }
+                MatchOp::Contains
+            } else if bytes[pos] == b'^' {
+                pos += 1; // skip ^
+                if pos < bytes.len() && bytes[pos] == b'=' {
+                    pos += 1;
+                }
+                MatchOp::StartsWith
+            } else {
+                pos += 1; // skip =
+                MatchOp::Exact
+            };
+
+            // Skip whitespace and quotes
+            while pos < bytes.len()
+                && (bytes[pos] == b' ' || bytes[pos] == b'"' || bytes[pos] == b'\'')
+            {
+                pos += 1;
+            }
+            let val_start = pos;
+            while pos < bytes.len()
+                && bytes[pos] != b'"'
+                && bytes[pos] != b'\''
+                && bytes[pos] != b']'
+            {
+                pos += 1;
+            }
+            let value = input[val_start..pos].trim().to_string();
+
+            // Skip closing quote and bracket
+            while pos < bytes.len() && bytes[pos] != b']' {
+                pos += 1;
+            }
+            if pos < bytes.len() {
+                pos += 1; // skip ]
+            }
+
+            attributes.push(AttributeMatcher { attr, op, value });
+        }
+
+        // Parse :nth(N)
+        if pos < bytes.len() && input[pos..].starts_with(":nth(") {
+            pos += 5; // skip :nth(
+            let nth_start = pos;
+            while pos < bytes.len() && bytes[pos] != b')' {
+                pos += 1;
+            }
+            let n: usize = input[nth_start..pos]
+                .parse()
+                .map_err(|_| Error::InvalidSelector("invalid :nth value".into()))?;
+            nth = Some(n);
+            if pos < bytes.len() {
+                pos += 1; // skip )
+            }
+        }
+
+        if role.is_none() && attributes.is_empty() && nth.is_none() {
+            return Err(Error::InvalidSelector(
+                "segment has no role, attributes, or nth".into(),
+            ));
+        }
+
+        Ok((
+            SelectorSegment {
+                role,
+                attributes,
+                nth,
+                combinator,
+            },
+            &input[pos..],
+        ))
+    }
+
+    /// Check if a node matches this selector (single-segment, non-hierarchical match).
+    /// For multi-segment selectors with combinators, use `matches_in_tree`.
+    pub fn matches(&self, node: &Node) -> bool {
+        // For single-segment selectors, just match the last segment
+        if self.segments.len() == 1 {
+            return Self::segment_matches(&self.segments[0], node);
+        }
+        // For multi-segment, only match the final segment (tree context needed for full matching)
+        Self::segment_matches(self.segments.last().unwrap(), node)
+    }
+
+    fn segment_matches(segment: &SelectorSegment, node: &Node) -> bool {
+        // Check role
+        if let Some(role) = segment.role {
+            if node.role != role {
+                return false;
+            }
+        }
+
+        // Check attributes
+        for attr in &segment.attributes {
+            let node_value = match attr.attr.as_str() {
+                "name" => node.name.as_deref(),
+                "value" => node.value.as_deref(),
+                "description" => node.description.as_deref(),
+                "role" => Some(node.role.as_selector()),
+                _ => None,
+            };
+
+            let Some(node_value) = node_value else {
+                return false;
+            };
+
+            let matched = match attr.op {
+                MatchOp::Exact => node_value == attr.value,
+                MatchOp::Contains => node_value
+                    .to_lowercase()
+                    .contains(&attr.value.to_lowercase()),
+                MatchOp::StartsWith => node_value
+                    .to_lowercase()
+                    .starts_with(&attr.value.to_lowercase()),
+            };
+
+            if !matched {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::StateSet;
+
+    fn make_node(id: u32, role: Role, name: Option<&str>) -> Node {
+        Node {
+            id,
+            role,
+            name: name.map(String::from),
+            value: None,
+            description: None,
+            bounds: None,
+            bounds_normalized: None,
+            actions: vec![],
+            states: StateSet::default(),
+            children: vec![],
+            parent: None,
+            depth: 0,
+            app_name: None,
+            raw: None,
+        }
+    }
+
+    #[test]
+    fn test_role_selector() {
+        let sel = Selector::parse("button").unwrap();
+        assert!(sel.matches(&make_node(0, Role::Button, Some("OK"))));
+        assert!(!sel.matches(&make_node(0, Role::TextField, Some("OK"))));
+    }
+
+    #[test]
+    fn test_attribute_exact() {
+        let sel = Selector::parse("[name=\"Submit\"]").unwrap();
+        assert!(sel.matches(&make_node(0, Role::Button, Some("Submit"))));
+        assert!(!sel.matches(&make_node(0, Role::Button, Some("Cancel"))));
+    }
+
+    #[test]
+    fn test_attribute_contains() {
+        let sel = Selector::parse("[name*=\"addr\"]").unwrap();
+        assert!(sel.matches(&make_node(0, Role::TextField, Some("Address Bar"))));
+        assert!(!sel.matches(&make_node(0, Role::TextField, Some("Search"))));
+    }
+
+    #[test]
+    fn test_attribute_starts_with() {
+        let sel = Selector::parse("[name^=\"addr\"]").unwrap();
+        assert!(sel.matches(&make_node(0, Role::TextField, Some("Address Bar"))));
+        assert!(!sel.matches(&make_node(0, Role::TextField, Some("My Address"))));
+    }
+
+    #[test]
+    fn test_role_plus_attribute() {
+        let sel = Selector::parse("button[name=\"Submit\"]").unwrap();
+        assert!(sel.matches(&make_node(0, Role::Button, Some("Submit"))));
+        assert!(!sel.matches(&make_node(0, Role::TextField, Some("Submit"))));
+        assert!(!sel.matches(&make_node(0, Role::Button, Some("Cancel"))));
+    }
+
+    #[test]
+    fn test_invalid_selector() {
+        assert!(Selector::parse("").is_err());
+        assert!(Selector::parse("nonexistent_role").is_err());
+    }
+
+    #[test]
+    fn test_nth_selector() {
+        let sel = Selector::parse("button:nth(2)").unwrap();
+        // nth is parsed but only used in tree context
+        assert!(sel.matches(&make_node(0, Role::Button, Some("OK"))));
+    }
+}

--- a/xa11y-core/src/tree.rs
+++ b/xa11y-core/src/tree.rs
@@ -1,0 +1,140 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::node::{Node, NodeId};
+use crate::provider::QueryOptions;
+use crate::role::Role;
+use crate::selector::Selector;
+
+/// A snapshot of an application's accessibility tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tree {
+    /// Application name
+    pub app_name: String,
+
+    /// Process ID (0 for multi-app queries)
+    pub pid: u32,
+
+    /// Screen dimensions at capture time (width, height)
+    pub screen_size: (u32, u32),
+
+    /// All nodes in DFS order
+    pub nodes: Vec<Node>,
+
+    /// Index from NodeId -> position in nodes vec (for O(1) lookup)
+    #[serde(skip)]
+    node_index: HashMap<NodeId, usize>,
+
+    /// Query options used to produce this snapshot
+    pub query: QueryOptions,
+}
+
+impl Tree {
+    /// Create a new Tree from nodes and metadata.
+    pub fn new(
+        app_name: String,
+        pid: u32,
+        screen_size: (u32, u32),
+        nodes: Vec<Node>,
+        query: QueryOptions,
+    ) -> Self {
+        let node_index = nodes.iter().enumerate().map(|(i, n)| (n.id, i)).collect();
+        Self {
+            app_name,
+            pid,
+            screen_size,
+            nodes,
+            node_index,
+            query,
+        }
+    }
+
+    /// Rebuild the index after deserialization.
+    pub fn rebuild_index(&mut self) {
+        self.node_index = self
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.id, i))
+            .collect();
+    }
+
+    /// Get a node by ID.
+    pub fn get(&self, id: NodeId) -> Option<&Node> {
+        self.node_index.get(&id).and_then(|&i| self.nodes.get(i))
+    }
+
+    /// Get the root node.
+    pub fn root(&self) -> Option<&Node> {
+        self.nodes.first()
+    }
+
+    /// Iterate all nodes.
+    pub fn iter(&self) -> impl Iterator<Item = &Node> {
+        self.nodes.iter()
+    }
+
+    /// Query nodes matching a CSS-like selector string.
+    pub fn query(&self, selector_str: &str) -> Result<Vec<&Node>> {
+        let selector = Selector::parse(selector_str)?;
+        Ok(self.nodes.iter().filter(|n| selector.matches(n)).collect())
+    }
+
+    /// Get children of a node.
+    pub fn children(&self, id: NodeId) -> Vec<&Node> {
+        self.get(id)
+            .map(|node| {
+                node.children
+                    .iter()
+                    .filter_map(|&cid| self.get(cid))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Get the subtree rooted at a node (including the node itself).
+    pub fn subtree(&self, id: NodeId) -> Vec<&Node> {
+        let mut result = Vec::new();
+        let mut stack = vec![id];
+        while let Some(current) = stack.pop() {
+            if let Some(node) = self.get(current) {
+                result.push(node);
+                // Push children in reverse so we visit them in order
+                for &child_id in node.children.iter().rev() {
+                    stack.push(child_id);
+                }
+            }
+        }
+        result
+    }
+
+    /// Find nodes by role.
+    pub fn find_by_role(&self, role: Role) -> Vec<&Node> {
+        self.nodes.iter().filter(|n| n.role == role).collect()
+    }
+
+    /// Find nodes by name (substring, case-insensitive).
+    pub fn find_by_name(&self, pattern: &str) -> Vec<&Node> {
+        let pattern_lower = pattern.to_lowercase();
+        self.nodes
+            .iter()
+            .filter(|n| {
+                n.name
+                    .as_ref()
+                    .is_some_and(|name| name.to_lowercase().contains(&pattern_lower))
+            })
+            .collect()
+    }
+
+    /// Returns the total number of nodes.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Returns true if the tree has no nodes.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+}

--- a/xa11y-core/tests/test_types.rs
+++ b/xa11y-core/tests/test_types.rs
@@ -1,0 +1,576 @@
+//! Integration tests for xa11y-core types — serialization, tree operations, selectors.
+
+use xa11y_core::*;
+
+/// Helper to create a test node.
+fn make_node(id: NodeId, role: Role, name: Option<&str>) -> Node {
+    Node {
+        id,
+        role,
+        name: name.map(String::from),
+        value: None,
+        description: None,
+        bounds: None,
+        bounds_normalized: None,
+        actions: vec![],
+        states: StateSet::default(),
+        children: vec![],
+        parent: None,
+        depth: 0,
+        app_name: None,
+        raw: None,
+    }
+}
+
+/// Build a realistic test tree:
+/// ```text
+/// 0: Window "Test App"
+/// ├── 1: Toolbar "Main Toolbar"
+/// │   ├── 2: Button "Back"
+/// │   ├── 3: Button "Forward"
+/// │   └── 4: TextField "Address Bar"
+/// ├── 5: Group "Content"
+/// │   ├── 6: Heading "Welcome"
+/// │   ├── 7: StaticText "Hello World"
+/// │   ├── 8: Button "Submit"
+/// │   └── 9: CheckBox "Remember Me"
+/// └── 10: Group "Status Bar"
+///     └── 11: StaticText "Ready"
+/// ```
+fn build_test_tree() -> Tree {
+    let nodes = vec![
+        {
+            let mut n = make_node(0, Role::Window, Some("Test App"));
+            n.children = vec![1, 5, 10];
+            n.depth = 0;
+            n
+        },
+        {
+            let mut n = make_node(1, Role::Toolbar, Some("Main Toolbar"));
+            n.children = vec![2, 3, 4];
+            n.parent = Some(0);
+            n.depth = 1;
+            n
+        },
+        {
+            let mut n = make_node(2, Role::Button, Some("Back"));
+            n.parent = Some(1);
+            n.depth = 2;
+            n.actions = vec![Action::Press];
+            n
+        },
+        {
+            let mut n = make_node(3, Role::Button, Some("Forward"));
+            n.parent = Some(1);
+            n.depth = 2;
+            n.actions = vec![Action::Press];
+            n
+        },
+        {
+            let mut n = make_node(4, Role::TextField, Some("Address Bar"));
+            n.parent = Some(1);
+            n.depth = 2;
+            n.actions = vec![Action::Focus, Action::SetValue];
+            n.states.editable = true;
+            n.value = Some("https://example.com".into());
+            n
+        },
+        {
+            let mut n = make_node(5, Role::Group, Some("Content"));
+            n.children = vec![6, 7, 8, 9];
+            n.parent = Some(0);
+            n.depth = 1;
+            n
+        },
+        {
+            let mut n = make_node(6, Role::Heading, Some("Welcome"));
+            n.parent = Some(5);
+            n.depth = 2;
+            n
+        },
+        {
+            let mut n = make_node(7, Role::StaticText, Some("Hello World"));
+            n.parent = Some(5);
+            n.depth = 2;
+            n
+        },
+        {
+            let mut n = make_node(8, Role::Button, Some("Submit"));
+            n.parent = Some(5);
+            n.depth = 2;
+            n.actions = vec![Action::Press];
+            n
+        },
+        {
+            let mut n = make_node(9, Role::CheckBox, Some("Remember Me"));
+            n.parent = Some(5);
+            n.depth = 2;
+            n.actions = vec![Action::Toggle];
+            n.states.checked = Some(Toggled::Off);
+            n
+        },
+        {
+            let mut n = make_node(10, Role::Group, Some("Status Bar"));
+            n.children = vec![11];
+            n.parent = Some(0);
+            n.depth = 1;
+            n
+        },
+        {
+            let mut n = make_node(11, Role::StaticText, Some("Ready"));
+            n.parent = Some(10);
+            n.depth = 2;
+            n
+        },
+    ];
+
+    Tree::new(
+        "Test App".into(),
+        1234,
+        (1920, 1080),
+        nodes,
+        QueryOptions::default(),
+    )
+}
+
+// ─── Tree Structure Tests ───────────────────────────────────────
+
+#[test]
+fn test_tree_node_count() {
+    let tree = build_test_tree();
+    assert_eq!(tree.len(), 12);
+    assert!(!tree.is_empty());
+}
+
+#[test]
+fn test_tree_root() {
+    let tree = build_test_tree();
+    let root = tree.root().unwrap();
+    assert_eq!(root.id, 0);
+    assert_eq!(root.role, Role::Window);
+    assert_eq!(root.name.as_deref(), Some("Test App"));
+}
+
+#[test]
+fn test_tree_get_by_id() {
+    let tree = build_test_tree();
+    let node = tree.get(4).unwrap();
+    assert_eq!(node.role, Role::TextField);
+    assert_eq!(node.name.as_deref(), Some("Address Bar"));
+
+    assert!(tree.get(999).is_none());
+}
+
+#[test]
+fn test_tree_children() {
+    let tree = build_test_tree();
+    let children = tree.children(1);
+    assert_eq!(children.len(), 3);
+    assert_eq!(children[0].name.as_deref(), Some("Back"));
+    assert_eq!(children[1].name.as_deref(), Some("Forward"));
+    assert_eq!(children[2].name.as_deref(), Some("Address Bar"));
+}
+
+#[test]
+fn test_tree_subtree() {
+    let tree = build_test_tree();
+    let subtree = tree.subtree(5);
+    assert_eq!(subtree.len(), 5); // Group + 4 children
+    assert_eq!(subtree[0].name.as_deref(), Some("Content"));
+}
+
+#[test]
+fn test_tree_find_by_role() {
+    let tree = build_test_tree();
+    let buttons = tree.find_by_role(Role::Button);
+    assert_eq!(buttons.len(), 3); // Back, Forward, Submit
+}
+
+#[test]
+fn test_tree_find_by_name() {
+    let tree = build_test_tree();
+
+    let results = tree.find_by_name("back");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name.as_deref(), Some("Back"));
+
+    // Case-insensitive substring match
+    let results = tree.find_by_name("HELLO");
+    assert_eq!(results.len(), 1);
+}
+
+// ─── Selector Tests ─────────────────────────────────────────────
+
+#[test]
+fn test_selector_by_role() {
+    let tree = build_test_tree();
+    let results = tree.query("button").unwrap();
+    assert_eq!(results.len(), 3);
+}
+
+#[test]
+fn test_selector_by_name_exact() {
+    let tree = build_test_tree();
+    let results = tree.query(r#"[name="Submit"]"#).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].role, Role::Button);
+}
+
+#[test]
+fn test_selector_by_name_contains() {
+    let tree = build_test_tree();
+    let results = tree.query(r#"[name*="bar"]"#).unwrap();
+    // "Address Bar", "Main Toolbar", "Status Bar"
+    assert_eq!(results.len(), 3);
+}
+
+#[test]
+fn test_selector_by_name_starts_with() {
+    let tree = build_test_tree();
+    let results = tree.query(r#"[name^="addr"]"#).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name.as_deref(), Some("Address Bar"));
+}
+
+#[test]
+fn test_selector_role_plus_attribute() {
+    let tree = build_test_tree();
+    let results = tree.query(r#"button[name="Submit"]"#).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, 8);
+}
+
+#[test]
+fn test_selector_invalid() {
+    let tree = build_test_tree();
+    assert!(tree.query("").is_err());
+    assert!(tree.query("nonexistent_role").is_err());
+}
+
+// ─── Serialization Tests ────────────────────────────────────────
+
+#[test]
+fn test_node_json_roundtrip() {
+    let mut node = make_node(42, Role::Button, Some("OK"));
+    node.actions = vec![Action::Press, Action::Focus];
+    node.bounds = Some(Rect {
+        x: 100,
+        y: 200,
+        width: 80,
+        height: 30,
+    });
+    node.states.focused = true;
+
+    let json = serde_json::to_string(&node).unwrap();
+    let deserialized: Node = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.id, 42);
+    assert_eq!(deserialized.role, Role::Button);
+    assert_eq!(deserialized.name.as_deref(), Some("OK"));
+    assert_eq!(deserialized.actions.len(), 2);
+    assert!(deserialized.states.focused);
+}
+
+#[test]
+fn test_tree_json_roundtrip() {
+    let tree = build_test_tree();
+    let json = serde_json::to_string(&tree).unwrap();
+    let mut deserialized: Tree = serde_json::from_str(&json).unwrap();
+    deserialized.rebuild_index();
+
+    assert_eq!(deserialized.app_name, "Test App");
+    assert_eq!(deserialized.pid, 1234);
+    assert_eq!(deserialized.len(), 12);
+    assert_eq!(
+        deserialized.get(4).unwrap().name.as_deref(),
+        Some("Address Bar")
+    );
+}
+
+#[test]
+fn test_role_serialization() {
+    let role = Role::Button;
+    let json = serde_json::to_string(&role).unwrap();
+    assert_eq!(json, "\"Button\"");
+
+    let deserialized: Role = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized, Role::Button);
+}
+
+#[test]
+fn test_action_serialization() {
+    let action = Action::Press;
+    let json = serde_json::to_string(&action).unwrap();
+    let deserialized: Action = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized, Action::Press);
+}
+
+#[test]
+fn test_action_data_serialization() {
+    let data = ActionData::Value("hello".into());
+    let json = serde_json::to_string(&data).unwrap();
+    let deserialized: ActionData = serde_json::from_str(&json).unwrap();
+    match deserialized {
+        ActionData::Value(v) => assert_eq!(v, "hello"),
+        _ => panic!("wrong variant"),
+    }
+}
+
+#[test]
+fn test_raw_platform_data_serialization() {
+    let raw = RawPlatformData::MacOS {
+        ax_role: "AXButton".into(),
+        ax_subrole: None,
+        ax_identifier: Some("btn_ok".into()),
+    };
+    let json = serde_json::to_string(&raw).unwrap();
+    let deserialized: RawPlatformData = serde_json::from_str(&json).unwrap();
+    match deserialized {
+        RawPlatformData::MacOS {
+            ax_role,
+            ax_identifier,
+            ..
+        } => {
+            assert_eq!(ax_role, "AXButton");
+            assert_eq!(ax_identifier.as_deref(), Some("btn_ok"));
+        }
+        _ => panic!("wrong variant"),
+    }
+}
+
+// ─── State Tests ────────────────────────────────────────────────
+
+#[test]
+fn test_state_defaults() {
+    let states = StateSet::default();
+    assert!(states.enabled);
+    assert!(states.visible);
+    assert!(!states.focused);
+    assert!(states.checked.is_none());
+    assert!(!states.selected);
+    assert!(states.expanded.is_none());
+    assert!(!states.editable);
+    assert!(!states.required);
+    assert!(!states.busy);
+}
+
+#[test]
+fn test_toggled_states() {
+    let tree = build_test_tree();
+    let checkbox = tree.get(9).unwrap();
+    assert_eq!(checkbox.states.checked, Some(Toggled::Off));
+}
+
+// ─── Event Filter Tests ────────────────────────────────────────
+
+#[test]
+fn test_event_filter_all() {
+    let filter = EventFilter::all();
+    assert!(filter.kinds.is_empty());
+    assert!(filter.selector.is_none());
+}
+
+#[test]
+fn test_event_filter_kinds() {
+    let filter = EventFilter::kinds(&[EventKind::FocusChanged, EventKind::ValueChanged]);
+    assert_eq!(filter.kinds.len(), 2);
+
+    let event = Event {
+        kind: EventKind::FocusChanged,
+        app: AppInfo {
+            name: "Test".into(),
+            pid: 1,
+            bundle_id: None,
+        },
+        target: None,
+        state_flag: None,
+        state_value: None,
+        timestamp: std::time::Duration::from_millis(0),
+    };
+    assert!(filter.matches(&event));
+
+    let event2 = Event {
+        kind: EventKind::WindowOpened,
+        ..event.clone()
+    };
+    assert!(!filter.matches(&event2));
+}
+
+#[test]
+fn test_event_filter_with_selector() {
+    let filter = EventFilter::new(
+        &[EventKind::ValueChanged],
+        Some(r#"text_field[name="Address Bar"]"#),
+    );
+    assert_eq!(filter.kinds.len(), 1);
+    assert!(filter.selector.is_some());
+}
+
+// ─── Event Serialization Tests ──────────────────────────────────
+
+#[test]
+fn test_event_json_roundtrip() {
+    let event = Event {
+        kind: EventKind::StateChanged,
+        app: AppInfo {
+            name: "Safari".into(),
+            pid: 5678,
+            bundle_id: Some("com.apple.Safari".into()),
+        },
+        target: Some(make_node(3, Role::CheckBox, Some("Dark Mode"))),
+        state_flag: Some(StateFlag::Checked),
+        state_value: Some(true),
+        timestamp: std::time::Duration::from_millis(1500),
+    };
+
+    let json = serde_json::to_string(&event).unwrap();
+    let deserialized: Event = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.kind, EventKind::StateChanged);
+    assert_eq!(deserialized.app.name, "Safari");
+    assert_eq!(deserialized.state_flag, Some(StateFlag::Checked));
+    assert_eq!(deserialized.state_value, Some(true));
+    assert_eq!(deserialized.timestamp.as_millis(), 1500);
+}
+
+// ─── Geometry Tests ─────────────────────────────────────────────
+
+#[test]
+fn test_rect() {
+    let rect = Rect {
+        x: 100,
+        y: 200,
+        width: 300,
+        height: 400,
+    };
+    let json = serde_json::to_string(&rect).unwrap();
+    let deserialized: Rect = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized, rect);
+}
+
+#[test]
+fn test_normalized_rect() {
+    let rect = NormalizedRect {
+        x1: 0.1,
+        y1: 0.2,
+        x2: 0.5,
+        y2: 0.8,
+    };
+    let json = serde_json::to_string(&rect).unwrap();
+    let deserialized: NormalizedRect = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized, rect);
+}
+
+// ─── Role Tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_role_from_selector() {
+    assert_eq!(Role::from_selector("button"), Some(Role::Button));
+    assert_eq!(Role::from_selector("text_field"), Some(Role::TextField));
+    assert_eq!(Role::from_selector("check_box"), Some(Role::CheckBox));
+    assert_eq!(Role::from_selector("checkbox"), Some(Role::CheckBox));
+    assert_eq!(Role::from_selector("nonexistent"), None);
+}
+
+#[test]
+fn test_role_roundtrip() {
+    let role = Role::TextField;
+    assert_eq!(Role::from_selector(role.as_selector()), Some(role));
+}
+
+#[test]
+fn test_all_roles_roundtrip() {
+    let roles = [
+        Role::Unknown,
+        Role::Window,
+        Role::Application,
+        Role::Button,
+        Role::CheckBox,
+        Role::RadioButton,
+        Role::TextField,
+        Role::TextArea,
+        Role::StaticText,
+        Role::ComboBox,
+        Role::List,
+        Role::ListItem,
+        Role::Menu,
+        Role::MenuItem,
+        Role::MenuBar,
+        Role::Tab,
+        Role::TabGroup,
+        Role::Table,
+        Role::TableRow,
+        Role::TableCell,
+        Role::Toolbar,
+        Role::ScrollBar,
+        Role::Slider,
+        Role::Image,
+        Role::Link,
+        Role::Group,
+        Role::Dialog,
+        Role::Alert,
+        Role::ProgressBar,
+        Role::TreeItem,
+        Role::WebArea,
+        Role::Heading,
+        Role::Separator,
+        Role::SplitGroup,
+    ];
+    for role in &roles {
+        let selector = role.as_selector();
+        let parsed = Role::from_selector(selector);
+        assert_eq!(parsed, Some(*role), "roundtrip failed for {selector}");
+    }
+}
+
+// ─── Permission Status Tests ────────────────────────────────────
+
+#[test]
+fn test_permission_status_serialization() {
+    let granted = PermissionStatus::Granted;
+    let json = serde_json::to_string(&granted).unwrap();
+    let deserialized: PermissionStatus = serde_json::from_str(&json).unwrap();
+    matches!(deserialized, PermissionStatus::Granted);
+
+    let denied = PermissionStatus::Denied {
+        instructions: "Go to System Preferences > Privacy > Accessibility".into(),
+    };
+    let json = serde_json::to_string(&denied).unwrap();
+    let deserialized: PermissionStatus = serde_json::from_str(&json).unwrap();
+    match deserialized {
+        PermissionStatus::Denied { instructions } => {
+            assert!(instructions.contains("System Preferences"));
+        }
+        _ => panic!("expected Denied"),
+    }
+}
+
+// ─── Query Options Tests ────────────────────────────────────────
+
+#[test]
+fn test_query_options_defaults() {
+    let opts = QueryOptions::default();
+    assert_eq!(opts.max_depth, u32::MAX);
+    assert_eq!(opts.max_elements, u32::MAX);
+    assert!(!opts.visible_only);
+    assert!(opts.roles.is_none());
+    assert!(!opts.include_raw);
+}
+
+#[test]
+fn test_query_options_serialization() {
+    let opts = QueryOptions {
+        max_depth: 5,
+        max_elements: 100,
+        visible_only: true,
+        roles: Some(vec![Role::Button, Role::TextField]),
+        include_raw: true,
+    };
+    let json = serde_json::to_string(&opts).unwrap();
+    let deserialized: QueryOptions = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.max_depth, 5);
+    assert_eq!(deserialized.max_elements, 100);
+    assert!(deserialized.visible_only);
+    assert_eq!(deserialized.roles.unwrap().len(), 2);
+    assert!(deserialized.include_raw);
+}

--- a/xa11y-linux/Cargo.toml
+++ b/xa11y-linux/Cargo.toml
@@ -11,3 +11,4 @@ xa11y-core.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = { version = "5", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["rt", "sync"] }
+serde_json.workspace = true

--- a/xa11y-linux/Cargo.toml
+++ b/xa11y-linux/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xa11y-linux"
+description = "Linux backend for xa11y (AT-SPI2 via D-Bus)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+xa11y-core.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = { version = "5", default-features = false, features = ["tokio"] }
+tokio = { version = "1", features = ["rt", "sync"] }

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1,0 +1,129 @@
+use zbus::zvariant::OwnedObjectPath;
+
+/// Reference to an AT-SPI2 accessible element on D-Bus.
+#[derive(Debug, Clone)]
+pub struct ElementRef {
+    pub bus_name: String,
+    pub path: OwnedObjectPath,
+}
+
+// ─── D-Bus Proxy Definitions ────────────────────────────────────
+
+#[zbus::proxy(
+    interface = "org.a11y.Bus",
+    default_service = "org.a11y.Bus",
+    default_path = "/org/a11y/bus"
+)]
+pub trait A11yBus {
+    fn get_address(&self) -> zbus::Result<String>;
+}
+
+#[zbus::proxy(interface = "org.a11y.atspi.Accessible")]
+pub trait Accessible {
+    #[zbus(property)]
+    fn name(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn description(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn child_count(&self) -> zbus::Result<i32>;
+
+    fn get_child_at_index(&self, index: i32) -> zbus::Result<(String, OwnedObjectPath)>;
+
+    fn get_children(&self) -> zbus::Result<Vec<(String, OwnedObjectPath)>>;
+
+    fn get_role(&self) -> zbus::Result<u32>;
+
+    fn get_state(&self) -> zbus::Result<Vec<u32>>;
+
+    fn get_interfaces(&self) -> zbus::Result<Vec<String>>;
+}
+
+#[zbus::proxy(interface = "org.a11y.atspi.Application")]
+pub trait Application {
+    #[zbus(property)]
+    fn id(&self) -> zbus::Result<i32>;
+}
+
+#[zbus::proxy(interface = "org.a11y.atspi.Component")]
+pub trait Component {
+    fn get_extents(&self, coord_type: u32) -> zbus::Result<(i32, i32, i32, i32)>;
+    fn grab_focus(&self) -> zbus::Result<bool>;
+    fn scroll_to(&self, scroll_type: u32) -> zbus::Result<bool>;
+}
+
+#[zbus::proxy(interface = "org.a11y.atspi.Action")]
+pub trait AtspiAction {
+    fn do_action(&self, index: i32) -> zbus::Result<bool>;
+    fn get_n_actions(&self) -> zbus::Result<i32>;
+    fn get_name(&self, index: i32) -> zbus::Result<String>;
+}
+
+#[zbus::proxy(interface = "org.a11y.atspi.Value")]
+pub trait Value {
+    #[zbus(property)]
+    fn current_value(&self) -> zbus::Result<f64>;
+    #[zbus(property)]
+    fn set_current_value(&self, value: f64) -> zbus::Result<()>;
+}
+
+#[zbus::proxy(interface = "org.a11y.atspi.Text")]
+pub trait Text {
+    fn get_text(&self, start_offset: i32, end_offset: i32) -> zbus::Result<String>;
+    fn get_character_count(&self) -> zbus::Result<i32>;
+}
+
+#[zbus::proxy(interface = "org.a11y.atspi.EditableText")]
+pub trait EditableText {
+    fn set_text_contents(&self, new_contents: &str) -> zbus::Result<bool>;
+}
+
+// ─── Connection ─────────────────────────────────────────────────
+
+pub async fn connect() -> xa11y_core::Result<zbus::Connection> {
+    let session = zbus::Connection::session()
+        .await
+        .map_err(|e| xa11y_core::Error::Platform(format!("D-Bus session bus unavailable: {e}")))?;
+
+    if let Ok(proxy) = A11yBusProxy::new(&session).await {
+        if let Ok(addr) = proxy.get_address().await {
+            if !addr.is_empty() {
+                if let Ok(builder) = zbus::connection::Builder::address(addr.as_str()) {
+                    if let Ok(conn) = builder.build().await {
+                        return Ok(conn);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(session)
+}
+
+// ─── Proxy Constructors ─────────────────────────────────────────
+
+/// Build a proxy for the given element. Takes owned bus_name/path to avoid lifetime issues.
+macro_rules! make_proxy_fn {
+    ($fn_name:ident, $proxy_type:ident) => {
+        pub async fn $fn_name<'a>(
+            conn: &'a zbus::Connection,
+            bus_name: &str,
+            path: &OwnedObjectPath,
+        ) -> zbus::Result<$proxy_type<'a>> {
+            $proxy_type::builder(conn)
+                .destination(bus_name.to_owned())?
+                .path(path.clone())?
+                .build()
+                .await
+        }
+    };
+}
+
+make_proxy_fn!(accessible_proxy, AccessibleProxy);
+make_proxy_fn!(component_proxy, ComponentProxy);
+make_proxy_fn!(action_proxy, AtspiActionProxy);
+make_proxy_fn!(value_proxy, ValueProxy);
+make_proxy_fn!(text_proxy, TextProxy);
+make_proxy_fn!(editable_text_proxy, EditableTextProxy);
+make_proxy_fn!(application_proxy, ApplicationProxy);

--- a/xa11y-linux/src/lib.rs
+++ b/xa11y-linux/src/lib.rs
@@ -7,6 +7,10 @@
 //! the crate compiles but exports nothing.
 
 #[cfg(target_os = "linux")]
+mod atspi;
+#[cfg(target_os = "linux")]
+mod mapping;
+#[cfg(target_os = "linux")]
 mod platform;
 
 #[cfg(target_os = "linux")]

--- a/xa11y-linux/src/lib.rs
+++ b/xa11y-linux/src/lib.rs
@@ -1,0 +1,18 @@
+//! Linux accessibility backend using AT-SPI2 over D-Bus.
+//!
+//! This backend uses the AT-SPI2 accessibility framework to read
+//! accessibility trees from running applications on Linux.
+//!
+//! This crate only provides functionality on Linux. On other platforms,
+//! the crate compiles but exports nothing.
+
+#[cfg(target_os = "linux")]
+mod platform;
+
+#[cfg(target_os = "linux")]
+pub use platform::LinuxProvider;
+
+#[cfg(target_os = "linux")]
+pub fn create_provider() -> LinuxProvider {
+    LinuxProvider::new()
+}

--- a/xa11y-linux/src/mapping.rs
+++ b/xa11y-linux/src/mapping.rs
@@ -1,0 +1,184 @@
+use xa11y_core::{Action, Role, StateSet, Toggled};
+
+// AT-SPI2 role constants
+const ROLE_ALERT: u32 = 2;
+const ROLE_CHECK_BOX: u32 = 7;
+const ROLE_CHECK_MENU_ITEM: u32 = 8;
+const ROLE_COMBO_BOX: u32 = 11;
+const ROLE_DESKTOP_ICON: u32 = 13;
+const ROLE_DIALOG: u32 = 16;
+const ROLE_FILE_CHOOSER: u32 = 19;
+const ROLE_FILLER: u32 = 20;
+const ROLE_FRAME: u32 = 23;
+const ROLE_ICON: u32 = 26;
+const ROLE_IMAGE: u32 = 27;
+const ROLE_LABEL: u32 = 29;
+const ROLE_LIST: u32 = 31;
+const ROLE_LIST_ITEM: u32 = 32;
+const ROLE_MENU: u32 = 33;
+const ROLE_MENU_BAR: u32 = 34;
+const ROLE_MENU_ITEM: u32 = 35;
+const ROLE_PAGE_TAB: u32 = 37;
+const ROLE_PAGE_TAB_LIST: u32 = 38;
+const ROLE_PANEL: u32 = 39;
+const ROLE_PASSWORD_TEXT: u32 = 40;
+const ROLE_POPUP_MENU: u32 = 41;
+const ROLE_PROGRESS_BAR: u32 = 42;
+const ROLE_PUSH_BUTTON: u32 = 43;
+const ROLE_RADIO_BUTTON: u32 = 44;
+const ROLE_RADIO_MENU_ITEM: u32 = 45;
+const ROLE_SCROLL_BAR: u32 = 48;
+const ROLE_SEPARATOR: u32 = 50;
+const ROLE_SLIDER: u32 = 51;
+const ROLE_SPIN_BUTTON: u32 = 52;
+const ROLE_SPLIT_PANE: u32 = 53;
+const ROLE_TABLE: u32 = 55;
+const ROLE_TABLE_CELL: u32 = 56;
+const ROLE_TABLE_COLUMN_HEADER: u32 = 57;
+const ROLE_TABLE_ROW_HEADER: u32 = 58;
+const ROLE_TEAROFF_MENU_ITEM: u32 = 59;
+const ROLE_TEXT: u32 = 61;
+const ROLE_TOGGLE_BUTTON: u32 = 62;
+const ROLE_TOOL_BAR: u32 = 63;
+const ROLE_TREE: u32 = 65;
+const ROLE_TREE_TABLE: u32 = 66;
+const ROLE_WINDOW: u32 = 69;
+const ROLE_APPLICATION: u32 = 75;
+const ROLE_ENTRY: u32 = 79;
+const ROLE_CAPTION: u32 = 81;
+const ROLE_DOCUMENT_FRAME: u32 = 82;
+const ROLE_HEADING: u32 = 83;
+const ROLE_SECTION: u32 = 85;
+const ROLE_FORM: u32 = 87;
+const ROLE_LINK: u32 = 88;
+const ROLE_TABLE_ROW: u32 = 90;
+const ROLE_TREE_ITEM: u32 = 91;
+const ROLE_DOCUMENT_WEB: u32 = 95;
+const ROLE_LIST_BOX: u32 = 98;
+const ROLE_GROUPING: u32 = 99;
+const ROLE_NOTIFICATION: u32 = 101;
+const ROLE_STATIC: u32 = 116;
+
+// AT-SPI2 state bit positions
+const STATE_BUSY: u32 = 3;
+const STATE_CHECKED: u32 = 4;
+const STATE_EDITABLE: u32 = 7;
+const STATE_ENABLED: u32 = 8;
+const STATE_EXPANDABLE: u32 = 9;
+const STATE_EXPANDED: u32 = 10;
+const STATE_FOCUSED: u32 = 12;
+const STATE_SELECTED: u32 = 23;
+const STATE_SHOWING: u32 = 25;
+const STATE_VISIBLE: u32 = 30;
+// States in second u32 (bit positions 32+)
+const STATE_INDETERMINATE: u32 = 32;
+const STATE_REQUIRED: u32 = 33;
+const STATE_CHECKABLE: u32 = 41;
+
+/// Map AT-SPI2 role ID to xa11y Role.
+pub fn map_role(role_id: u32) -> Role {
+    match role_id {
+        ROLE_ALERT | ROLE_NOTIFICATION => Role::Alert,
+        ROLE_APPLICATION => Role::Application,
+        ROLE_PUSH_BUTTON | ROLE_TOGGLE_BUTTON => Role::Button,
+        ROLE_CHECK_BOX | ROLE_CHECK_MENU_ITEM => Role::CheckBox,
+        ROLE_COMBO_BOX => Role::ComboBox,
+        ROLE_DIALOG | ROLE_FILE_CHOOSER => Role::Dialog,
+        ROLE_PANEL | ROLE_SECTION | ROLE_FORM | ROLE_FILLER | ROLE_GROUPING => Role::Group,
+        ROLE_HEADING => Role::Heading,
+        ROLE_IMAGE | ROLE_ICON | ROLE_DESKTOP_ICON => Role::Image,
+        ROLE_LINK => Role::Link,
+        ROLE_LIST | ROLE_LIST_BOX | ROLE_TREE => Role::List,
+        ROLE_LIST_ITEM => Role::ListItem,
+        ROLE_MENU | ROLE_POPUP_MENU => Role::Menu,
+        ROLE_MENU_BAR => Role::MenuBar,
+        ROLE_MENU_ITEM | ROLE_TEAROFF_MENU_ITEM => Role::MenuItem,
+        ROLE_PROGRESS_BAR => Role::ProgressBar,
+        ROLE_RADIO_BUTTON | ROLE_RADIO_MENU_ITEM => Role::RadioButton,
+        ROLE_SCROLL_BAR => Role::ScrollBar,
+        ROLE_SEPARATOR => Role::Separator,
+        ROLE_SLIDER => Role::Slider,
+        ROLE_SPLIT_PANE => Role::SplitGroup,
+        ROLE_LABEL | ROLE_CAPTION | ROLE_STATIC => Role::StaticText,
+        ROLE_PAGE_TAB => Role::Tab,
+        ROLE_PAGE_TAB_LIST => Role::TabGroup,
+        ROLE_TABLE | ROLE_TREE_TABLE => Role::Table,
+        ROLE_TABLE_CELL | ROLE_TABLE_COLUMN_HEADER | ROLE_TABLE_ROW_HEADER => Role::TableCell,
+        ROLE_TABLE_ROW => Role::TableRow,
+        ROLE_TEXT => Role::TextArea,
+        ROLE_ENTRY | ROLE_PASSWORD_TEXT | ROLE_SPIN_BUTTON => Role::TextField,
+        ROLE_TOOL_BAR => Role::Toolbar,
+        ROLE_TREE_ITEM => Role::TreeItem,
+        ROLE_DOCUMENT_FRAME | ROLE_DOCUMENT_WEB => Role::WebArea,
+        ROLE_FRAME | ROLE_WINDOW => Role::Window,
+        _ => Role::Unknown,
+    }
+}
+
+/// Map AT-SPI2 state bitfield to xa11y StateSet.
+pub fn map_states(state_bits: &[u32]) -> StateSet {
+    let bits: u64 = match state_bits.len() {
+        0 => return StateSet::default(),
+        1 => state_bits[0] as u64,
+        _ => (state_bits[0] as u64) | ((state_bits[1] as u64) << 32),
+    };
+
+    let has = |bit: u32| -> bool { bits & (1u64 << bit) != 0 };
+
+    StateSet {
+        enabled: has(STATE_ENABLED),
+        visible: has(STATE_VISIBLE) || has(STATE_SHOWING),
+        focused: has(STATE_FOCUSED),
+        checked: if has(STATE_CHECKABLE) || has(STATE_CHECKED) {
+            if has(STATE_INDETERMINATE) {
+                Some(Toggled::Mixed)
+            } else if has(STATE_CHECKED) {
+                Some(Toggled::On)
+            } else {
+                Some(Toggled::Off)
+            }
+        } else {
+            None
+        },
+        selected: has(STATE_SELECTED),
+        expanded: if has(STATE_EXPANDABLE) {
+            Some(has(STATE_EXPANDED))
+        } else {
+            None
+        },
+        editable: has(STATE_EDITABLE),
+        required: has(STATE_REQUIRED),
+        busy: has(STATE_BUSY),
+    }
+}
+
+/// Map an AT-SPI2 action name string to xa11y Action.
+pub fn map_action_name(name: &str) -> Option<Action> {
+    match name.to_lowercase().as_str() {
+        "click" | "activate" | "press" | "invoke" => Some(Action::Press),
+        "toggle" | "check" | "uncheck" => Some(Action::Toggle),
+        "expand" | "open" => Some(Action::Expand),
+        "collapse" | "close" => Some(Action::Collapse),
+        "select" => Some(Action::Select),
+        "menu" | "showmenu" | "popup" | "show menu" | "show_menu" => Some(Action::ShowMenu),
+        "increment" => Some(Action::Increment),
+        "decrement" => Some(Action::Decrement),
+        _ => None,
+    }
+}
+
+/// Get AT-SPI2 action names that correspond to an xa11y Action.
+pub fn atspi_names_for_action(action: &Action) -> &'static [&'static str] {
+    match action {
+        Action::Press => &["click", "activate", "press", "invoke"],
+        Action::Toggle => &["toggle", "check", "uncheck", "click"],
+        Action::Expand => &["expand", "open"],
+        Action::Collapse => &["collapse", "close"],
+        Action::Select => &["select"],
+        Action::ShowMenu => &["menu", "showmenu", "popup", "show menu"],
+        Action::Increment => &["increment"],
+        Action::Decrement => &["decrement"],
+        // Focus, SetValue, ScrollIntoView handled via other interfaces
+        _ => &[],
+    }
+}

--- a/xa11y-linux/src/platform.rs
+++ b/xa11y-linux/src/platform.rs
@@ -1,14 +1,46 @@
+use std::sync::Mutex;
+
+use tokio::runtime::Runtime;
 use xa11y_core::*;
+use zbus::zvariant::OwnedObjectPath;
+
+use crate::atspi::{self, ElementRef};
+use crate::mapping;
 
 /// Linux accessibility provider using AT-SPI2 over D-Bus.
 pub struct LinuxProvider {
-    // Internal state for D-Bus connection and cached element paths
+    rt: Runtime,
+    conn: Mutex<Option<zbus::Connection>>,
+    /// Cached element references from the last snapshot, indexed by NodeId.
+    elements: Mutex<Vec<ElementRef>>,
+    /// Last query target and options, for re-traversal on action dispatch.
+    last_target: Mutex<Option<AppTarget>>,
+    last_query: Mutex<Option<QueryOptions>>,
 }
 
 impl LinuxProvider {
     pub fn new() -> Self {
-        // TODO: Connect to AT-SPI2 registry via D-Bus
-        Self {}
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create tokio runtime");
+        Self {
+            rt,
+            conn: Mutex::new(None),
+            elements: Mutex::new(Vec::new()),
+            last_target: Mutex::new(None),
+            last_query: Mutex::new(None),
+        }
+    }
+
+    fn connection(&self) -> Result<zbus::Connection> {
+        let mut guard = self.conn.lock().unwrap();
+        if let Some(ref conn) = *guard {
+            return Ok(conn.clone());
+        }
+        let conn = self.rt.block_on(atspi::connect())?;
+        *guard = Some(conn.clone());
+        Ok(conn)
     }
 }
 
@@ -19,35 +51,636 @@ impl Default for LinuxProvider {
 }
 
 impl Provider for LinuxProvider {
-    fn get_app_tree(&self, _target: &AppTarget, _opts: &QueryOptions) -> Result<Tree> {
-        // TODO: Implement AT-SPI2 tree traversal
-        // 1. Connect to org.a11y.atspi.Registry on D-Bus
-        // 2. Find the target app in the registry
-        // 3. DFS traverse via AT-SPI Accessible interface
-        // 4. Map AT-SPI roles to xa11y roles
-        Err(Error::Platform("Linux provider not yet implemented".into()))
+    fn check_permissions(&self) -> Result<PermissionStatus> {
+        let conn = self.connection()?;
+        let result: Result<()> = self.rt.block_on(async {
+            let registry = registry_root()?;
+            let proxy = atspi::accessible_proxy(&conn, &registry.bus_name, &registry.path)
+                .await
+                .map_err(|e| Error::Platform(format!("AT-SPI2 registry unavailable: {e}")))?;
+            let _count: i32 = proxy
+                .child_count()
+                .await
+                .map_err(|e| Error::Platform(format!("AT-SPI2 registry query failed: {e}")))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(PermissionStatus::Granted),
+            Err(Error::Platform(msg)) => Ok(PermissionStatus::Denied {
+                instructions: format!(
+                    "AT-SPI2 is not available: {msg}. \
+                     Ensure at-spi2-core is installed and accessibility is enabled: \
+                     gsettings set org.gnome.desktop.interface toolkit-accessibility true"
+                ),
+            }),
+            Err(e) => Err(e),
+        }
     }
 
-    fn get_all_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
-        Err(Error::Platform("Linux provider not yet implemented".into()))
+    fn list_apps(&self) -> Result<Vec<AppInfo>> {
+        let conn = self.connection()?;
+        self.rt.block_on(list_apps_async(&conn))
+    }
+
+    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree> {
+        let conn = self.connection()?;
+        let (tree, elements) = self.rt.block_on(get_app_tree_async(&conn, target, opts))?;
+
+        *self.elements.lock().unwrap() = elements;
+        *self.last_target.lock().unwrap() = Some(target.clone());
+        *self.last_query.lock().unwrap() = Some(opts.clone());
+
+        Ok(tree)
+    }
+
+    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+        let conn = self.connection()?;
+        let apps = self.rt.block_on(list_apps_async(&conn))?;
+        let screen_size = get_screen_size();
+
+        let all_nodes: Vec<Node> = apps
+            .iter()
+            .enumerate()
+            .map(|(i, app)| Node {
+                id: i as NodeId,
+                role: Role::Application,
+                name: Some(app.name.clone()),
+                value: None,
+                description: None,
+                bounds: None,
+                bounds_normalized: None,
+                actions: vec![],
+                states: StateSet::default(),
+                children: vec![],
+                parent: None,
+                depth: 0,
+                app_name: Some(app.name.clone()),
+                raw: None,
+            })
+            .collect();
+
+        Ok(Tree::new(
+            String::new(),
+            0,
+            screen_size,
+            all_nodes,
+            opts.clone(),
+        ))
     }
 
     fn perform_action(
         &self,
-        _node_id: NodeId,
-        _action: Action,
-        _data: Option<ActionData>,
+        node_id: NodeId,
+        action: Action,
+        data: Option<ActionData>,
     ) -> Result<()> {
-        Err(Error::Platform("Linux provider not yet implemented".into()))
+        let conn = self.connection()?;
+        let elements = self.elements.lock().unwrap();
+
+        let elem = elements
+            .get(node_id as usize)
+            .ok_or(Error::NodeNotFound(node_id))?
+            .clone();
+        drop(elements);
+
+        self.rt
+            .block_on(perform_action_async(&conn, &elem, action, data))
+    }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+fn registry_root() -> Result<ElementRef> {
+    Ok(ElementRef {
+        bus_name: "org.a11y.atspi.Registry".into(),
+        path: OwnedObjectPath::try_from("/org/a11y/atspi/accessible/root")
+            .map_err(|e| Error::Platform(format!("invalid path: {e}")))?,
+    })
+}
+
+// ─── Async Implementation ───────────────────────────────────────
+
+async fn list_apps_async(conn: &zbus::Connection) -> Result<Vec<AppInfo>> {
+    let registry = registry_root()?;
+    let proxy = atspi::accessible_proxy(conn, &registry.bus_name, &registry.path)
+        .await
+        .map_err(|e| Error::Platform(format!("AT-SPI2 registry unavailable: {e}")))?;
+
+    let children: Vec<(String, OwnedObjectPath)> = proxy
+        .get_children()
+        .await
+        .map_err(|e| Error::Platform(format!("failed to get registry children: {e}")))?;
+
+    let mut apps = Vec::new();
+    for (bus_name, path) in children {
+        let child = ElementRef {
+            bus_name: bus_name.clone(),
+            path,
+        };
+
+        let name: String = match atspi::accessible_proxy(conn, &child.bus_name, &child.path).await {
+            Ok(p) => p.name().await.unwrap_or_default(),
+            Err(_) => continue,
+        };
+
+        let pid: u32 = match atspi::application_proxy(conn, &child.bus_name, &child.path).await {
+            Ok(p) => p.id().await.unwrap_or(0) as u32,
+            Err(_) => 0,
+        };
+
+        if name.is_empty() && pid == 0 {
+            continue;
+        }
+
+        apps.push(AppInfo {
+            name: if name.is_empty() {
+                format!("pid:{pid}")
+            } else {
+                name
+            },
+            pid,
+            bundle_id: None,
+        });
     }
 
-    fn check_permissions(&self) -> Result<PermissionStatus> {
-        // TODO: Check if AT-SPI2 is enabled
-        // gsettings get org.gnome.desktop.interface toolkit-accessibility
-        Err(Error::Platform("Linux provider not yet implemented".into()))
+    Ok(apps)
+}
+
+async fn get_app_tree_async(
+    conn: &zbus::Connection,
+    target: &AppTarget,
+    opts: &QueryOptions,
+) -> Result<(Tree, Vec<ElementRef>)> {
+    let registry = registry_root()?;
+    let proxy = atspi::accessible_proxy(conn, &registry.bus_name, &registry.path)
+        .await
+        .map_err(|e| Error::Platform(format!("AT-SPI2 registry unavailable: {e}")))?;
+
+    let children: Vec<(String, OwnedObjectPath)> = proxy
+        .get_children()
+        .await
+        .map_err(|e| Error::Platform(format!("failed to get registry children: {e}")))?;
+
+    // Find the target app
+    let mut app_root: Option<ElementRef> = None;
+    let mut app_name = String::new();
+    let mut app_pid: u32 = 0;
+
+    for (bus_name, path) in children {
+        let child = ElementRef {
+            bus_name: bus_name.clone(),
+            path,
+        };
+
+        let name: String = match atspi::accessible_proxy(conn, &child.bus_name, &child.path).await {
+            Ok(p) => p.name().await.unwrap_or_default(),
+            Err(_) => continue,
+        };
+
+        let pid: u32 = match atspi::application_proxy(conn, &child.bus_name, &child.path).await {
+            Ok(p) => p.id().await.unwrap_or(0) as u32,
+            Err(_) => 0,
+        };
+
+        let matches = match target {
+            AppTarget::ByName(ref target_name) => {
+                name.to_lowercase().contains(&target_name.to_lowercase())
+            }
+            AppTarget::ByPid(target_pid) => pid == *target_pid,
+            AppTarget::ByWindow(_) => false,
+        };
+
+        if matches {
+            app_root = Some(child);
+            app_name = name;
+            app_pid = pid;
+            break;
+        }
     }
 
-    fn list_apps(&self) -> Result<Vec<AppInfo>> {
-        Err(Error::Platform("Linux provider not yet implemented".into()))
+    let app_root = app_root.ok_or_else(|| {
+        Error::AppNotFound(match target {
+            AppTarget::ByName(n) => n.clone(),
+            AppTarget::ByPid(p) => format!("pid:{p}"),
+            AppTarget::ByWindow(h) => format!("window:{}", h.id),
+        })
+    })?;
+
+    let screen_size = get_screen_size();
+
+    let mut nodes: Vec<Node> = Vec::new();
+    let mut elements: Vec<ElementRef> = Vec::new();
+    let mut next_id: NodeId = 0;
+
+    traverse_element(
+        conn,
+        &app_root,
+        None,
+        0,
+        &app_name,
+        opts,
+        screen_size,
+        &mut nodes,
+        &mut elements,
+        &mut next_id,
+    )
+    .await;
+
+    let tree = Tree::new(app_name, app_pid, screen_size, nodes, opts.clone());
+    Ok((tree, elements))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn traverse_element(
+    conn: &zbus::Connection,
+    elem: &ElementRef,
+    parent_id: Option<NodeId>,
+    depth: u32,
+    app_name: &str,
+    opts: &QueryOptions,
+    screen_size: (u32, u32),
+    nodes: &mut Vec<Node>,
+    elements: &mut Vec<ElementRef>,
+    next_id: &mut NodeId,
+) {
+    if depth > opts.max_depth || *next_id >= opts.max_elements {
+        return;
     }
+
+    let Ok(proxy) = atspi::accessible_proxy(conn, &elem.bus_name, &elem.path).await else {
+        return;
+    };
+
+    let name: Option<String> = proxy.name().await.ok().filter(|s| !s.is_empty());
+    let description: Option<String> = proxy.description().await.ok().filter(|s| !s.is_empty());
+    let role_id: u32 = proxy.get_role().await.unwrap_or(67);
+    let role = mapping::map_role(role_id);
+    let state_bits: Vec<u32> = proxy.get_state().await.unwrap_or_default();
+    let states = mapping::map_states(&state_bits);
+
+    if let Some(ref roles) = opts.roles {
+        if !roles.contains(&role) {
+            return;
+        }
+    }
+
+    if opts.visible_only && !states.visible {
+        return;
+    }
+
+    let my_id = *next_id;
+    *next_id += 1;
+
+    // Bounds from Component interface
+    let bounds: Option<Rect> =
+        if let Ok(comp) = atspi::component_proxy(conn, &elem.bus_name, &elem.path).await {
+            comp.get_extents(0).await.ok().map(|(x, y, w, h)| Rect {
+                x,
+                y,
+                width: w,
+                height: h,
+            })
+        } else {
+            None
+        };
+
+    let bounds_normalized: Option<NormalizedRect> = bounds.and_then(|b| {
+        if screen_size.0 > 0 && screen_size.1 > 0 {
+            Some(NormalizedRect {
+                x1: b.x as f64 / screen_size.0 as f64,
+                y1: b.y as f64 / screen_size.1 as f64,
+                x2: (b.x + b.width) as f64 / screen_size.0 as f64,
+                y2: (b.y + b.height) as f64 / screen_size.1 as f64,
+            })
+        } else {
+            None
+        }
+    });
+
+    let interfaces: Vec<String> = proxy.get_interfaces().await.unwrap_or_default();
+    let value: Option<String> = get_element_value(conn, elem, role, &interfaces).await;
+    let actions: Vec<Action> = get_element_actions(conn, elem, &interfaces).await;
+
+    let raw: Option<RawPlatformData> = if opts.include_raw {
+        Some(RawPlatformData::Linux {
+            atspi_role: role_id.to_string(),
+            bus_name: elem.bus_name.clone(),
+            object_path: elem.path.to_string(),
+        })
+    } else {
+        None
+    };
+
+    let node = Node {
+        id: my_id,
+        role,
+        name,
+        value,
+        description,
+        bounds,
+        bounds_normalized,
+        actions,
+        states,
+        children: vec![],
+        parent: parent_id,
+        depth,
+        app_name: Some(app_name.to_string()),
+        raw,
+    };
+
+    let node_idx = nodes.len();
+    nodes.push(node);
+    elements.push(elem.clone());
+
+    let children_refs: Vec<(String, OwnedObjectPath)> =
+        proxy.get_children().await.unwrap_or_default();
+    let mut child_ids: Vec<NodeId> = Vec::new();
+
+    for (bus_name, path) in children_refs {
+        if *next_id >= opts.max_elements {
+            break;
+        }
+        let child_elem = ElementRef { bus_name, path };
+        let child_id = *next_id;
+        let prev_count = nodes.len();
+
+        Box::pin(traverse_element(
+            conn,
+            &child_elem,
+            Some(my_id),
+            depth + 1,
+            app_name,
+            opts,
+            screen_size,
+            nodes,
+            elements,
+            next_id,
+        ))
+        .await;
+
+        if nodes.len() > prev_count {
+            child_ids.push(child_id);
+        }
+    }
+
+    nodes[node_idx].children = child_ids;
+}
+
+async fn get_element_value(
+    conn: &zbus::Connection,
+    elem: &ElementRef,
+    role: Role,
+    interfaces: &[String],
+) -> Option<String> {
+    let has_text = interfaces.iter().any(|i| i == "org.a11y.atspi.Text");
+    let has_value = interfaces.iter().any(|i| i == "org.a11y.atspi.Value");
+
+    if has_text
+        && matches!(
+            role,
+            Role::TextField | Role::TextArea | Role::StaticText | Role::Heading | Role::Link
+        )
+    {
+        if let Ok(text_proxy) = atspi::text_proxy(conn, &elem.bus_name, &elem.path).await {
+            if let Ok(content) = text_proxy.get_text(0, -1).await {
+                if !content.is_empty() {
+                    return Some(content);
+                }
+            }
+        }
+    }
+
+    if has_value
+        && matches!(
+            role,
+            Role::Slider | Role::ProgressBar | Role::ScrollBar | Role::TextField
+        )
+    {
+        if let Ok(val_proxy) = atspi::value_proxy(conn, &elem.bus_name, &elem.path).await {
+            if let Ok(v) = val_proxy.current_value().await {
+                return Some(v.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+async fn get_element_actions(
+    conn: &zbus::Connection,
+    elem: &ElementRef,
+    interfaces: &[String],
+) -> Vec<Action> {
+    let has_action = interfaces.iter().any(|i| i == "org.a11y.atspi.Action");
+    if !has_action {
+        // Still check for Focus/SetValue via other interfaces
+        let mut actions = Vec::new();
+        let has_component = interfaces.iter().any(|i| i == "org.a11y.atspi.Component");
+        if has_component {
+            actions.push(Action::Focus);
+        }
+        let has_editable = interfaces
+            .iter()
+            .any(|i| i == "org.a11y.atspi.EditableText" || i == "org.a11y.atspi.Value");
+        if has_editable {
+            actions.push(Action::SetValue);
+        }
+        return actions;
+    }
+
+    let Ok(proxy) = atspi::action_proxy(conn, &elem.bus_name, &elem.path).await else {
+        return vec![];
+    };
+
+    let n: i32 = proxy.get_n_actions().await.unwrap_or(0);
+    let mut actions: Vec<Action> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for i in 0..n {
+        if let Ok(name) = proxy.get_name(i).await {
+            if let Some(action) = mapping::map_action_name(&name) {
+                if seen.insert(action) {
+                    actions.push(action);
+                }
+            }
+        }
+    }
+
+    let has_component = interfaces.iter().any(|i| i == "org.a11y.atspi.Component");
+    if has_component && !seen.contains(&Action::Focus) {
+        actions.push(Action::Focus);
+    }
+
+    let has_editable = interfaces
+        .iter()
+        .any(|i| i == "org.a11y.atspi.EditableText" || i == "org.a11y.atspi.Value");
+    if has_editable && !seen.contains(&Action::SetValue) {
+        actions.push(Action::SetValue);
+    }
+
+    actions
+}
+
+async fn perform_action_async(
+    conn: &zbus::Connection,
+    elem: &ElementRef,
+    action: Action,
+    data: Option<ActionData>,
+) -> Result<()> {
+    let bn = &elem.bus_name;
+    let p = &elem.path;
+    match action {
+        Action::Focus => {
+            let proxy = atspi::component_proxy(conn, bn, p)
+                .await
+                .map_err(|e| Error::ActionNotSupported(format!("no Component interface: {e}")))?;
+            let _ok: bool = proxy
+                .grab_focus()
+                .await
+                .map_err(|e| Error::Platform(format!("GrabFocus failed: {e}")))?;
+            Ok(())
+        }
+        Action::SetValue => {
+            let value = data
+                .ok_or_else(|| Error::ActionNotSupported("SetValue requires ActionData".into()))?;
+            match value {
+                ActionData::Value(text) => {
+                    let proxy = atspi::editable_text_proxy(conn, bn, p).await.map_err(|e| {
+                        Error::ActionNotSupported(format!("no EditableText interface: {e}"))
+                    })?;
+                    let _ok: bool = proxy
+                        .set_text_contents(&text)
+                        .await
+                        .map_err(|e| Error::Platform(format!("SetTextContents failed: {e}")))?;
+                    Ok(())
+                }
+                ActionData::NumericValue(v) => {
+                    let proxy = atspi::value_proxy(conn, bn, p).await.map_err(|e| {
+                        Error::ActionNotSupported(format!("no Value interface: {e}"))
+                    })?;
+                    proxy
+                        .set_current_value(v)
+                        .await
+                        .map_err(|e| Error::Platform(format!("SetCurrentValue failed: {e}")))?;
+                    Ok(())
+                }
+                _ => Err(Error::ActionNotSupported(
+                    "SetValue requires Value or NumericValue data".into(),
+                )),
+            }
+        }
+        Action::ScrollIntoView => {
+            let proxy = atspi::component_proxy(conn, bn, p)
+                .await
+                .map_err(|e| Error::ActionNotSupported(format!("no Component interface: {e}")))?;
+            let _ok: bool = proxy
+                .scroll_to(0)
+                .await
+                .map_err(|e| Error::Platform(format!("ScrollTo failed: {e}")))?;
+            Ok(())
+        }
+        _ => {
+            let proxy = atspi::action_proxy(conn, bn, p)
+                .await
+                .map_err(|e| Error::ActionNotSupported(format!("no Action interface: {e}")))?;
+
+            let n: i32 = proxy
+                .get_n_actions()
+                .await
+                .map_err(|e| Error::Platform(format!("GetNActions failed: {e}")))?;
+
+            let target_names = mapping::atspi_names_for_action(&action);
+
+            for i in 0..n {
+                if let Ok(name) = proxy.get_name(i).await {
+                    let lower = name.to_lowercase();
+                    if target_names.iter().any(|t| *t == lower) {
+                        let _ok: bool = proxy
+                            .do_action(i)
+                            .await
+                            .map_err(|e| Error::Platform(format!("DoAction failed: {e}")))?;
+                        return Ok(());
+                    }
+                }
+            }
+
+            Err(Error::ActionNotSupported(format!(
+                "action {action:?} not available on this element"
+            )))
+        }
+    }
+}
+
+/// Detect screen size using available tools, with a fallback default.
+fn get_screen_size() -> (u32, u32) {
+    // Try xdpyinfo (X11)
+    if let Ok(output) = std::process::Command::new("xdpyinfo").output() {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("dimensions:") {
+                    if let Some(dims) = trimmed.split_whitespace().nth(1) {
+                        let parts: Vec<&str> = dims.split('x').collect();
+                        if parts.len() == 2 {
+                            if let (Ok(w), Ok(h)) = (parts[0].parse(), parts[1].parse()) {
+                                return (w, h);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Try swaymsg (Sway/Wayland)
+    if let Ok(output) = std::process::Command::new("swaymsg")
+        .args(["-t", "get_outputs", "--raw"])
+        .output()
+    {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&stdout) {
+                if let Some(arr) = val.as_array() {
+                    for output in arr {
+                        if let (Some(w), Some(h)) = (
+                            output
+                                .get("current_mode")
+                                .and_then(|m| m.get("width"))
+                                .and_then(|v| v.as_u64()),
+                            output
+                                .get("current_mode")
+                                .and_then(|m| m.get("height"))
+                                .and_then(|v| v.as_u64()),
+                        ) {
+                            return (w as u32, h as u32);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Try wlr-randr (wlroots Wayland compositors)
+    if let Ok(output) = std::process::Command::new("wlr-randr").output() {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                let trimmed = line.trim();
+                if trimmed.contains("px") {
+                    if let Some(dims) = trimmed.split_whitespace().next() {
+                        let parts: Vec<&str> = dims.split('x').collect();
+                        if parts.len() == 2 {
+                            if let (Ok(w), Ok(h)) = (parts[0].parse(), parts[1].parse()) {
+                                return (w, h);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    (1920, 1080)
 }

--- a/xa11y-linux/src/platform.rs
+++ b/xa11y-linux/src/platform.rs
@@ -1,0 +1,53 @@
+use xa11y_core::*;
+
+/// Linux accessibility provider using AT-SPI2 over D-Bus.
+pub struct LinuxProvider {
+    // Internal state for D-Bus connection and cached element paths
+}
+
+impl LinuxProvider {
+    pub fn new() -> Self {
+        // TODO: Connect to AT-SPI2 registry via D-Bus
+        Self {}
+    }
+}
+
+impl Default for LinuxProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Provider for LinuxProvider {
+    fn get_app_tree(&self, _target: &AppTarget, _opts: &QueryOptions) -> Result<Tree> {
+        // TODO: Implement AT-SPI2 tree traversal
+        // 1. Connect to org.a11y.atspi.Registry on D-Bus
+        // 2. Find the target app in the registry
+        // 3. DFS traverse via AT-SPI Accessible interface
+        // 4. Map AT-SPI roles to xa11y roles
+        Err(Error::Platform("Linux provider not yet implemented".into()))
+    }
+
+    fn get_all_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
+        Err(Error::Platform("Linux provider not yet implemented".into()))
+    }
+
+    fn perform_action(
+        &self,
+        _node_id: NodeId,
+        _action: Action,
+        _data: Option<ActionData>,
+    ) -> Result<()> {
+        Err(Error::Platform("Linux provider not yet implemented".into()))
+    }
+
+    fn check_permissions(&self) -> Result<PermissionStatus> {
+        // TODO: Check if AT-SPI2 is enabled
+        // gsettings get org.gnome.desktop.interface toolkit-accessibility
+        Err(Error::Platform("Linux provider not yet implemented".into()))
+    }
+
+    fn list_apps(&self) -> Result<Vec<AppInfo>> {
+        Err(Error::Platform("Linux provider not yet implemented".into()))
+    }
+}

--- a/xa11y-macos/Cargo.toml
+++ b/xa11y-macos/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xa11y-macos"
+description = "macOS backend for xa11y (AXUIElement via ApplicationServices)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+xa11y-core.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+core-foundation-sys = "0.8"

--- a/xa11y-macos/Cargo.toml
+++ b/xa11y-macos/Cargo.toml
@@ -11,3 +11,5 @@ xa11y-core.workspace = true
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
+core-graphics = "0.24"
+serde_json.workspace = true

--- a/xa11y-macos/src/ax_ffi.rs
+++ b/xa11y-macos/src/ax_ffi.rs
@@ -1,0 +1,368 @@
+//! Raw FFI bindings to macOS AXUIElement (ApplicationServices) functions.
+
+use core_foundation::array::CFArrayRef;
+use core_foundation::base::{CFTypeRef, TCFType};
+use core_foundation::boolean::CFBooleanRef;
+use core_foundation::number::CFNumberRef;
+use core_foundation::string::{CFString, CFStringRef};
+use std::ffi::c_void;
+use std::ptr;
+
+// Opaque AXUIElement type
+pub type AXUIElementRef = *const c_void;
+pub type AXError = i32;
+
+// AXError codes
+pub const K_AX_ERROR_SUCCESS: AXError = 0;
+
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    pub fn AXIsProcessTrusted() -> bool;
+
+    pub fn AXUIElementCreateApplication(pid: i32) -> AXUIElementRef;
+
+    pub fn AXUIElementCreateSystemWide() -> AXUIElementRef;
+
+    pub fn AXUIElementCopyAttributeValue(
+        element: AXUIElementRef,
+        attribute: CFStringRef,
+        value: *mut CFTypeRef,
+    ) -> AXError;
+
+    pub fn AXUIElementGetAttributeValueCount(
+        element: AXUIElementRef,
+        attribute: CFStringRef,
+        count: *mut i64,
+    ) -> AXError;
+
+    pub fn AXUIElementCopyAttributeValues(
+        element: AXUIElementRef,
+        attribute: CFStringRef,
+        index: i64,
+        max_values: i64,
+        values: *mut CFArrayRef,
+    ) -> AXError;
+
+    pub fn AXUIElementPerformAction(element: AXUIElementRef, action: CFStringRef) -> AXError;
+
+    pub fn AXUIElementSetAttributeValue(
+        element: AXUIElementRef,
+        attribute: CFStringRef,
+        value: CFTypeRef,
+    ) -> AXError;
+
+    pub fn AXUIElementCopyActionNames(element: AXUIElementRef, names: *mut CFArrayRef) -> AXError;
+
+    pub fn AXUIElementGetPid(element: AXUIElementRef, pid: *mut i32) -> AXError;
+}
+
+// Keep AXUIElementRef alive; release on drop via CFRelease.
+use core_foundation::base::CFRelease;
+
+/// Safe wrapper around AXUIElementRef with automatic memory management.
+#[derive(Debug)]
+pub struct AXElement {
+    raw: AXUIElementRef,
+}
+
+unsafe impl Send for AXElement {}
+unsafe impl Sync for AXElement {}
+
+impl Clone for AXElement {
+    fn clone(&self) -> Self {
+        unsafe {
+            core_foundation::base::CFRetain(self.raw as CFTypeRef);
+        }
+        Self { raw: self.raw }
+    }
+}
+
+impl Drop for AXElement {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            unsafe { CFRelease(self.raw as CFTypeRef) };
+        }
+    }
+}
+
+impl AXElement {
+    /// Create from a raw AXUIElementRef. Takes ownership (does NOT retain).
+    pub fn from_raw(raw: AXUIElementRef) -> Option<Self> {
+        if raw.is_null() {
+            None
+        } else {
+            Some(Self { raw })
+        }
+    }
+
+    /// Create an AXUIElement for an application by PID.
+    pub fn application(pid: i32) -> Option<Self> {
+        let raw = unsafe { AXUIElementCreateApplication(pid) };
+        Self::from_raw(raw)
+    }
+
+    /// Create a system-wide AXUIElement.
+    pub fn system_wide() -> Option<Self> {
+        let raw = unsafe { AXUIElementCreateSystemWide() };
+        Self::from_raw(raw)
+    }
+
+    pub fn raw(&self) -> AXUIElementRef {
+        self.raw
+    }
+
+    /// Get a string attribute value.
+    pub fn string_attribute(&self, attr: &str) -> Option<String> {
+        let cf_attr = CFString::new(attr);
+        let mut value: CFTypeRef = ptr::null();
+        let err = unsafe {
+            AXUIElementCopyAttributeValue(self.raw, cf_attr.as_concrete_TypeRef(), &mut value)
+        };
+        if err != K_AX_ERROR_SUCCESS || value.is_null() {
+            return None;
+        }
+        // Check if it's a CFString
+        let cf_str: CFString = unsafe {
+            if core_foundation::string::CFStringGetTypeID()
+                == core_foundation::base::CFGetTypeID(value)
+            {
+                CFString::wrap_under_create_rule(value as CFStringRef)
+            } else {
+                CFRelease(value);
+                return None;
+            }
+        };
+        Some(cf_str.to_string())
+    }
+
+    /// Get a boolean attribute value.
+    pub fn bool_attribute(&self, attr: &str) -> Option<bool> {
+        let cf_attr = CFString::new(attr);
+        let mut value: CFTypeRef = ptr::null();
+        let err = unsafe {
+            AXUIElementCopyAttributeValue(self.raw, cf_attr.as_concrete_TypeRef(), &mut value)
+        };
+        if err != K_AX_ERROR_SUCCESS || value.is_null() {
+            return None;
+        }
+        let type_id = unsafe { core_foundation::base::CFGetTypeID(value) };
+        if type_id == unsafe { core_foundation::boolean::CFBooleanGetTypeID() } {
+            let b = unsafe { core_foundation::boolean::CFBooleanGetValue(value as CFBooleanRef) };
+            unsafe { CFRelease(value) };
+            Some(b)
+        } else {
+            unsafe { CFRelease(value) };
+            None
+        }
+    }
+
+    /// Get a numeric (f64) attribute value.
+    pub fn number_attribute(&self, attr: &str) -> Option<f64> {
+        let cf_attr = CFString::new(attr);
+        let mut value: CFTypeRef = ptr::null();
+        let err = unsafe {
+            AXUIElementCopyAttributeValue(self.raw, cf_attr.as_concrete_TypeRef(), &mut value)
+        };
+        if err != K_AX_ERROR_SUCCESS || value.is_null() {
+            return None;
+        }
+        let type_id = unsafe { core_foundation::base::CFGetTypeID(value) };
+        if type_id == unsafe { core_foundation::number::CFNumberGetTypeID() } {
+            let cf_num = unsafe {
+                core_foundation::number::CFNumber::wrap_under_create_rule(value as CFNumberRef)
+            };
+            let result = cf_num.to_f64();
+            result
+        } else {
+            unsafe { CFRelease(value) };
+            None
+        }
+    }
+
+    /// Get an AXUIElement attribute value (e.g. AXFocusedUIElement).
+    pub fn element_attribute(&self, attr: &str) -> Option<AXElement> {
+        let cf_attr = CFString::new(attr);
+        let mut value: CFTypeRef = ptr::null();
+        let err = unsafe {
+            AXUIElementCopyAttributeValue(self.raw, cf_attr.as_concrete_TypeRef(), &mut value)
+        };
+        if err != K_AX_ERROR_SUCCESS || value.is_null() {
+            return None;
+        }
+        // Treat the returned CFTypeRef as an AXUIElementRef (it is retained by CopyAttributeValue)
+        Some(AXElement {
+            raw: value as AXUIElementRef,
+        })
+    }
+
+    /// Get children (array of AXUIElements).
+    pub fn children(&self) -> Vec<AXElement> {
+        let cf_attr = CFString::new("AXChildren");
+        let mut count: i64 = 0;
+        let err = unsafe {
+            AXUIElementGetAttributeValueCount(self.raw, cf_attr.as_concrete_TypeRef(), &mut count)
+        };
+        if err != K_AX_ERROR_SUCCESS || count <= 0 {
+            return vec![];
+        }
+
+        let mut array: CFArrayRef = ptr::null();
+        let err = unsafe {
+            AXUIElementCopyAttributeValues(
+                self.raw,
+                cf_attr.as_concrete_TypeRef(),
+                0,
+                count,
+                &mut array,
+            )
+        };
+        if err != K_AX_ERROR_SUCCESS || array.is_null() {
+            return vec![];
+        }
+
+        let cf_array = unsafe {
+            core_foundation::array::CFArray::<*const c_void>::wrap_under_create_rule(array)
+        };
+        let len = cf_array.len();
+        let mut result = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let elem_ref = unsafe { *cf_array.get_unchecked(i) };
+            if !elem_ref.is_null() {
+                unsafe { core_foundation::base::CFRetain(elem_ref as CFTypeRef) };
+                result.push(AXElement {
+                    raw: elem_ref as AXUIElementRef,
+                });
+            }
+        }
+        result
+    }
+
+    /// Get the position (x, y) of the element.
+    pub fn position(&self) -> Option<(f64, f64)> {
+        let cf_attr = CFString::new("AXPosition");
+        let mut value: CFTypeRef = ptr::null();
+        let err = unsafe {
+            AXUIElementCopyAttributeValue(self.raw, cf_attr.as_concrete_TypeRef(), &mut value)
+        };
+        if err != K_AX_ERROR_SUCCESS || value.is_null() {
+            return None;
+        }
+        let mut point = core_graphics::geometry::CGPoint::new(0.0, 0.0);
+        let ok = unsafe {
+            AXValueGetValue(
+                value as AXValueRef,
+                AX_VALUE_TYPE_CGPOINT,
+                &mut point as *mut _ as *mut c_void,
+            )
+        };
+        unsafe { CFRelease(value) };
+        if ok {
+            Some((point.x, point.y))
+        } else {
+            None
+        }
+    }
+
+    /// Get the size (width, height) of the element.
+    pub fn size(&self) -> Option<(f64, f64)> {
+        let cf_attr = CFString::new("AXSize");
+        let mut value: CFTypeRef = ptr::null();
+        let err = unsafe {
+            AXUIElementCopyAttributeValue(self.raw, cf_attr.as_concrete_TypeRef(), &mut value)
+        };
+        if err != K_AX_ERROR_SUCCESS || value.is_null() {
+            return None;
+        }
+        let mut size = core_graphics::geometry::CGSize::new(0.0, 0.0);
+        let ok = unsafe {
+            AXValueGetValue(
+                value as AXValueRef,
+                AX_VALUE_TYPE_CGSIZE,
+                &mut size as *mut _ as *mut c_void,
+            )
+        };
+        unsafe { CFRelease(value) };
+        if ok {
+            Some((size.width, size.height))
+        } else {
+            None
+        }
+    }
+
+    /// Get action names supported by this element.
+    pub fn action_names(&self) -> Vec<String> {
+        let mut names: CFArrayRef = ptr::null();
+        let err = unsafe { AXUIElementCopyActionNames(self.raw, &mut names) };
+        if err != K_AX_ERROR_SUCCESS || names.is_null() {
+            return vec![];
+        }
+        let cf_array = unsafe {
+            core_foundation::array::CFArray::<*const c_void>::wrap_under_create_rule(names)
+        };
+        let len = cf_array.len();
+        let mut result = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let val = unsafe { *cf_array.get_unchecked(i) };
+            if !val.is_null() {
+                let s = unsafe { CFString::wrap_under_get_rule(val as CFStringRef) };
+                result.push(s.to_string());
+            }
+        }
+        result
+    }
+
+    /// Perform a named action.
+    pub fn perform_action(&self, action: &str) -> bool {
+        let cf_action = CFString::new(action);
+        let err = unsafe { AXUIElementPerformAction(self.raw, cf_action.as_concrete_TypeRef()) };
+        err == K_AX_ERROR_SUCCESS
+    }
+
+    /// Set an attribute to a string value.
+    pub fn set_string_attribute(&self, attr: &str, value: &str) -> bool {
+        let cf_attr = CFString::new(attr);
+        let cf_value = CFString::new(value);
+        let err = unsafe {
+            AXUIElementSetAttributeValue(
+                self.raw,
+                cf_attr.as_concrete_TypeRef(),
+                cf_value.as_concrete_TypeRef() as CFTypeRef,
+            )
+        };
+        err == K_AX_ERROR_SUCCESS
+    }
+
+    /// Set an attribute to a numeric value.
+    pub fn set_number_attribute(&self, attr: &str, value: f64) -> bool {
+        let cf_attr = CFString::new(attr);
+        let cf_num = core_foundation::number::CFNumber::from(value);
+        let err = unsafe {
+            AXUIElementSetAttributeValue(
+                self.raw,
+                cf_attr.as_concrete_TypeRef(),
+                cf_num.as_concrete_TypeRef() as CFTypeRef,
+            )
+        };
+        err == K_AX_ERROR_SUCCESS
+    }
+
+    /// Get the PID of the application owning this element.
+    pub fn pid(&self) -> Option<i32> {
+        let mut pid: i32 = 0;
+        let err = unsafe { AXUIElementGetPid(self.raw, &mut pid) };
+        if err == K_AX_ERROR_SUCCESS {
+            Some(pid)
+        } else {
+            None
+        }
+    }
+}
+
+// AXValue types for position/size
+type AXValueRef = *const c_void;
+const AX_VALUE_TYPE_CGPOINT: i32 = 1;
+const AX_VALUE_TYPE_CGSIZE: i32 = 2;
+
+extern "C" {
+    fn AXValueGetValue(value: AXValueRef, value_type: i32, value_ptr: *mut c_void) -> bool;
+}

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -1,0 +1,18 @@
+//! macOS accessibility backend using AXUIElement APIs.
+//!
+//! This backend uses Apple's Accessibility API (AXUIElement) to read
+//! accessibility trees from running applications on macOS.
+//!
+//! This crate only provides functionality on macOS. On other platforms,
+//! the crate compiles but exports nothing.
+
+#[cfg(target_os = "macos")]
+mod platform;
+
+#[cfg(target_os = "macos")]
+pub use platform::MacOSProvider;
+
+#[cfg(target_os = "macos")]
+pub fn create_provider() -> MacOSProvider {
+    MacOSProvider::new()
+}

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -7,6 +7,10 @@
 //! the crate compiles but exports nothing.
 
 #[cfg(target_os = "macos")]
+mod ax_ffi;
+#[cfg(target_os = "macos")]
+mod mapping;
+#[cfg(target_os = "macos")]
 mod platform;
 
 #[cfg(target_os = "macos")]

--- a/xa11y-macos/src/mapping.rs
+++ b/xa11y-macos/src/mapping.rs
@@ -1,0 +1,152 @@
+use xa11y_core::{Action, Role, StateSet, Toggled};
+
+/// Map an AX role string to xa11y Role.
+pub fn map_role(ax_role: &str, ax_subrole: Option<&str>) -> Role {
+    match ax_role {
+        "AXApplication" => Role::Application,
+        "AXWindow" | "AXSheet" | "AXDrawer" => Role::Window,
+        "AXButton" => Role::Button,
+        "AXCheckBox" => Role::CheckBox,
+        "AXRadioButton" => Role::RadioButton,
+        "AXTextField" | "AXSecureTextField" | "AXSearchField" | "AXComboBox" => {
+            if ax_role == "AXComboBox" {
+                Role::ComboBox
+            } else {
+                Role::TextField
+            }
+        }
+        "AXTextArea" => Role::TextArea,
+        "AXStaticText" => Role::StaticText,
+        "AXList" | "AXOutline" => {
+            if ax_role == "AXOutline" {
+                // AXOutline is a tree view
+                Role::List
+            } else {
+                Role::List
+            }
+        }
+        "AXRow" => {
+            if ax_subrole == Some("AXOutlineRow") {
+                Role::TreeItem
+            } else {
+                Role::TableRow
+            }
+        }
+        "AXCell" => Role::TableCell,
+        "AXTable" => Role::Table,
+        "AXMenu" => Role::Menu,
+        "AXMenuBar" => Role::MenuBar,
+        "AXMenuItem" | "AXMenuBarItem" => Role::MenuItem,
+        "AXTabGroup" => Role::TabGroup,
+        "AXRadioGroup" => Role::Group,
+        "AXGroup" | "AXSplitGroup" | "AXScrollArea" | "AXLayoutArea" | "AXMatte" => {
+            if ax_role == "AXSplitGroup" {
+                Role::SplitGroup
+            } else {
+                Role::Group
+            }
+        }
+        "AXToolbar" => Role::Toolbar,
+        "AXScrollBar" => Role::ScrollBar,
+        "AXSlider" => Role::Slider,
+        "AXImage" => Role::Image,
+        "AXLink" => Role::Link,
+        "AXProgressIndicator" | "AXBusyIndicator" | "AXRelevanceIndicator" => Role::ProgressBar,
+        "AXValueIndicator" => Role::Slider,
+        "AXPopUpButton" => Role::ComboBox,
+        "AXDialog" => Role::Dialog,
+        "AXHeading" => Role::Heading,
+        "AXSplitter" | "AXRuler" => Role::Separator,
+        "AXWebArea" | "AXBrowser" => Role::WebArea,
+        "AXDisclosureTriangle" => Role::Button,
+        "AXColorWell" | "AXIncrementor" | "AXStepper" => Role::Slider,
+        "AXTab" => Role::Tab,
+        _ => {
+            // Check subrole for additional hints
+            match ax_subrole.unwrap_or("") {
+                "AXDialog" | "AXSystemDialog" => Role::Dialog,
+                "AXAlert" | "AXSystemFloatingWindow" => Role::Alert,
+                _ => Role::Unknown,
+            }
+        }
+    }
+}
+
+/// Build StateSet from AX attributes on an element.
+pub struct AXAttributes {
+    pub enabled: Option<bool>,
+    pub focused: Option<bool>,
+    pub selected: Option<bool>,
+    pub value: Option<AXValueState>,
+    pub expanded: Option<bool>,
+    pub is_expandable: bool,
+    pub required: Option<bool>,
+    pub busy: Option<bool>,
+    pub role: &'static str,
+}
+
+pub enum AXValueState {
+    Bool(bool),
+    Mixed,
+}
+
+pub fn map_states(
+    enabled: bool,
+    focused: bool,
+    selected: bool,
+    value: Option<i64>,
+    expanded: Option<bool>,
+    role: Role,
+) -> StateSet {
+    let checked = match role {
+        Role::CheckBox | Role::RadioButton => match value {
+            Some(2) => Some(Toggled::Mixed),
+            Some(1) => Some(Toggled::On),
+            Some(0) => Some(Toggled::Off),
+            _ => Some(Toggled::Off),
+        },
+        _ => None,
+    };
+
+    StateSet {
+        enabled,
+        visible: true, // AX only returns visible elements by default
+        focused,
+        checked,
+        selected,
+        expanded,
+        editable: false, // Will be set based on role in platform.rs
+        required: false,
+        busy: false,
+    }
+}
+
+/// Map an AX action name to xa11y Action.
+pub fn map_action_name(name: &str) -> Option<Action> {
+    match name {
+        "AXPress" => Some(Action::Press),
+        "AXShowMenu" => Some(Action::ShowMenu),
+        "AXIncrement" => Some(Action::Increment),
+        "AXDecrement" => Some(Action::Decrement),
+        "AXConfirm" => Some(Action::Press),
+        "AXCancel" => None,
+        "AXRaise" => Some(Action::Focus),
+        "AXPick" => Some(Action::Select),
+        _ => None,
+    }
+}
+
+/// Get the AX action name for an xa11y Action.
+pub fn ax_action_for(action: &Action) -> Option<&'static str> {
+    match action {
+        Action::Press => Some("AXPress"),
+        Action::Toggle => Some("AXPress"),
+        Action::ShowMenu => Some("AXShowMenu"),
+        Action::Increment => Some("AXIncrement"),
+        Action::Decrement => Some("AXDecrement"),
+        Action::Expand => Some("AXPress"),
+        Action::Collapse => Some("AXPress"),
+        Action::Select => Some("AXPick"),
+        _ => None,
+    }
+}

--- a/xa11y-macos/src/platform.rs
+++ b/xa11y-macos/src/platform.rs
@@ -1,13 +1,22 @@
+use std::collections::HashSet;
+use std::sync::Mutex;
+
 use xa11y_core::*;
+
+use crate::ax_ffi::AXElement;
+use crate::mapping;
 
 /// macOS accessibility provider using AXUIElement APIs.
 pub struct MacOSProvider {
-    // Internal state for caching element handles
+    /// Cached element references from the last snapshot, indexed by NodeId.
+    elements: Mutex<Vec<AXElement>>,
 }
 
 impl MacOSProvider {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            elements: Mutex::new(Vec::new()),
+        }
     }
 }
 
@@ -18,34 +27,507 @@ impl Default for MacOSProvider {
 }
 
 impl Provider for MacOSProvider {
-    fn get_app_tree(&self, _target: &AppTarget, _opts: &QueryOptions) -> Result<Tree> {
-        // TODO: Implement AXUIElement traversal
-        // 1. Find the target app via NSWorkspace or AXUIElementCreateApplication(pid)
-        // 2. DFS traverse the accessibility tree
-        // 3. Map AX roles/attributes to xa11y types
-        // 4. Cache live AXUIElementRef handles for action dispatch
-        Err(Error::Platform("macOS provider not yet implemented".into()))
+    fn check_permissions(&self) -> Result<PermissionStatus> {
+        let trusted = unsafe { crate::ax_ffi::AXIsProcessTrusted() };
+        if trusted {
+            Ok(PermissionStatus::Granted)
+        } else {
+            Ok(PermissionStatus::Denied {
+                instructions: "Accessibility access is not enabled. \
+                    Go to System Settings > Privacy & Security > Accessibility \
+                    and add this application."
+                    .into(),
+            })
+        }
     }
 
-    fn get_all_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
-        Err(Error::Platform("macOS provider not yet implemented".into()))
+    fn list_apps(&self) -> Result<Vec<AppInfo>> {
+        list_running_apps()
+    }
+
+    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree> {
+        let apps = list_running_apps()?;
+        let app = find_target_app(&apps, target)?;
+
+        let ax_app = AXElement::application(app.pid as i32).ok_or_else(|| {
+            Error::Platform(format!("Failed to create AXUIElement for pid {}", app.pid))
+        })?;
+
+        let screen_size = get_screen_size();
+        let mut nodes: Vec<Node> = Vec::new();
+        let mut elements: Vec<AXElement> = Vec::new();
+        let mut next_id: NodeId = 0;
+
+        traverse_element(
+            &ax_app,
+            None,
+            0,
+            &app.name,
+            opts,
+            screen_size,
+            &mut nodes,
+            &mut elements,
+            &mut next_id,
+        );
+
+        *self.elements.lock().unwrap() = elements;
+
+        Ok(Tree::new(
+            app.name.clone(),
+            app.pid,
+            screen_size,
+            nodes,
+            opts.clone(),
+        ))
+    }
+
+    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+        let apps = list_running_apps()?;
+        let screen_size = get_screen_size();
+
+        let all_nodes: Vec<Node> = apps
+            .iter()
+            .enumerate()
+            .map(|(i, app)| Node {
+                id: i as NodeId,
+                role: Role::Application,
+                name: Some(app.name.clone()),
+                value: None,
+                description: None,
+                bounds: None,
+                bounds_normalized: None,
+                actions: vec![],
+                states: StateSet::default(),
+                children: vec![],
+                parent: None,
+                depth: 0,
+                app_name: Some(app.name.clone()),
+                raw: None,
+            })
+            .collect();
+
+        Ok(Tree::new(
+            String::new(),
+            0,
+            screen_size,
+            all_nodes,
+            opts.clone(),
+        ))
     }
 
     fn perform_action(
         &self,
-        _node_id: NodeId,
-        _action: Action,
-        _data: Option<ActionData>,
+        node_id: NodeId,
+        action: Action,
+        data: Option<ActionData>,
     ) -> Result<()> {
-        Err(Error::Platform("macOS provider not yet implemented".into()))
+        let elements = self.elements.lock().unwrap();
+        let elem = elements
+            .get(node_id as usize)
+            .ok_or(Error::NodeNotFound(node_id))?;
+
+        match action {
+            Action::Focus => {
+                // AXRaise on the window, or set AXFocused
+                if !elem.set_string_attribute("AXFocused", "1") {
+                    // Try AXRaise action
+                    elem.perform_action("AXRaise");
+                }
+                Ok(())
+            }
+            Action::SetValue => {
+                let data =
+                    data.ok_or_else(|| Error::ActionNotSupported("SetValue requires data".into()))?;
+                match data {
+                    ActionData::Value(text) => {
+                        if !elem.set_string_attribute("AXValue", &text) {
+                            return Err(Error::Platform("Failed to set AXValue".into()));
+                        }
+                        Ok(())
+                    }
+                    ActionData::NumericValue(v) => {
+                        if !elem.set_number_attribute("AXValue", v) {
+                            return Err(Error::Platform("Failed to set AXValue".into()));
+                        }
+                        Ok(())
+                    }
+                    _ => Err(Error::ActionNotSupported(
+                        "SetValue requires Value or NumericValue data".into(),
+                    )),
+                }
+            }
+            Action::ScrollIntoView => {
+                // AXScrollToVisible is not a standard action; try setting AXVisibleCharacterRange
+                // or use AXPress as fallback
+                elem.perform_action("AXScrollToVisible");
+                Ok(())
+            }
+            _ => {
+                if let Some(ax_action) = mapping::ax_action_for(&action) {
+                    if elem.perform_action(ax_action) {
+                        Ok(())
+                    } else {
+                        Err(Error::ActionNotSupported(format!(
+                            "action {action:?} failed on this element"
+                        )))
+                    }
+                } else {
+                    Err(Error::ActionNotSupported(format!(
+                        "action {action:?} not supported on macOS"
+                    )))
+                }
+            }
+        }
+    }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+fn find_target_app(apps: &[AppInfo], target: &AppTarget) -> Result<AppInfo> {
+    let found = apps.iter().find(|app| match target {
+        AppTarget::ByName(ref name) => app.name.to_lowercase().contains(&name.to_lowercase()),
+        AppTarget::ByPid(pid) => app.pid == *pid,
+        AppTarget::ByWindow(_) => false,
+    });
+
+    found.cloned().ok_or_else(|| {
+        Error::AppNotFound(match target {
+            AppTarget::ByName(n) => n.clone(),
+            AppTarget::ByPid(p) => format!("pid:{p}"),
+            AppTarget::ByWindow(h) => format!("window:{}", h.id),
+        })
+    })
+}
+
+/// List running apps using NSWorkspace via the `ps` command as a portable fallback.
+fn list_running_apps() -> Result<Vec<AppInfo>> {
+    // Use ps to get running GUI apps. On macOS, apps with a window server connection
+    // typically have a bundle and are in /Applications or similar.
+    let output = std::process::Command::new("ps")
+        .args(["-eo", "pid,comm"])
+        .output()
+        .map_err(|e| Error::Platform(format!("failed to run ps: {e}")))?;
+
+    if !output.status.success() {
+        return Err(Error::Platform("ps command failed".into()));
     }
 
-    fn check_permissions(&self) -> Result<PermissionStatus> {
-        // TODO: Call AXIsProcessTrusted()
-        Err(Error::Platform("macOS provider not yet implemented".into()))
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut apps = Vec::new();
+    let mut seen_names = HashSet::new();
+
+    for line in stdout.lines().skip(1) {
+        let trimmed = line.trim();
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        let pid_str = match parts.next() {
+            Some(s) => s.trim(),
+            None => continue,
+        };
+        let comm = match parts.next() {
+            Some(s) => s.trim(),
+            None => continue,
+        };
+
+        let pid: u32 = match pid_str.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        // Filter to .app bundle executables
+        if !comm.contains(".app/") {
+            continue;
+        }
+
+        // Extract app name from path like /Applications/Safari.app/Contents/MacOS/Safari
+        let app_name = if let Some(idx) = comm.rfind(".app/") {
+            let before = &comm[..idx];
+            before.rsplit('/').next().unwrap_or(comm).to_string()
+        } else {
+            comm.rsplit('/').next().unwrap_or(comm).to_string()
+        };
+
+        if app_name.is_empty() || !seen_names.insert(app_name.clone()) {
+            continue;
+        }
+
+        // Try to extract bundle_id from the path
+        let bundle_id = extract_bundle_id(comm);
+
+        apps.push(AppInfo {
+            name: app_name,
+            pid,
+            bundle_id,
+        });
     }
 
-    fn list_apps(&self) -> Result<Vec<AppInfo>> {
-        Err(Error::Platform("macOS provider not yet implemented".into()))
+    Ok(apps)
+}
+
+fn extract_bundle_id(path: &str) -> Option<String> {
+    // Try to read Info.plist from the .app bundle
+    if let Some(idx) = path.find(".app/") {
+        let bundle_path = format!("{}/Contents/Info.plist", &path[..idx + 4]);
+        if let Ok(output) = std::process::Command::new("defaults")
+            .args(["read", &bundle_path, "CFBundleIdentifier"])
+            .output()
+        {
+            if output.status.success() {
+                let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !id.is_empty() {
+                    return Some(id);
+                }
+            }
+        }
     }
+    None
+}
+
+#[allow(clippy::too_many_arguments)]
+fn traverse_element(
+    elem: &AXElement,
+    parent_id: Option<NodeId>,
+    depth: u32,
+    app_name: &str,
+    opts: &QueryOptions,
+    screen_size: (u32, u32),
+    nodes: &mut Vec<Node>,
+    elements: &mut Vec<AXElement>,
+    next_id: &mut NodeId,
+) {
+    if depth > opts.max_depth || *next_id >= opts.max_elements {
+        return;
+    }
+
+    let ax_role = elem.string_attribute("AXRole").unwrap_or_default();
+    let ax_subrole = elem.string_attribute("AXSubrole");
+    let role = mapping::map_role(&ax_role, ax_subrole.as_deref());
+
+    if let Some(ref roles) = opts.roles {
+        if !roles.contains(&role) {
+            return;
+        }
+    }
+
+    let name = elem
+        .string_attribute("AXTitle")
+        .or_else(|| elem.string_attribute("AXDescription"))
+        .filter(|s| !s.is_empty());
+
+    let description = elem.string_attribute("AXHelp").filter(|s| !s.is_empty());
+
+    // Bounds
+    let bounds: Option<Rect> = match (elem.position(), elem.size()) {
+        (Some((x, y)), Some((w, h))) => Some(Rect {
+            x: x as i32,
+            y: y as i32,
+            width: w as i32,
+            height: h as i32,
+        }),
+        _ => None,
+    };
+
+    let bounds_normalized: Option<NormalizedRect> = bounds.and_then(|b| {
+        if screen_size.0 > 0 && screen_size.1 > 0 {
+            Some(NormalizedRect {
+                x1: b.x as f64 / screen_size.0 as f64,
+                y1: b.y as f64 / screen_size.1 as f64,
+                x2: (b.x + b.width) as f64 / screen_size.0 as f64,
+                y2: (b.y + b.height) as f64 / screen_size.1 as f64,
+            })
+        } else {
+            None
+        }
+    });
+
+    // States
+    let enabled = elem.bool_attribute("AXEnabled").unwrap_or(true);
+    let focused = elem.bool_attribute("AXFocused").unwrap_or(false);
+    let selected = elem.bool_attribute("AXSelected").unwrap_or(false);
+
+    let value_int = elem.number_attribute("AXValue").map(|v| v as i64);
+    let expanded = if matches!(
+        role,
+        Role::TreeItem | Role::ComboBox | Role::Group | Role::MenuItem
+    ) {
+        elem.bool_attribute("AXExpanded")
+    } else {
+        None
+    };
+
+    let mut states = mapping::map_states(enabled, focused, selected, value_int, expanded, role);
+
+    // Check editable
+    if matches!(role, Role::TextField | Role::TextArea) {
+        states.editable = true;
+    }
+
+    if opts.visible_only && !states.visible {
+        return;
+    }
+
+    let my_id = *next_id;
+    *next_id += 1;
+
+    // Value
+    let value: Option<String> = get_element_value(elem, role);
+
+    // Actions
+    let actions: Vec<Action> = get_element_actions(elem, role);
+
+    // Raw platform data
+    let raw: Option<RawPlatformData> = if opts.include_raw {
+        let ax_identifier = elem.string_attribute("AXIdentifier");
+        Some(RawPlatformData::MacOS {
+            ax_role,
+            ax_subrole,
+            ax_identifier,
+        })
+    } else {
+        None
+    };
+
+    let node = Node {
+        id: my_id,
+        role,
+        name,
+        value,
+        description,
+        bounds,
+        bounds_normalized,
+        actions,
+        states,
+        children: vec![],
+        parent: parent_id,
+        depth,
+        app_name: Some(app_name.to_string()),
+        raw,
+    };
+
+    let node_idx = nodes.len();
+    nodes.push(node);
+    elements.push(elem.clone());
+
+    // Traverse children
+    let children = elem.children();
+    let mut child_ids: Vec<NodeId> = Vec::new();
+
+    for child in &children {
+        if *next_id >= opts.max_elements {
+            break;
+        }
+        let child_id = *next_id;
+        let prev_count = nodes.len();
+
+        traverse_element(
+            child,
+            Some(my_id),
+            depth + 1,
+            app_name,
+            opts,
+            screen_size,
+            nodes,
+            elements,
+            next_id,
+        );
+
+        if nodes.len() > prev_count {
+            child_ids.push(child_id);
+        }
+    }
+
+    nodes[node_idx].children = child_ids;
+}
+
+fn get_element_value(elem: &AXElement, role: Role) -> Option<String> {
+    match role {
+        Role::TextField | Role::TextArea | Role::StaticText | Role::Heading | Role::Link => {
+            elem.string_attribute("AXValue").filter(|s| !s.is_empty())
+        }
+        Role::Slider | Role::ProgressBar | Role::ScrollBar => {
+            elem.number_attribute("AXValue").map(|v| v.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn get_element_actions(elem: &AXElement, role: Role) -> Vec<Action> {
+    let ax_names = elem.action_names();
+    let mut actions: Vec<Action> = Vec::new();
+    let mut seen = HashSet::new();
+
+    for name in &ax_names {
+        if let Some(action) = mapping::map_action_name(name) {
+            if seen.insert(action) {
+                actions.push(action);
+            }
+        }
+    }
+
+    // Always allow Focus if element supports it
+    if !seen.contains(&Action::Focus) {
+        actions.push(Action::Focus);
+    }
+
+    // SetValue for editable fields and sliders
+    if matches!(
+        role,
+        Role::TextField | Role::TextArea | Role::Slider | Role::ComboBox
+    ) && !seen.contains(&Action::SetValue)
+    {
+        actions.push(Action::SetValue);
+    }
+
+    // Toggle for checkboxes
+    if matches!(role, Role::CheckBox | Role::RadioButton) && !seen.contains(&Action::Toggle) {
+        actions.push(Action::Toggle);
+    }
+
+    actions
+}
+
+/// Get screen size from the main display.
+fn get_screen_size() -> (u32, u32) {
+    // Use system_profiler or CGMainDisplayID as fallback
+    // For now, use a simpler approach via the system_profiler command
+    if let Ok(output) = std::process::Command::new("system_profiler")
+        .args(["SPDisplaysDataType", "-json"])
+        .output()
+    {
+        if output.status.success() {
+            if let Ok(val) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
+                if let Some(displays) = val.get("SPDisplaysDataType").and_then(|d| d.as_array()) {
+                    for gpu in displays {
+                        if let Some(ndisplays) =
+                            gpu.get("spdisplays_ndrvs").and_then(|d| d.as_array())
+                        {
+                            for display in ndisplays {
+                                let res = display
+                                    .get("_spdisplays_resolution")
+                                    .and_then(|r| r.as_str());
+                                if let Some(res_str) = res {
+                                    // Format: "2560 x 1440" or similar
+                                    let parts: Vec<&str> = res_str.split(" x ").collect();
+                                    if parts.len() == 2 {
+                                        if let (Ok(w), Ok(h)) = (
+                                            parts[0].trim().parse::<u32>(),
+                                            parts[1]
+                                                .trim()
+                                                .split_whitespace()
+                                                .next()
+                                                .unwrap_or("")
+                                                .parse::<u32>(),
+                                        ) {
+                                            return (w, h);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    (1920, 1080)
 }

--- a/xa11y-macos/src/platform.rs
+++ b/xa11y-macos/src/platform.rs
@@ -1,0 +1,51 @@
+use xa11y_core::*;
+
+/// macOS accessibility provider using AXUIElement APIs.
+pub struct MacOSProvider {
+    // Internal state for caching element handles
+}
+
+impl MacOSProvider {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for MacOSProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Provider for MacOSProvider {
+    fn get_app_tree(&self, _target: &AppTarget, _opts: &QueryOptions) -> Result<Tree> {
+        // TODO: Implement AXUIElement traversal
+        // 1. Find the target app via NSWorkspace or AXUIElementCreateApplication(pid)
+        // 2. DFS traverse the accessibility tree
+        // 3. Map AX roles/attributes to xa11y types
+        // 4. Cache live AXUIElementRef handles for action dispatch
+        Err(Error::Platform("macOS provider not yet implemented".into()))
+    }
+
+    fn get_all_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
+        Err(Error::Platform("macOS provider not yet implemented".into()))
+    }
+
+    fn perform_action(
+        &self,
+        _node_id: NodeId,
+        _action: Action,
+        _data: Option<ActionData>,
+    ) -> Result<()> {
+        Err(Error::Platform("macOS provider not yet implemented".into()))
+    }
+
+    fn check_permissions(&self) -> Result<PermissionStatus> {
+        // TODO: Call AXIsProcessTrusted()
+        Err(Error::Platform("macOS provider not yet implemented".into()))
+    }
+
+    fn list_apps(&self) -> Result<Vec<AppInfo>> {
+        Err(Error::Platform("macOS provider not yet implemented".into()))
+    }
+}

--- a/xa11y-windows/Cargo.toml
+++ b/xa11y-windows/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "xa11y-windows"
+description = "Windows backend for xa11y (UI Automation)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+xa11y-core.workspace = true
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_UI_Accessibility",
+    "Win32_System_Com",
+    "Win32_Foundation",
+] }

--- a/xa11y-windows/Cargo.toml
+++ b/xa11y-windows/Cargo.toml
@@ -13,4 +13,5 @@ windows = { version = "0.58", features = [
     "Win32_UI_Accessibility",
     "Win32_System_Com",
     "Win32_Foundation",
+    "Win32_UI_WindowsAndMessaging",
 ] }

--- a/xa11y-windows/src/lib.rs
+++ b/xa11y-windows/src/lib.rs
@@ -1,0 +1,18 @@
+//! Windows accessibility backend using UI Automation (UIA).
+//!
+//! This backend uses Microsoft's UI Automation API to read
+//! accessibility trees from running applications on Windows.
+//!
+//! This crate only provides functionality on Windows. On other platforms,
+//! the crate compiles but exports nothing.
+
+#[cfg(target_os = "windows")]
+mod platform;
+
+#[cfg(target_os = "windows")]
+pub use platform::WindowsProvider;
+
+#[cfg(target_os = "windows")]
+pub fn create_provider() -> WindowsProvider {
+    WindowsProvider::new()
+}

--- a/xa11y-windows/src/lib.rs
+++ b/xa11y-windows/src/lib.rs
@@ -7,6 +7,8 @@
 //! the crate compiles but exports nothing.
 
 #[cfg(target_os = "windows")]
+mod mapping;
+#[cfg(target_os = "windows")]
 mod platform;
 
 #[cfg(target_os = "windows")]

--- a/xa11y-windows/src/mapping.rs
+++ b/xa11y-windows/src/mapping.rs
@@ -1,0 +1,155 @@
+use xa11y_core::{Action, Role, StateSet, Toggled};
+
+// UIA Control Type IDs
+const UIA_BUTTON: i32 = 50000;
+const UIA_CALENDAR: i32 = 50001;
+const UIA_CHECK_BOX: i32 = 50002;
+const UIA_COMBO_BOX: i32 = 50003;
+const UIA_EDIT: i32 = 50004;
+const UIA_HYPERLINK: i32 = 50005;
+const UIA_IMAGE: i32 = 50006;
+const UIA_LIST_ITEM: i32 = 50007;
+const UIA_LIST: i32 = 50008;
+const UIA_MENU: i32 = 50009;
+const UIA_MENU_BAR: i32 = 50010;
+const UIA_MENU_ITEM: i32 = 50011;
+const UIA_PROGRESS_BAR: i32 = 50012;
+const UIA_RADIO_BUTTON: i32 = 50013;
+const UIA_SCROLL_BAR: i32 = 50014;
+const UIA_SLIDER: i32 = 50015;
+const UIA_SPINNER: i32 = 50016;
+const UIA_STATUS_BAR: i32 = 50017;
+const UIA_TAB: i32 = 50018;
+const UIA_TAB_ITEM: i32 = 50019;
+const UIA_TEXT: i32 = 50020;
+const UIA_TOOL_BAR: i32 = 50021;
+const UIA_TOOL_TIP: i32 = 50022;
+const UIA_TREE: i32 = 50023;
+const UIA_TREE_ITEM: i32 = 50024;
+const UIA_CUSTOM: i32 = 50025;
+const UIA_GROUP: i32 = 50026;
+const UIA_THUMB: i32 = 50027;
+const UIA_DATA_GRID: i32 = 50028;
+const UIA_DATA_ITEM: i32 = 50029;
+const UIA_DOCUMENT: i32 = 50030;
+const UIA_SPLIT_BUTTON: i32 = 50031;
+const UIA_WINDOW: i32 = 50032;
+const UIA_PANE: i32 = 50033;
+const UIA_HEADER: i32 = 50034;
+const UIA_HEADER_ITEM: i32 = 50035;
+const UIA_TABLE: i32 = 50036;
+const UIA_TITLE_BAR: i32 = 50037;
+const UIA_SEPARATOR: i32 = 50038;
+const UIA_APP_BAR: i32 = 50040;
+
+/// Map UIA control type ID to xa11y Role.
+pub fn map_role(control_type: i32) -> Role {
+    match control_type {
+        UIA_BUTTON | UIA_SPLIT_BUTTON => Role::Button,
+        UIA_CHECK_BOX => Role::CheckBox,
+        UIA_RADIO_BUTTON => Role::RadioButton,
+        UIA_EDIT => Role::TextField,
+        UIA_TEXT => Role::StaticText,
+        UIA_COMBO_BOX => Role::ComboBox,
+        UIA_LIST => Role::List,
+        UIA_LIST_ITEM | UIA_DATA_ITEM => Role::ListItem,
+        UIA_MENU => Role::Menu,
+        UIA_MENU_BAR | UIA_APP_BAR => Role::MenuBar,
+        UIA_MENU_ITEM => Role::MenuItem,
+        UIA_TAB => Role::TabGroup,
+        UIA_TAB_ITEM => Role::Tab,
+        UIA_TABLE | UIA_DATA_GRID => Role::Table,
+        UIA_HEADER | UIA_HEADER_ITEM => Role::TableCell,
+        UIA_TOOL_BAR => Role::Toolbar,
+        UIA_SCROLL_BAR | UIA_THUMB => Role::ScrollBar,
+        UIA_SLIDER | UIA_SPINNER => Role::Slider,
+        UIA_IMAGE => Role::Image,
+        UIA_HYPERLINK => Role::Link,
+        UIA_GROUP | UIA_PANE | UIA_CUSTOM | UIA_CALENDAR | UIA_STATUS_BAR => Role::Group,
+        UIA_PROGRESS_BAR => Role::ProgressBar,
+        UIA_TREE => Role::List,
+        UIA_TREE_ITEM => Role::TreeItem,
+        UIA_DOCUMENT => Role::WebArea,
+        UIA_WINDOW | UIA_TITLE_BAR => Role::Window,
+        UIA_SEPARATOR => Role::Separator,
+        UIA_TOOL_TIP => Role::Alert,
+        _ => Role::Unknown,
+    }
+}
+
+/// Build StateSet from UIA element properties.
+pub fn map_states(
+    is_enabled: bool,
+    is_offscreen: bool,
+    has_keyboard_focus: bool,
+    toggle_state: Option<i32>,
+    is_selected: bool,
+    expand_collapse_state: Option<i32>,
+) -> StateSet {
+    // Toggle states: 0=Off, 1=On, 2=Indeterminate
+    let checked = toggle_state.map(|t| match t {
+        1 => Toggled::On,
+        2 => Toggled::Mixed,
+        _ => Toggled::Off,
+    });
+
+    // ExpandCollapse states: 0=Collapsed, 1=Expanded, 2=PartiallyExpanded, 3=LeafNode
+    let expanded = expand_collapse_state.and_then(|s| match s {
+        0 => Some(false),
+        1 | 2 => Some(true),
+        _ => None, // LeafNode = not expandable
+    });
+
+    StateSet {
+        enabled: is_enabled,
+        visible: !is_offscreen,
+        focused: has_keyboard_focus,
+        checked,
+        selected: is_selected,
+        expanded,
+        editable: false,
+        required: false,
+        busy: false,
+    }
+}
+
+/// Map UIA pattern availability to xa11y actions.
+pub fn actions_from_patterns(
+    has_invoke: bool,
+    has_toggle: bool,
+    has_expand_collapse: bool,
+    has_selection_item: bool,
+    has_value: bool,
+    has_range_value: bool,
+    has_scroll_item: bool,
+) -> Vec<Action> {
+    let mut actions = Vec::new();
+
+    if has_invoke {
+        actions.push(Action::Press);
+    }
+    if has_toggle {
+        actions.push(Action::Toggle);
+    }
+    if has_expand_collapse {
+        actions.push(Action::Expand);
+        actions.push(Action::Collapse);
+    }
+    if has_selection_item {
+        actions.push(Action::Select);
+    }
+    if has_value || has_range_value {
+        actions.push(Action::SetValue);
+    }
+    if has_range_value {
+        actions.push(Action::Increment);
+        actions.push(Action::Decrement);
+    }
+    if has_scroll_item {
+        actions.push(Action::ScrollIntoView);
+    }
+
+    actions.push(Action::Focus);
+
+    actions
+}

--- a/xa11y-windows/src/platform.rs
+++ b/xa11y-windows/src/platform.rs
@@ -1,0 +1,61 @@
+use xa11y_core::*;
+
+/// Windows accessibility provider using UI Automation.
+pub struct WindowsProvider {
+    // Internal state for UIA automation instance and cached elements
+}
+
+impl WindowsProvider {
+    pub fn new() -> Self {
+        // TODO: Initialize COM and create IUIAutomation instance
+        // CoInitializeEx(COINIT_MULTITHREADED)
+        Self {}
+    }
+}
+
+impl Default for WindowsProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Provider for WindowsProvider {
+    fn get_app_tree(&self, _target: &AppTarget, _opts: &QueryOptions) -> Result<Tree> {
+        // TODO: Implement UIA tree traversal
+        // 1. Find the target app window via UIA root element
+        // 2. Use ContentView (not RawView) for traversal
+        // 3. Map UIA control types to xa11y roles
+        // 4. Query UIA patterns to determine available actions
+        Err(Error::Platform(
+            "Windows provider not yet implemented".into(),
+        ))
+    }
+
+    fn get_all_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
+        Err(Error::Platform(
+            "Windows provider not yet implemented".into(),
+        ))
+    }
+
+    fn perform_action(
+        &self,
+        _node_id: NodeId,
+        _action: Action,
+        _data: Option<ActionData>,
+    ) -> Result<()> {
+        Err(Error::Platform(
+            "Windows provider not yet implemented".into(),
+        ))
+    }
+
+    fn check_permissions(&self) -> Result<PermissionStatus> {
+        // Windows doesn't require special permissions for local UIA queries
+        Ok(PermissionStatus::Granted)
+    }
+
+    fn list_apps(&self) -> Result<Vec<AppInfo>> {
+        Err(Error::Platform(
+            "Windows provider not yet implemented".into(),
+        ))
+    }
+}

--- a/xa11y-windows/src/platform.rs
+++ b/xa11y-windows/src/platform.rs
@@ -1,15 +1,48 @@
+use std::sync::Mutex;
+
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CLSCTX_ALL, COINIT_MULTITHREADED,
+};
+use windows::Win32::UI::Accessibility::{
+    CUIAutomation, IUIAutomation, IUIAutomationCondition, IUIAutomationElement,
+    IUIAutomationExpandCollapsePattern, IUIAutomationInvokePattern, IUIAutomationRangeValuePattern,
+    IUIAutomationScrollItemPattern, IUIAutomationSelectionItemPattern, IUIAutomationTogglePattern,
+    IUIAutomationTreeWalker, IUIAutomationValuePattern, TreeScope_Children, TreeScope_Element,
+    UIA_ExpandCollapsePatternId, UIA_InvokePatternId, UIA_RangeValuePatternId,
+    UIA_ScrollItemPatternId, UIA_SelectionItemPatternId, UIA_TogglePatternId, UIA_ValuePatternId,
+};
+
 use xa11y_core::*;
+
+use crate::mapping;
 
 /// Windows accessibility provider using UI Automation.
 pub struct WindowsProvider {
-    // Internal state for UIA automation instance and cached elements
+    uia: Mutex<Option<IUIAutomation>>,
+    /// Cached element references from the last snapshot, indexed by NodeId.
+    elements: Mutex<Vec<IUIAutomationElement>>,
 }
 
 impl WindowsProvider {
     pub fn new() -> Self {
-        // TODO: Initialize COM and create IUIAutomation instance
-        // CoInitializeEx(COINIT_MULTITHREADED)
-        Self {}
+        Self {
+            uia: Mutex::new(None),
+            elements: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn automation(&self) -> Result<IUIAutomation> {
+        let mut guard = self.uia.lock().unwrap();
+        if let Some(ref uia) = *guard {
+            return Ok(uia.clone());
+        }
+        unsafe {
+            CoInitializeEx(None, COINIT_MULTITHREADED).ok().ok();
+            let uia: IUIAutomation = CoCreateInstance(&CUIAutomation, None, CLSCTX_ALL)
+                .map_err(|e| Error::Platform(format!("Failed to create UIA: {e}")))?;
+            *guard = Some(uia.clone());
+            Ok(uia)
+        }
     }
 }
 
@@ -19,43 +52,613 @@ impl Default for WindowsProvider {
     }
 }
 
+unsafe impl Send for WindowsProvider {}
+unsafe impl Sync for WindowsProvider {}
+
 impl Provider for WindowsProvider {
-    fn get_app_tree(&self, _target: &AppTarget, _opts: &QueryOptions) -> Result<Tree> {
-        // TODO: Implement UIA tree traversal
-        // 1. Find the target app window via UIA root element
-        // 2. Use ContentView (not RawView) for traversal
-        // 3. Map UIA control types to xa11y roles
-        // 4. Query UIA patterns to determine available actions
-        Err(Error::Platform(
-            "Windows provider not yet implemented".into(),
-        ))
-    }
-
-    fn get_all_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
-        Err(Error::Platform(
-            "Windows provider not yet implemented".into(),
-        ))
-    }
-
-    fn perform_action(
-        &self,
-        _node_id: NodeId,
-        _action: Action,
-        _data: Option<ActionData>,
-    ) -> Result<()> {
-        Err(Error::Platform(
-            "Windows provider not yet implemented".into(),
-        ))
-    }
-
     fn check_permissions(&self) -> Result<PermissionStatus> {
         // Windows doesn't require special permissions for local UIA queries
         Ok(PermissionStatus::Granted)
     }
 
     fn list_apps(&self) -> Result<Vec<AppInfo>> {
-        Err(Error::Platform(
-            "Windows provider not yet implemented".into(),
+        let uia = self.automation()?;
+        unsafe {
+            let root = uia
+                .GetRootElement()
+                .map_err(|e| Error::Platform(format!("Failed to get root element: {e}")))?;
+
+            let condition: IUIAutomationCondition = uia
+                .CreateTrueCondition()
+                .map_err(|e| Error::Platform(format!("Failed to create condition: {e}")))?;
+
+            let children = root
+                .FindAll(TreeScope_Children, &condition)
+                .map_err(|e| Error::Platform(format!("Failed to enumerate children: {e}")))?;
+
+            let count = children
+                .Length()
+                .map_err(|e| Error::Platform(format!("Failed to get count: {e}")))?;
+
+            let mut apps = Vec::new();
+            for i in 0..count {
+                let elem = match children.GetElement(i) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+
+                let name = elem
+                    .CurrentName()
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
+
+                let pid = elem.CurrentProcessId().unwrap_or(0) as u32;
+
+                if name.is_empty() && pid == 0 {
+                    continue;
+                }
+
+                apps.push(AppInfo {
+                    name: if name.is_empty() {
+                        format!("pid:{pid}")
+                    } else {
+                        name
+                    },
+                    pid,
+                    bundle_id: None,
+                });
+            }
+
+            Ok(apps)
+        }
+    }
+
+    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree> {
+        let uia = self.automation()?;
+
+        unsafe {
+            let root = uia
+                .GetRootElement()
+                .map_err(|e| Error::Platform(format!("Failed to get root element: {e}")))?;
+
+            // Find the target app window
+            let condition: IUIAutomationCondition = uia
+                .CreateTrueCondition()
+                .map_err(|e| Error::Platform(format!("Failed to create condition: {e}")))?;
+
+            let children = root
+                .FindAll(TreeScope_Children, &condition)
+                .map_err(|e| Error::Platform(format!("Failed to enumerate children: {e}")))?;
+
+            let count = children.Length().unwrap_or(0);
+
+            let mut app_elem: Option<IUIAutomationElement> = None;
+            let mut app_name = String::new();
+            let mut app_pid: u32 = 0;
+
+            for i in 0..count {
+                let elem = match children.GetElement(i) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+
+                let name = elem
+                    .CurrentName()
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
+
+                let pid = elem.CurrentProcessId().unwrap_or(0) as u32;
+
+                let matches = match target {
+                    AppTarget::ByName(ref target_name) => {
+                        name.to_lowercase().contains(&target_name.to_lowercase())
+                    }
+                    AppTarget::ByPid(target_pid) => pid == *target_pid,
+                    AppTarget::ByWindow(handle) => {
+                        // Compare native window handle
+                        elem.CurrentNativeWindowHandle()
+                            .map(|h| h.0 as u64 == handle.id)
+                            .unwrap_or(false)
+                    }
+                };
+
+                if matches {
+                    app_elem = Some(elem);
+                    app_name = name;
+                    app_pid = pid;
+                    break;
+                }
+            }
+
+            let app_elem = app_elem.ok_or_else(|| {
+                Error::AppNotFound(match target {
+                    AppTarget::ByName(n) => n.clone(),
+                    AppTarget::ByPid(p) => format!("pid:{p}"),
+                    AppTarget::ByWindow(h) => format!("window:{}", h.id),
+                })
+            })?;
+
+            let screen_size = get_screen_size();
+            let walker = uia
+                .ContentViewWalker()
+                .map_err(|e| Error::Platform(format!("Failed to get content walker: {e}")))?;
+
+            let mut nodes: Vec<Node> = Vec::new();
+            let mut elements: Vec<IUIAutomationElement> = Vec::new();
+            let mut next_id: NodeId = 0;
+
+            traverse_element(
+                &walker,
+                &app_elem,
+                None,
+                0,
+                &app_name,
+                opts,
+                screen_size,
+                &mut nodes,
+                &mut elements,
+                &mut next_id,
+            );
+
+            *self.elements.lock().unwrap() = elements;
+
+            Ok(Tree::new(
+                app_name,
+                app_pid,
+                screen_size,
+                nodes,
+                opts.clone(),
+            ))
+        }
+    }
+
+    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+        let apps = self.list_apps()?;
+        let screen_size = get_screen_size();
+
+        let all_nodes: Vec<Node> = apps
+            .iter()
+            .enumerate()
+            .map(|(i, app)| Node {
+                id: i as NodeId,
+                role: Role::Application,
+                name: Some(app.name.clone()),
+                value: None,
+                description: None,
+                bounds: None,
+                bounds_normalized: None,
+                actions: vec![],
+                states: StateSet::default(),
+                children: vec![],
+                parent: None,
+                depth: 0,
+                app_name: Some(app.name.clone()),
+                raw: None,
+            })
+            .collect();
+
+        Ok(Tree::new(
+            String::new(),
+            0,
+            screen_size,
+            all_nodes,
+            opts.clone(),
         ))
+    }
+
+    fn perform_action(
+        &self,
+        node_id: NodeId,
+        action: Action,
+        data: Option<ActionData>,
+    ) -> Result<()> {
+        let elements = self.elements.lock().unwrap();
+        let elem = elements
+            .get(node_id as usize)
+            .ok_or(Error::NodeNotFound(node_id))?;
+
+        unsafe {
+            match action {
+                Action::Press => {
+                    let pattern: IUIAutomationInvokePattern =
+                        elem.GetCurrentPatternAs(UIA_InvokePatternId).map_err(|e| {
+                            Error::ActionNotSupported(format!("no Invoke pattern: {e}"))
+                        })?;
+                    pattern
+                        .Invoke()
+                        .map_err(|e| Error::Platform(format!("Invoke failed: {e}")))?;
+                    Ok(())
+                }
+                Action::Toggle => {
+                    let pattern: IUIAutomationTogglePattern =
+                        elem.GetCurrentPatternAs(UIA_TogglePatternId).map_err(|e| {
+                            Error::ActionNotSupported(format!("no Toggle pattern: {e}"))
+                        })?;
+                    pattern
+                        .Toggle()
+                        .map_err(|e| Error::Platform(format!("Toggle failed: {e}")))?;
+                    Ok(())
+                }
+                Action::Expand => {
+                    let pattern: IUIAutomationExpandCollapsePattern = elem
+                        .GetCurrentPatternAs(UIA_ExpandCollapsePatternId)
+                        .map_err(|e| {
+                            Error::ActionNotSupported(format!("no ExpandCollapse pattern: {e}"))
+                        })?;
+                    pattern
+                        .Expand()
+                        .map_err(|e| Error::Platform(format!("Expand failed: {e}")))?;
+                    Ok(())
+                }
+                Action::Collapse => {
+                    let pattern: IUIAutomationExpandCollapsePattern = elem
+                        .GetCurrentPatternAs(UIA_ExpandCollapsePatternId)
+                        .map_err(|e| {
+                            Error::ActionNotSupported(format!("no ExpandCollapse pattern: {e}"))
+                        })?;
+                    pattern
+                        .Collapse()
+                        .map_err(|e| Error::Platform(format!("Collapse failed: {e}")))?;
+                    Ok(())
+                }
+                Action::Select => {
+                    let pattern: IUIAutomationSelectionItemPattern = elem
+                        .GetCurrentPatternAs(UIA_SelectionItemPatternId)
+                        .map_err(|e| {
+                            Error::ActionNotSupported(format!("no SelectionItem pattern: {e}"))
+                        })?;
+                    pattern
+                        .Select()
+                        .map_err(|e| Error::Platform(format!("Select failed: {e}")))?;
+                    Ok(())
+                }
+                Action::Focus => {
+                    elem.SetFocus()
+                        .map_err(|e| Error::Platform(format!("SetFocus failed: {e}")))?;
+                    Ok(())
+                }
+                Action::SetValue => {
+                    let data = data.ok_or_else(|| {
+                        Error::ActionNotSupported("SetValue requires data".into())
+                    })?;
+                    match data {
+                        ActionData::Value(text) => {
+                            let pattern: IUIAutomationValuePattern =
+                                elem.GetCurrentPatternAs(UIA_ValuePatternId).map_err(|e| {
+                                    Error::ActionNotSupported(format!("no Value pattern: {e}"))
+                                })?;
+                            let bstr = windows::core::BSTR::from(text.as_str());
+                            pattern
+                                .SetValue(&bstr)
+                                .map_err(|e| Error::Platform(format!("SetValue failed: {e}")))?;
+                            Ok(())
+                        }
+                        ActionData::NumericValue(v) => {
+                            let pattern: IUIAutomationRangeValuePattern = elem
+                                .GetCurrentPatternAs(UIA_RangeValuePatternId)
+                                .map_err(|e| {
+                                    Error::ActionNotSupported(format!("no RangeValue pattern: {e}"))
+                                })?;
+                            pattern.SetValue(v).map_err(|e| {
+                                Error::Platform(format!("SetRangeValue failed: {e}"))
+                            })?;
+                            Ok(())
+                        }
+                        _ => Err(Error::ActionNotSupported(
+                            "SetValue requires Value or NumericValue data".into(),
+                        )),
+                    }
+                }
+                Action::ScrollIntoView => {
+                    let pattern: IUIAutomationScrollItemPattern = elem
+                        .GetCurrentPatternAs(UIA_ScrollItemPatternId)
+                        .map_err(|e| {
+                            Error::ActionNotSupported(format!("no ScrollItem pattern: {e}"))
+                        })?;
+                    pattern
+                        .ScrollIntoView()
+                        .map_err(|e| Error::Platform(format!("ScrollIntoView failed: {e}")))?;
+                    Ok(())
+                }
+                Action::Increment => {
+                    let pattern: IUIAutomationRangeValuePattern = elem
+                        .GetCurrentPatternAs(UIA_RangeValuePatternId)
+                        .map_err(|e| {
+                            Error::ActionNotSupported(format!("no RangeValue pattern: {e}"))
+                        })?;
+                    let current = pattern.CurrentValue().unwrap_or(0.0);
+                    let small_change = pattern.CurrentSmallChange().unwrap_or(1.0);
+                    pattern
+                        .SetValue(current + small_change)
+                        .map_err(|e| Error::Platform(format!("Increment failed: {e}")))?;
+                    Ok(())
+                }
+                Action::Decrement => {
+                    let pattern: IUIAutomationRangeValuePattern = elem
+                        .GetCurrentPatternAs(UIA_RangeValuePatternId)
+                        .map_err(|e| {
+                            Error::ActionNotSupported(format!("no RangeValue pattern: {e}"))
+                        })?;
+                    let current = pattern.CurrentValue().unwrap_or(0.0);
+                    let small_change = pattern.CurrentSmallChange().unwrap_or(1.0);
+                    pattern
+                        .SetValue(current - small_change)
+                        .map_err(|e| Error::Platform(format!("Decrement failed: {e}")))?;
+                    Ok(())
+                }
+                Action::ShowMenu => {
+                    // Try ExpandCollapse for dropdown menus
+                    if let Ok(pattern) = elem
+                        .GetCurrentPatternAs::<IUIAutomationExpandCollapsePattern>(
+                            UIA_ExpandCollapsePatternId,
+                        )
+                    {
+                        pattern
+                            .Expand()
+                            .map_err(|e| Error::Platform(format!("ShowMenu/Expand failed: {e}")))?;
+                        Ok(())
+                    } else {
+                        Err(Error::ActionNotSupported(
+                            "ShowMenu not supported on this element".into(),
+                        ))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn traverse_element(
+    walker: &IUIAutomationTreeWalker,
+    elem: &IUIAutomationElement,
+    parent_id: Option<NodeId>,
+    depth: u32,
+    app_name: &str,
+    opts: &QueryOptions,
+    screen_size: (u32, u32),
+    nodes: &mut Vec<Node>,
+    elements: &mut Vec<IUIAutomationElement>,
+    next_id: &mut NodeId,
+) {
+    if depth > opts.max_depth || *next_id >= opts.max_elements {
+        return;
+    }
+
+    let control_type = elem.CurrentControlType().unwrap_or(0);
+    let role = mapping::map_role(control_type);
+
+    if let Some(ref roles) = opts.roles {
+        if !roles.contains(&role) {
+            return;
+        }
+    }
+
+    let name: Option<String> = elem
+        .CurrentName()
+        .ok()
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty());
+
+    let help_text: Option<String> = elem
+        .CurrentHelpText()
+        .ok()
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty());
+
+    // Bounds
+    let bounds: Option<Rect> = elem.CurrentBoundingRectangle().ok().map(|r| Rect {
+        x: r.left as i32,
+        y: r.top as i32,
+        width: (r.right - r.left) as i32,
+        height: (r.bottom - r.top) as i32,
+    });
+
+    let bounds_normalized: Option<NormalizedRect> = bounds.and_then(|b| {
+        if screen_size.0 > 0 && screen_size.1 > 0 {
+            Some(NormalizedRect {
+                x1: b.x as f64 / screen_size.0 as f64,
+                y1: b.y as f64 / screen_size.1 as f64,
+                x2: (b.x + b.width) as f64 / screen_size.0 as f64,
+                y2: (b.y + b.height) as f64 / screen_size.1 as f64,
+            })
+        } else {
+            None
+        }
+    });
+
+    // States
+    let is_enabled = elem.CurrentIsEnabled().map(|b| b.as_bool()).unwrap_or(true);
+    let is_offscreen = elem
+        .CurrentIsOffscreen()
+        .map(|b| b.as_bool())
+        .unwrap_or(false);
+    let has_focus = elem
+        .CurrentHasKeyboardFocus()
+        .map(|b| b.as_bool())
+        .unwrap_or(false);
+
+    let toggle_state: Option<i32> = elem
+        .GetCurrentPatternAs::<IUIAutomationTogglePattern>(UIA_TogglePatternId)
+        .ok()
+        .and_then(|p| p.CurrentToggleState().ok())
+        .map(|s| s.0);
+
+    let is_selected = elem
+        .GetCurrentPatternAs::<IUIAutomationSelectionItemPattern>(UIA_SelectionItemPatternId)
+        .ok()
+        .and_then(|p| p.CurrentIsSelected().ok())
+        .map(|b| b.as_bool())
+        .unwrap_or(false);
+
+    let expand_state: Option<i32> = elem
+        .GetCurrentPatternAs::<IUIAutomationExpandCollapsePattern>(UIA_ExpandCollapsePatternId)
+        .ok()
+        .and_then(|p| p.CurrentExpandCollapseState().ok())
+        .map(|s| s.0);
+
+    let mut states = mapping::map_states(
+        is_enabled,
+        is_offscreen,
+        has_focus,
+        toggle_state,
+        is_selected,
+        expand_state,
+    );
+
+    if matches!(role, Role::TextField | Role::TextArea) {
+        states.editable = true;
+    }
+
+    if opts.visible_only && !states.visible {
+        return;
+    }
+
+    let my_id = *next_id;
+    *next_id += 1;
+
+    // Value
+    let value: Option<String> = get_element_value(elem, role);
+
+    // Actions from patterns
+    let has_invoke = elem
+        .GetCurrentPatternAs::<IUIAutomationInvokePattern>(UIA_InvokePatternId)
+        .is_ok();
+    let has_toggle = toggle_state.is_some();
+    let has_expand = expand_state.is_some();
+    let has_selection_item = elem
+        .GetCurrentPatternAs::<IUIAutomationSelectionItemPattern>(UIA_SelectionItemPatternId)
+        .is_ok();
+    let has_value = elem
+        .GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId)
+        .is_ok();
+    let has_range_value = elem
+        .GetCurrentPatternAs::<IUIAutomationRangeValuePattern>(UIA_RangeValuePatternId)
+        .is_ok();
+    let has_scroll_item = elem
+        .GetCurrentPatternAs::<IUIAutomationScrollItemPattern>(UIA_ScrollItemPatternId)
+        .is_ok();
+
+    let actions = mapping::actions_from_patterns(
+        has_invoke,
+        has_toggle,
+        has_expand,
+        has_selection_item,
+        has_value,
+        has_range_value,
+        has_scroll_item,
+    );
+
+    // Raw data
+    let raw: Option<RawPlatformData> = if opts.include_raw {
+        let automation_id = elem
+            .CurrentAutomationId()
+            .ok()
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty());
+        let class_name = elem
+            .CurrentClassName()
+            .ok()
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty());
+        Some(RawPlatformData::Windows {
+            control_type_id: control_type,
+            automation_id,
+            class_name,
+        })
+    } else {
+        None
+    };
+
+    let node = Node {
+        id: my_id,
+        role,
+        name,
+        value,
+        description: help_text,
+        bounds,
+        bounds_normalized,
+        actions,
+        states,
+        children: vec![],
+        parent: parent_id,
+        depth,
+        app_name: Some(app_name.to_string()),
+        raw,
+    };
+
+    let node_idx = nodes.len();
+    nodes.push(node);
+    elements.push(elem.clone());
+
+    // Traverse children using the content view walker
+    let mut child_ids: Vec<NodeId> = Vec::new();
+
+    if let Ok(first_child) = walker.GetFirstChildElement(elem) {
+        let mut current = first_child;
+        loop {
+            if *next_id >= opts.max_elements {
+                break;
+            }
+
+            let child_id = *next_id;
+            let prev_count = nodes.len();
+
+            traverse_element(
+                walker,
+                &current,
+                Some(my_id),
+                depth + 1,
+                app_name,
+                opts,
+                screen_size,
+                nodes,
+                elements,
+                next_id,
+            );
+
+            if nodes.len() > prev_count {
+                child_ids.push(child_id);
+            }
+
+            match walker.GetNextSiblingElement(&current) {
+                Ok(next) => current = next,
+                Err(_) => break,
+            }
+        }
+    }
+
+    nodes[node_idx].children = child_ids;
+}
+
+unsafe fn get_element_value(elem: &IUIAutomationElement, role: Role) -> Option<String> {
+    match role {
+        Role::TextField | Role::TextArea | Role::StaticText | Role::Heading | Role::Link => elem
+            .GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId)
+            .ok()
+            .and_then(|p| p.CurrentValue().ok())
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty()),
+        Role::Slider | Role::ProgressBar | Role::ScrollBar => elem
+            .GetCurrentPatternAs::<IUIAutomationRangeValuePattern>(UIA_RangeValuePatternId)
+            .ok()
+            .and_then(|p| p.CurrentValue().ok())
+            .map(|v| v.to_string()),
+        _ => None,
+    }
+}
+
+fn get_screen_size() -> (u32, u32) {
+    use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
+    unsafe {
+        let w = GetSystemMetrics(SM_CXSCREEN);
+        let h = GetSystemMetrics(SM_CYSCREEN);
+        if w > 0 && h > 0 {
+            (w as u32, h as u32)
+        } else {
+            (1920, 1080)
+        }
     }
 }

--- a/xa11y/Cargo.toml
+++ b/xa11y/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "xa11y"
+description = "Cross-platform accessibility client library"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+xa11y-core.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+xa11y-macos = { path = "../xa11y-macos" }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+xa11y-windows = { path = "../xa11y-windows" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+xa11y-linux = { path = "../xa11y-linux" }
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -1,0 +1,52 @@
+//! xa11y — Cross-Platform Accessibility Client Library
+//!
+//! Provides a unified API over platform-specific accessibility APIs,
+//! letting consumers query UI structure and perform actions without
+//! writing platform-specific code.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use xa11y::*;
+//!
+//! let provider = create_provider();
+//! let status = provider.check_permissions().unwrap();
+//! let tree = provider.get_app_tree(
+//!     &AppTarget::ByName("Safari".into()),
+//!     &QueryOptions::default(),
+//! ).unwrap();
+//!
+//! let buttons = tree.find_by_role(Role::Button);
+//! ```
+
+// Re-export all core types
+pub use xa11y_core::*;
+
+/// Create a platform-appropriate accessibility provider.
+///
+/// Returns a boxed `Provider` implementation for the current platform.
+///
+/// # Panics
+///
+/// Panics on unsupported platforms.
+pub fn create_provider() -> Box<dyn Provider> {
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(xa11y_macos::create_provider())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Box::new(xa11y_windows::create_provider())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        Box::new(xa11y_linux::create_provider())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        panic!("xa11y: unsupported platform")
+    }
+}

--- a/xa11y/tests/test_integration.rs
+++ b/xa11y/tests/test_integration.rs
@@ -1,0 +1,220 @@
+//! Integration tests for the xa11y umbrella crate.
+//!
+//! These tests verify that the umbrella crate correctly re-exports core types
+//! and that the platform provider can be instantiated on each OS.
+
+use xa11y::*;
+
+#[test]
+fn test_create_provider() {
+    // Should not panic — provider creation should work on all supported platforms
+    let _provider = create_provider();
+}
+
+#[test]
+fn test_provider_check_permissions() {
+    let provider = create_provider();
+    // The provider should return a result (either Granted or Denied),
+    // or a "not yet implemented" error — but not panic.
+    let result = provider.check_permissions();
+    // We don't assert success since CI may not have accessibility permissions,
+    // but it should not panic.
+    match result {
+        Ok(PermissionStatus::Granted) => {
+            // Great, we have permissions
+        }
+        Ok(PermissionStatus::Denied { instructions }) => {
+            // Expected in CI environments
+            assert!(!instructions.is_empty());
+        }
+        Err(_) => {
+            // "not yet implemented" is acceptable during early development
+        }
+    }
+}
+
+#[test]
+fn test_provider_list_apps() {
+    let provider = create_provider();
+    // list_apps should either succeed or return a "not implemented" error
+    match provider.list_apps() {
+        Ok(apps) => {
+            // If it succeeds, each app should have a name and pid
+            for app in &apps {
+                assert!(!app.name.is_empty());
+                assert!(app.pid > 0);
+            }
+        }
+        Err(_) => {
+            // "not yet implemented" is acceptable
+        }
+    }
+}
+
+#[test]
+fn test_core_types_accessible() {
+    // Verify core types are re-exported through the umbrella crate
+    let _role = Role::Button;
+    let _action = Action::Press;
+    let _kind = EventKind::FocusChanged;
+    let _state = ElementState::Visible;
+    let _flag = StateFlag::Focused;
+
+    let target = AppTarget::ByName("Test".into());
+    match &target {
+        AppTarget::ByName(name) => assert_eq!(name, "Test"),
+        _ => panic!("wrong variant"),
+    }
+
+    let opts = QueryOptions::default();
+    assert_eq!(opts.max_depth, u32::MAX);
+}
+
+#[test]
+fn test_tree_operations_through_umbrella() {
+    // Build a tree using types from the umbrella crate
+    let nodes = vec![
+        Node {
+            id: 0,
+            role: Role::Window,
+            name: Some("Test Window".into()),
+            value: None,
+            description: None,
+            bounds: Some(Rect {
+                x: 0,
+                y: 0,
+                width: 800,
+                height: 600,
+            }),
+            bounds_normalized: Some(NormalizedRect {
+                x1: 0.0,
+                y1: 0.0,
+                x2: 0.417,
+                y2: 0.556,
+            }),
+            actions: vec![],
+            states: StateSet::default(),
+            children: vec![1, 2],
+            parent: None,
+            depth: 0,
+            app_name: Some("Test".into()),
+            raw: None,
+        },
+        Node {
+            id: 1,
+            role: Role::Button,
+            name: Some("OK".into()),
+            value: None,
+            description: None,
+            bounds: None,
+            bounds_normalized: None,
+            actions: vec![Action::Press, Action::Focus],
+            states: StateSet {
+                enabled: true,
+                visible: true,
+                focused: true,
+                ..StateSet::default()
+            },
+            children: vec![],
+            parent: Some(0),
+            depth: 1,
+            app_name: Some("Test".into()),
+            raw: None,
+        },
+        Node {
+            id: 2,
+            role: Role::Button,
+            name: Some("Cancel".into()),
+            value: None,
+            description: None,
+            bounds: None,
+            bounds_normalized: None,
+            actions: vec![Action::Press],
+            states: StateSet::default(),
+            children: vec![],
+            parent: Some(0),
+            depth: 1,
+            app_name: Some("Test".into()),
+            raw: None,
+        },
+    ];
+
+    let tree = Tree::new(
+        "Test".into(),
+        42,
+        (1920, 1080),
+        nodes,
+        QueryOptions::default(),
+    );
+
+    assert_eq!(tree.len(), 3);
+    assert_eq!(tree.find_by_role(Role::Button).len(), 2);
+    assert_eq!(tree.find_by_name("ok").len(), 1);
+    assert_eq!(tree.query("button").unwrap().len(), 2);
+    assert_eq!(tree.query(r#"button[name="OK"]"#).unwrap().len(), 1);
+    assert_eq!(tree.children(0).len(), 2);
+}
+
+#[test]
+fn test_tree_json_serialization() {
+    let nodes = vec![Node {
+        id: 0,
+        role: Role::Window,
+        name: Some("Test".into()),
+        value: None,
+        description: None,
+        bounds: None,
+        bounds_normalized: None,
+        actions: vec![],
+        states: StateSet::default(),
+        children: vec![],
+        parent: None,
+        depth: 0,
+        app_name: None,
+        raw: None,
+    }];
+
+    let tree = Tree::new(
+        "App".into(),
+        1,
+        (1920, 1080),
+        nodes,
+        QueryOptions::default(),
+    );
+    let json = serde_json::to_string_pretty(&tree).unwrap();
+
+    // Should contain expected fields
+    assert!(json.contains("\"app_name\""));
+    assert!(json.contains("\"Test\""));
+    assert!(json.contains("\"Window\""));
+
+    // Should deserialize back
+    let mut restored: Tree = serde_json::from_str(&json).unwrap();
+    restored.rebuild_index();
+    assert_eq!(restored.len(), 1);
+    assert_eq!(restored.root().unwrap().role, Role::Window);
+}
+
+#[test]
+fn test_event_system_types() {
+    let filter = EventFilter::new(
+        &[EventKind::FocusChanged, EventKind::ValueChanged],
+        Some("button"),
+    );
+    assert_eq!(filter.kinds.len(), 2);
+    assert_eq!(filter.selector.as_deref(), Some("button"));
+
+    let event = Event {
+        kind: EventKind::FocusChanged,
+        app: AppInfo {
+            name: "Test".into(),
+            pid: 1,
+            bundle_id: None,
+        },
+        target: None,
+        state_flag: None,
+        state_value: None,
+        timestamp: std::time::Duration::from_secs(1),
+    };
+    assert!(filter.matches(&event));
+}


### PR DESCRIPTION
Implement the Rust workspace from the design doc with:
- xa11y-core: All core types (Role, Action, Node, Tree, StateSet,
  Selector, Event system, Provider/EventProvider traits)
- xa11y-macos: macOS backend stub (AXUIElement)
- xa11y-windows: Windows backend stub (UI Automation)
- xa11y-linux: Linux backend stub (AT-SPI2 via D-Bus)
- xa11y: Umbrella crate with create_provider() auto-selecting platform

Add comprehensive integration tests (48 tests):
- Tree structure operations (children, subtree, find_by_role/name)
- CSS-like selector queries (role, attribute exact/contains/startsWith)
- JSON serialization roundtrips for all core types
- Event filter matching
- Role enum selector string roundtrips
- Provider instantiation on each platform

Add GitHub Actions CI workflow running on all 3 OS targets:
- Core tests on ubuntu/macos/windows matrix
- Per-platform integration tests with system deps
- Lint job (rustfmt + clippy)

https://claude.ai/code/session_017xJmKJxFB5P9Xiwm4A67M3