### PR TITLE
Improve wait_for abstraction with new states and closure escape hatch

### DIFF
--- a/xa11y-core/src/event.rs
+++ b/xa11y-core/src/event.rs
@@ -144,7 +144,10 @@ impl EventFilter {
 }
 
 /// Desired element state for wait_for operations.
-/// Directly mirrors Playwright's `locator.waitFor({state})`.
+///
+/// Basic variants (`Attached`, `Detached`, `Visible`, `Hidden`, `Enabled`,
+/// `Disabled`, `Focused`, `Unfocused`) cover common cases. For arbitrary
+/// conditions, use [`Locator::wait_until`] with a closure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ElementState {
     /// Wait until an element matching the selector exists in the tree.
@@ -157,4 +160,34 @@ pub enum ElementState {
     Hidden,
     /// Wait until a matching element is enabled.
     Enabled,
+    /// Wait until a matching element is disabled (exists but not enabled).
+    Disabled,
+    /// Wait until a matching element has keyboard focus.
+    Focused,
+    /// Wait until a matching element does not have keyboard focus.
+    Unfocused,
+}
+
+impl ElementState {
+    /// Evaluate whether the condition is met for the given node.
+    ///
+    /// `node` is `None` when no element matched the selector.
+    pub fn is_met(self, node: Option<&Node>) -> bool {
+        match self {
+            Self::Attached => node.is_some(),
+            Self::Detached => node.is_none(),
+            Self::Visible => node.is_some_and(|n| n.states.visible),
+            Self::Hidden => node.is_none() || node.is_some_and(|n| !n.states.visible),
+            Self::Enabled => node.is_some_and(|n| n.states.enabled),
+            Self::Disabled => node.is_some_and(|n| !n.states.enabled),
+            Self::Focused => node.is_some_and(|n| n.states.focused),
+            Self::Unfocused => node.is_some_and(|n| !n.states.focused),
+        }
+    }
+
+    /// Whether this state represents an "absent" condition where the node may
+    /// not exist in the tree when the condition is met.
+    pub fn is_absence_state(self) -> bool {
+        matches!(self, Self::Detached | Self::Hidden)
+    }
 }

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -320,19 +320,68 @@ impl<'p> Locator<'p> {
         self.wait_for_state(ElementState::Enabled, timeout)
     }
 
+    /// Wait until the element is disabled (exists but not enabled).
+    pub fn wait_disabled(&self, timeout: Duration) -> Result<Node> {
+        self.wait_for_state(ElementState::Disabled, timeout)
+    }
+
     /// Wait until the element is hidden or removed.
     pub fn wait_hidden(&self, timeout: Duration) -> Result<Node> {
         self.wait_for_state(ElementState::Hidden, timeout)
     }
 
