### PR TITLE
Move children/parent navigation from Tree to Node

### DIFF
--- a/xa11y-python/Cargo.lock
+++ b/xa11y-python/Cargo.lock
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "xa11y-core",
  "xa11y-linux",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-linux"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "xa11y-core",
  "zbus",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-macos"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "core-foundation",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-windows"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "windows",
  "xa11y-core",

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -87,8 +87,8 @@ class AppInfo:
 class Node:
     """A single element in the accessibility tree.
 
-    Nodes are immutable snapshots. Tree navigation (children, parent)
-    requires going through the :class:`Tree` that produced this node.
+    Nodes are immutable snapshots that form a navigable graph —
+    use :attr:`children` and :attr:`parent` to traverse.
     """
 
     @property
@@ -121,6 +121,12 @@ class Node:
     @property
     def actions(self) -> list[str]:
         """List of supported action names."""
+    @property
+    def children(self) -> list[Node]:
+        """Direct children of this node."""
+    @property
+    def parent(self) -> Node | None:
+        """Parent node, or ``None`` for the root."""
     @property
     def bounds(self) -> Rect | None:
         """Bounding rectangle in screen coordinates."""
@@ -190,10 +196,6 @@ class Tree:
     @property
     def root(self) -> Node:
         """The root node of the tree."""
-    def children(self, node: Node) -> list[Node]:
-        """Get direct children of a node."""
-    def parent(self, node: Node) -> Node | None:
-        """Get the parent of a node, or ``None`` for the root."""
     def query(self, selector: str) -> list[Node]:
         """Find all nodes matching a CSS-like selector string."""
     def find_by_role(self, role: str) -> list[Node]:

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -217,6 +217,7 @@ fn make_py_node(py: Python<'_>, n: &xa11y::Node) -> PyResult<Py<Node>> {
             children_indices: n.children_indices.clone(),
             parent_idx: n.parent_index,
             _index: n.index,
+            _all_nodes: None,
         },
     )
 }
