### PR TITLE
Fix Python docs formatting and sync tab state

### DIFF
--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -224,13 +224,18 @@ def _render_function_section(func: ast.FunctionDef, *, prefix: str = "xa11y") ->
     return "\n".join(lines).rstrip()
 
 
+def _escape_table_pipe(text: str) -> str:
+    """Escape pipe characters in text destined for a Markdown table cell."""
+    return text.replace("|", "\\|")
+
+
 def _render_properties_table(members: list[ast.FunctionDef]) -> str:
     lines = [
         "| Property | Type | Description |",
         "| -------- | ---- | ----------- |",
     ]
     for m in members:
-        ret = _unparse_annotation(m.returns)
+        ret = _escape_table_pipe(_unparse_annotation(m.returns))
         doc = _first_line_docstring(m)
         lines.append(f"| `{m.name}` | `{ret}` | {doc} |")
     return "\n".join(lines)
@@ -250,11 +255,11 @@ def _render_methods_table(
         ]
     )
     for m in members:
-        sig = _format_signature(m)
+        sig = _escape_table_pipe(_format_signature(m))
         ret = _unparse_annotation(m.returns)
         doc = _first_line_docstring(m)
         # Suppress None return type for __init__ and void actions
-        ret_display = f"`{ret}`" if ret and ret != "None" else ""
+        ret_display = f"`{_escape_table_pipe(ret)}`" if ret and ret != "None" else ""
         lines.append(f"| `{m.name}({sig})` | {ret_display} | {doc} |")
     return "\n".join(lines)
 

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## Installation
 
-<Tabs>
+<Tabs syncKey="lang">
   <TabItem label="Rust">
     Add `xa11y` to your `Cargo.toml`:
 
@@ -29,13 +29,13 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## Platform Setup
 
-<Tabs>
+<Tabs syncKey="platform">
   <TabItem label="macOS">
     Grant accessibility permissions to your terminal app (or IDE) in **System Settings → Privacy & Security → Accessibility**.
 
     xa11y can check this for you:
 
-    <Tabs>
+    <Tabs syncKey="lang">
       <TabItem label="Rust">
         ```rust
         use xa11y::*;
@@ -69,7 +69,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## Reading an Accessibility Tree
 
-<Tabs>
+<Tabs syncKey="lang">
   <TabItem label="Rust">
     ```rust
     use xa11y::*;
@@ -107,7 +107,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 xa11y supports CSS-like selectors to find elements in the tree.
 
-<Tabs>
+<Tabs syncKey="lang">
   <TabItem label="Rust">
     ```rust
     use xa11y::*;
@@ -151,7 +151,7 @@ xa11y supports CSS-like selectors to find elements in the tree.
 
 ## Performing Actions
 
-<Tabs>
+<Tabs syncKey="lang">
   <TabItem label="Rust">
     ```rust
     use xa11y::*;
@@ -191,7 +191,7 @@ xa11y supports CSS-like selectors to find elements in the tree.
 
 ## Listing Applications
 
-<Tabs>
+<Tabs syncKey="lang">
   <TabItem label="Rust">
     ```rust
     use xa11y::*;


### PR DESCRIPTION
## Summary

- **Escape `|` in table cells**: Python union types like `str | None` in generated API docs were breaking Markdown table parsing because `|` is the column delimiter. Added `_escape_table_pipe()` helper to escape pipes in signatures and return types within table rows.
- **Sync tab state across groups**: Added `syncKey="lang"` to all Rust/Python `<Tabs>` and `syncKey="platform"` to the platform `<Tabs>` in quick-start.mdx so selecting a language in one tab group updates all others.

## Test plan

- [ ] Run `python docs/generate_python_api.py` and verify the generated `python.mdx` renders tables correctly (pipes in union types like `str | None` should appear as inline code, not break columns)
- [ ] Open the quick-start page and verify selecting Python in one tab group switches all language tabs to Python

https://claude.ai/code/session_01E5kJuEQizWfBT7k6Kof8fF