-    fn wait_for_state(&self, state: ElementState, timeout: Duration) -> Result<Node> {
-        // Try to downcast to EventProvider for native wait support.
-        // Since we can't downcast trait objects, fall back to polling.
-        self.poll_for_state(state, timeout)
+    /// Wait until the element has keyboard focus.
+    pub fn wait_focused(&self, timeout: Duration) -> Result<Node> {
+        self.wait_for_state(ElementState::Focused, timeout)
     }
 
-    /// Poll-based wait: repeatedly snapshot + check until state is reached or timeout.
-    fn poll_for_state(&self, state: ElementState, timeout: Duration) -> Result<Node> {
+    /// Wait until the element does not have keyboard focus.
+    pub fn wait_unfocused(&self, timeout: Duration) -> Result<Node> {
+        self.wait_for_state(ElementState::Unfocused, timeout)
+    }
+
+    /// Wait for an [`ElementState`] condition to be met.
+    pub fn wait_for_state(&self, state: ElementState, timeout: Duration) -> Result<Node> {
+        self.poll_until(|node| state.is_met(node), state.is_absence_state(), timeout)
+    }
+
+    /// Wait until an arbitrary predicate is satisfied, polling with fresh
+    /// snapshots at ~100 ms intervals.
+    ///
+    /// The predicate receives `Some(&Node)` when the selector matches, or
+    /// `None` when no element matches. Return `true` to stop waiting.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use xa11y_core::*;
+    /// # use std::time::Duration;
+    /// # fn example(loc: &Locator) -> Result<()> {
+    /// // Wait until the element's value becomes "Done":
+    /// let node = loc.wait_until(
+    ///     |n| n.is_some_and(|n| n.value.as_deref() == Some("Done")),
+    ///     Duration::from_secs(5),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn wait_until(
+        &self,
+        predicate: impl Fn(Option<&Node>) -> bool,
+        timeout: Duration,
+    ) -> Result<Node> {
+        self.poll_until(&predicate, false, timeout)
+    }
+
+    /// Core polling loop shared by `wait_for_state` and `wait_until`.
+    ///
+    /// `allow_absent`: when true, the condition can be satisfied even when no
+    /// node matches (used for Detached/Hidden states).
+    fn poll_until(
+        &self,
+        predicate: impl Fn(Option<&Node>) -> bool,
+        allow_absent: bool,
+        timeout: Duration,
+    ) -> Result<Node> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -347,40 +396,11 @@ impl<'p> Locator<'p> {
             let idx = self.nth.unwrap_or(0);
             let node = matches.as_ref().and_then(|m| m.get(idx).copied());
 
-            let condition_met = match state {
-                ElementState::Attached => node.is_some(),
-                ElementState::Detached => node.is_none(),
-                ElementState::Visible => node.is_some_and(|n| n.states.visible),
-                ElementState::Hidden => node.is_none() || node.is_some_and(|n| !n.states.visible),
-                ElementState::Enabled => node.is_some_and(|n| n.states.enabled),
-            };
-
-            if condition_met {
-                return match state {
-                    ElementState::Detached | ElementState::Hidden => {
-                        // For "gone" states, return the last known node or a synthetic one
-                        Ok(node.cloned().unwrap_or_else(|| Node {
-                            role: Role::Unknown,
-                            name: None,
-                            value: None,
-                            description: None,
-                            bounds: None,
-                            bounds_normalized: None,
-                            actions: vec![],
-                            states: StateSet::default(),
-                            numeric_value: None,
-                            min_value: None,
-                            max_value: None,
-                            stable_id: None,
-                            raw: None,
-                            index: 0,
-                            children_indices: vec![],
-                            parent_index: None,
-                        }))
-                    }
-                    _ => Ok(node
-                        .expect("node exists for attached/visible/enabled")
-                        .clone()),
+            if predicate(node) {
+                return if allow_absent {
+                    Ok(node.cloned().unwrap_or_else(Node::synthetic_empty))
+                } else {
+                    Ok(node.expect("predicate requires node to exist").clone())
                 };
             }
 

--- a/xa11y-core/src/node.rs
+++ b/xa11y-core/src/node.rs
@@ -74,6 +74,31 @@ pub struct Node {
     pub parent_index: Option<NodeIndex>,
 }
 
+impl Node {
+    /// Create a synthetic empty node, used as a placeholder when a wait
+    /// condition is satisfied by the *absence* of a node (e.g. Detached/Hidden).
+    pub fn synthetic_empty() -> Self {
+        Self {
+            role: Role::Unknown,
+            name: None,
+            value: None,
+            description: None,
+            bounds: None,
+            bounds_normalized: None,
+            actions: vec![],
+            states: StateSet::default(),
+            numeric_value: None,
+            min_value: None,
+            max_value: None,
+            stable_id: None,
+            raw: None,
+            index: 0,
+            children_indices: vec![],
+            parent_index: None,
+        }
+    }
+}
+
 /// Boolean state flags for a node.
 ///
 /// **Semantics for non-applicable states:** When a state doesn't apply to an

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1289,33 +1289,8 @@ impl EventProvider for LinuxProvider {
             let matches = tree.query(selector).ok();
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
-            let condition_met = match state {
-                ElementState::Attached => node.is_some(),
-                ElementState::Detached => node.is_none(),
-                ElementState::Visible => node.is_some_and(|n| n.states.visible),
-                ElementState::Hidden => node.is_none() || node.is_some_and(|n| !n.states.visible),
-                ElementState::Enabled => node.is_some_and(|n| n.states.enabled),
-            };
-
-            if condition_met {
-                return Ok(node.cloned().unwrap_or_else(|| Node {
-                    role: Role::Unknown,
-                    name: None,
-                    value: None,
-                    description: None,
-                    bounds: None,
-                    bounds_normalized: None,
-                    actions: vec![],
-                    states: StateSet::default(),
-                    numeric_value: None,
-                    min_value: None,
-                    max_value: None,
-                    stable_id: None,
-                    raw: None,
-                    index: 0,
-                    children_indices: vec![],
-                    parent_index: None,
-                }));
+            if state.is_met(node) {
+                return Ok(node.cloned().unwrap_or_else(Node::synthetic_empty));
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1627,33 +1627,8 @@ impl EventProvider for MacOSProvider {
             let matches = tree.query(selector).ok();
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
-            let condition_met = match state {
-                ElementState::Attached => node.is_some(),
-                ElementState::Detached => node.is_none(),
-                ElementState::Visible => node.is_some_and(|n| n.states.visible),
-                ElementState::Hidden => node.is_none() || node.is_some_and(|n| !n.states.visible),
-                ElementState::Enabled => node.is_some_and(|n| n.states.enabled),
-            };
-
-            if condition_met {
-                return Ok(node.cloned().unwrap_or_else(|| Node {
-                    role: Role::Unknown,
-                    name: None,
-                    value: None,
-                    description: None,
-                    bounds: None,
-                    bounds_normalized: None,
-                    actions: vec![],
-                    states: StateSet::default(),
-                    numeric_value: None,
-                    min_value: None,
-                    max_value: None,
-                    stable_id: None,
-                    raw: None,
-                    index: 0,
-                    children_indices: vec![],
-                    parent_index: None,
-                }));
+            if state.is_met(node) {
+                return Ok(node.cloned().unwrap_or_else(Node::synthetic_empty));
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -1210,13 +1210,12 @@ impl Locator {
                 return Err(to_py_err(xa11y::Error::Timeout { elapsed }));
             }
 
-            let tree_result = self.provider.get_app_tree(&self.target, &self.opts);
-            let node = tree_result.ok().and_then(|tree| {
-                tree.query(&self.selector).ok().and_then(|matches| {
-                    let idx = self.nth.unwrap_or(0);
-                    matches.get(idx).cloned()
-                })
-            });
+            let node: Option<xa11y::Node> = (|| {
+                let tree = self.provider.get_app_tree(&self.target, &self.opts).ok()?;
+                let matches = tree.query(&self.selector).ok()?;
+                let idx = self.nth.unwrap_or(0);
+                matches.get(idx).copied().cloned()
+            })();
 
             let met = Python::with_gil(|py| -> PyResult<bool> {
                 let arg: PyObject = match node.as_ref() {

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -1118,6 +1118,35 @@ impl Locator {
         self.poll_state(WaitState::Hidden, Duration::from_secs_f64(timeout))
     }
 
+    #[pyo3(signature = (timeout=5.0))]
+    fn wait_disabled(&self, timeout: f64) -> PyResult<()> {
+        self.poll_state(WaitState::Disabled, Duration::from_secs_f64(timeout))
+    }
+
+    #[pyo3(signature = (timeout=5.0))]
+    fn wait_focused(&self, timeout: f64) -> PyResult<()> {
+        self.poll_state(WaitState::Focused, Duration::from_secs_f64(timeout))
+    }
+
+    #[pyo3(signature = (timeout=5.0))]
+    fn wait_unfocused(&self, timeout: f64) -> PyResult<()> {
+        self.poll_state(WaitState::Unfocused, Duration::from_secs_f64(timeout))
+    }
+
+    /// Wait until an arbitrary predicate is satisfied.
+    ///
+    /// The callback receives a dict with the node's properties when the element
+    /// exists, or ``None`` when no element matches the selector. Return ``True``
+    /// to stop waiting.
+    ///
+    /// Example::
+    ///
+    ///     locator.wait_until(lambda n: n is not None and n["value"] == "Done")
+    #[pyo3(signature = (predicate, timeout=5.0))]
+    fn wait_until(&self, predicate: PyObject, timeout: f64) -> PyResult<()> {
+        self.poll_predicate(predicate, Duration::from_secs_f64(timeout))
+    }
+
     fn __repr__(&self) -> String {
         format!("Locator(selector='{}')", self.selector)
     }
@@ -1129,6 +1158,9 @@ enum WaitState {
     Visible,
     Hidden,
     Enabled,
+    Disabled,
+    Focused,
+    Unfocused,
 }
 
 impl Locator {
@@ -1168,6 +1200,41 @@ impl Locator {
             .map_err(to_py_err)
     }
 
+    fn poll_predicate(&self, predicate: PyObject, timeout: Duration) -> PyResult<()> {
+        let start = std::time::Instant::now();
+        let poll_interval = Duration::from_millis(100);
+
+        loop {
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                return Err(to_py_err(xa11y::Error::Timeout { elapsed }));
+            }
+
+            let tree_result = self.provider.get_app_tree(&self.target, &self.opts);
+            let node = tree_result.ok().and_then(|tree| {
+                tree.query(&self.selector).ok().and_then(|matches| {
+                    let idx = self.nth.unwrap_or(0);
+                    matches.get(idx).cloned()
+                })
+            });
+
+            let met = Python::with_gil(|py| -> PyResult<bool> {
+                let arg: PyObject = match node.as_ref() {
+                    Some(n) => make_py_node(py, n)?.into_any(),
+                    None => py.None(),
+                };
+                let result = predicate.call1(py, (arg,))?;
+                result.extract::<bool>(py)
+            })?;
+
+            if met {
+                return Ok(());
+            }
+
+            std::thread::sleep(poll_interval);
+        }
+    }
+
     fn poll_state(&self, state: WaitState, timeout: Duration) -> PyResult<()> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
@@ -1194,6 +1261,9 @@ impl Locator {
                     states.is_none() || states.as_ref().is_some_and(|s| !s.visible)
                 }
                 WaitState::Enabled => states.as_ref().is_some_and(|s| s.enabled),
+                WaitState::Disabled => states.as_ref().is_some_and(|s| !s.enabled),
+                WaitState::Focused => states.as_ref().is_some_and(|s| s.focused),
+                WaitState::Unfocused => states.as_ref().is_some_and(|s| !s.focused),
             };
 
             if met {

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -1508,33 +1508,8 @@ impl EventProvider for WindowsProvider {
             let matches = tree.query(selector).ok();
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
-            let condition_met = match state {
-                ElementState::Attached => node.is_some(),
-                ElementState::Detached => node.is_none(),
-                ElementState::Visible => node.is_some_and(|n| n.states.visible),
-                ElementState::Hidden => node.is_none() || node.is_some_and(|n| !n.states.visible),
-                ElementState::Enabled => node.is_some_and(|n| n.states.enabled),
-            };
-
-            if condition_met {
-                return Ok(node.cloned().unwrap_or_else(|| Node {
-                    role: Role::Unknown,
-                    name: None,
-                    value: None,
-                    description: None,
-                    bounds: None,
-                    bounds_normalized: None,
-                    actions: vec![],
-                    states: StateSet::default(),
-                    numeric_value: None,
-                    min_value: None,
-                    max_value: None,
-                    stable_id: None,
-                    raw: None,
-                    index: 0,
-                    children_indices: vec![],
-                    parent_index: None,
-                }));
+            if state.is_met(node) {
+                return Ok(node.cloned().unwrap_or_else(Node::synthetic_empty));
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -79,7 +79,7 @@ mod tests {
             has_test_app,
             "get_all_apps should include the test app. Apps: {:?}",
             tree.iter()
-                .filter(|n| n.parent_index.map_or(true, |p| p == 0))
+                .filter(|n| n.parent_index.is_none_or(|p| p == 0))
                 .map(|n| &n.name)
                 .collect::<Vec<_>>()
         );


### PR DESCRIPTION
## Summary

- **Add `Disabled`, `Focused`, `Unfocused` variants** to `ElementState`, filling the gaps in the wait API (e.g. wait for disabled was missing despite wait for enabled existing)
- **Add `ElementState::is_met()`** to centralize condition evaluation — eliminates duplicated match blocks across `Locator` and all 3 platform providers (Linux, macOS, Windows)
- **Add `Node::synthetic_empty()`** to deduplicate the placeholder node construction used for absence states
- **Add `Locator::wait_until(closure)`** as an escape hatch for arbitrary predicates that don't fit named states (e.g. waiting for a specific value)
- **Update Python bindings** with `wait_disabled`, `wait_focused`, `wait_unfocused`, and `wait_until` (accepts a Python callable)

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo check --workspace` passes clean
- [x] `cargo test --workspace` passes (including new doctest for `wait_until`)
- [x] `cargo fmt --all -- --check` passes
- [ ] Integration tests via `./run_integ_tests.sh` (CI)

https://claude.ai/code/session_01HdanrnavpWXPgQRA1sEnvn