### PR TITLE
fix: remove invalid [workspace] section from release.toml

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,3 @@
-[workspace]
 allow-branch = ["main"]
 consolidate-commits = true
 shared-version = true


### PR DESCRIPTION
cargo-release doesn't support [workspace] as a TOML section header in release.toml. The fields should be at the top level.

https://claude.ai/code/session_01S3fwHVEawA2tcrnt567SMr