### PR TITLE
Fix invalid --document-private-items=false flag in cargo doc command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm run build
 
       - name: Generate Rust API docs
-        run: cargo doc --workspace --no-deps --document-private-items=false
+        run: cargo doc --workspace --no-deps
         env:
           RUSTDOCFLAGS: --default-theme ayu
 


### PR DESCRIPTION
The flag is boolean and doesn't accept a value; omitting it is the
correct way to exclude private items from rustdoc output.

https://claude.ai/code/session_01BBrvJPTA2KP7hPmtzC4AHn