@@ -302,11 +303,8 @@ impl AppInfo {
 
 // ── Node ────────────────────────────────────────────────────────────────────
 
-/// A node in the accessibility tree. Nodes are returned from Tree queries
-/// and carry their own data + indices for tree navigation.
-///
-/// Tree navigation (children, parent) requires going through the Tree
-/// that produced this node.
+/// A node in the accessibility tree. Nodes form a navigable graph —
+/// use `node.children` and `node.parent` to traverse.
 #[pyclass]
 struct Node {
     #[pyo3(get)]
@@ -356,15 +354,39 @@ struct Node {
     #[pyo3(get)]
     busy: bool,
 
-    // Indices for tree navigation (resolved via Tree)
     children_indices: Vec<u32>,
     parent_idx: Option<u32>,
-
     _index: u32,
+
+    /// Shared reference to all nodes in the tree (for graph navigation).
+    _all_nodes: Option<Py<PyList>>,
 }
 
 #[pymethods]
 impl Node {
+    #[getter]
+    fn children(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
+        let Some(ref all) = self._all_nodes else {
+            return Ok(vec![]);
+        };
+        let list = all.bind(py);
+        self.children_indices
+            .iter()
+            .map(|&idx| list.get_item(idx as usize).map(|item| item.unbind()))
+            .collect()
+    }
+
+    #[getter]
+    fn parent(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        let Some(ref all) = self._all_nodes else {
+            return Ok(None);
+        };
+        match self.parent_idx {
+            Some(idx) => Ok(Some(all.bind(py).get_item(idx as usize)?.unbind())),
+            None => Ok(None),
+        }
+    }
+
     #[getter]
     fn bounds(&self) -> Option<Rect> {
         self.bounds_data.map(|(x, y, w, h)| Rect {
@@ -447,20 +469,6 @@ impl Tree {
             .first()
             .map(|n| n.clone_ref(py))
             .ok_or_else(|| PyValueError::new_err("Tree has no nodes"))
-    }
-
-    /// Get children of a node.
-    fn children(&self, py: Python<'_>, node: &Node) -> Vec<Py<Node>> {
-        node.children_indices
-            .iter()
-            .filter_map(|&idx| self.py_nodes.get(idx as usize).map(|n| n.clone_ref(py)))
-            .collect()
-    }
-
-    /// Get the parent of a node.
-    fn parent(&self, py: Python<'_>, node: &Node) -> Option<Py<Node>> {
-        node.parent_idx
-            .and_then(|idx| self.py_nodes.get(idx as usize).map(|n| n.clone_ref(py)))
     }
 
     /// Query nodes matching a CSS-like selector string.
@@ -759,6 +767,12 @@ fn convert_tree(
             .get(i as u32)
             .expect("index valid in range 0..len");
         py_nodes.push(make_py_node(py, n)?);
+    }
+
+    // Build a shared PyList so every Node can navigate to children/parent directly.
+    let all_nodes_list: Py<PyList> = PyList::new(py, &py_nodes)?.unbind();
+    for py_node in &py_nodes {
+        py_node.borrow_mut(py)._all_nodes = Some(all_nodes_list.clone_ref(py));
     }
 
     Py::new(

--- a/xa11y-python/tests/test_node.py
+++ b/xa11y-python/tests/test_node.py
@@ -43,7 +43,7 @@ def test_node_description_none(tree):
 
 def test_node_depth(tree):
     assert tree.root.depth == 0
-    window = tree.children(tree.root)[0]
+    window = tree.root.children[0]
     assert window.depth == 1
     buttons = tree.query("button")
     assert all(b.depth == 3 for b in buttons)
@@ -106,7 +106,7 @@ def test_visible_false(tree):
 
 
 def test_focused(tree):
-    window = tree.children(tree.root)[0]
+    window = tree.root.children[0]
     assert window.focused is True
     assert tree.root.focused is False
 
@@ -285,7 +285,7 @@ def test_node_repr_hidden(tree):
 
 
 def test_node_repr_focused(tree):
-    window = tree.children(tree.root)[0]
+    window = tree.root.children[0]
     r = repr(window)
     assert "focused=True" in r
 
@@ -297,7 +297,7 @@ def test_node_str_is_repr(tree):
 def test_node_len_children_count(tree):
     root = tree.root
     assert len(root) == 1  # one child (window)
-    window = tree.children(root)[0]
+    window = root.children[0]
     assert len(window) == 2  # toolbar + group
     back = next(b for b in tree.query("button") if b.name == "Back")
     assert len(back) == 0  # leaf

--- a/xa11y-python/tests/test_tree.py
+++ b/xa11y-python/tests/test_tree.py
@@ -31,19 +31,19 @@ def test_tree_root_depth_zero(tree):
     assert tree.root.depth == 0
 
 
-# ── Navigation ───────────────────────────────────────────────────────────────
+# ── Navigation (via Node.children / Node.parent) ────────────────────────────
 
 
 def test_children_of_root(tree):
-    children = tree.children(tree.root)
+    children = tree.root.children
     assert len(children) == 1
     assert children[0].role == "window"
     assert children[0].name == "Main Window"
 
 
 def test_children_of_window(tree):
-    window = tree.children(tree.root)[0]
-    children = tree.children(window)
+    window = tree.root.children[0]
+    children = window.children
     assert len(children) == 2
     assert children[0].role == "toolbar"
     assert children[1].role == "group"
@@ -52,26 +52,36 @@ def test_children_of_window(tree):
 def test_children_of_leaf(tree):
     buttons = tree.query("button")
     back = next(b for b in buttons if b.name == "Back")
-    assert tree.children(back) == []
+    assert back.children == []
 
 
 def test_parent_of_root_is_none(tree):
-    assert tree.parent(tree.root) is None
+    assert tree.root.parent is None
 
 
 def test_parent_of_button(tree):
     buttons = tree.query("button")
     back = next(b for b in buttons if b.name == "Back")
-    parent = tree.parent(back)
+    parent = back.parent
     assert parent is not None
     assert parent.role == "toolbar"
     assert parent.name == "Navigation"
 
 
 def test_parent_child_roundtrip(tree):
-    window = tree.children(tree.root)[0]
-    toolbar = tree.children(window)[0]
-    assert tree.parent(toolbar).name == "Main Window"
+    window = tree.root.children[0]
+    toolbar = window.children[0]
+    assert toolbar.parent.name == "Main Window"
+
+
+def test_deep_graph_traversal(tree):
+    """Verify node.children[i].children[j] style navigation works."""
+    root = tree.root
+    toolbar = root.children[0].children[0]
+    assert toolbar.role == "toolbar"
+    back = toolbar.children[0]
+    assert back.name == "Back"
+    assert back.parent.parent.role == "window"
 
 
 # ── Query ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Python bindings now support graph-style traversal: `node.children[0].children` instead of `tree.children(node)`
- Added `children` and `parent` as properties on `Node`, backed by a shared `PyList` of all tree nodes
- Removed `children()` and `parent()` methods from `Tree` (no longer needed)
- Updated type stubs and all tests

## Test plan

- [x] All 201 Python unit tests pass
- [x] Rust compilation clean with `-Dwarnings`
- [x] New `test_deep_graph_traversal` test verifies `node.children[0].children[0]` style navigation

https://claude.ai/code/session_01G7UoWX8mV3x5pJjY5nxSFE