### PR TITLE
Require context manager for Python Provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ CI runs with `RUSTFLAGS: -Dwarnings`, so all warnings are errors. Before committ
    - Build: `cd xa11y-python && pip install -e .`
    - Check: `cd xa11y-python && cargo check` (compile the Rust extension)
    - Format: `cd xa11y-python && cargo fmt -- --check`
+   - Lint: `cd xa11y-python && ruff check .` (import sorting, style — config in `pyproject.toml`)
    - Tests: `cd xa11y-python && python -m pytest tests/ -v`
 
 Common CI failures:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,17 +43,27 @@ CI runs with `RUSTFLAGS: -Dwarnings`, so all warnings are errors. Before committ
    - Linux: `./run_integ_tests.sh`
    - macOS: `./run_integ_tests_macos.sh`
 5. **No new `#[allow(...)]` without justification** — if you must suppress a warning, add a comment explaining why
+6. **Python bindings** (if touching `xa11y-python/`):
+   - `xa11y-python` is excluded from the Cargo workspace — `cargo check --workspace` does **not** cover it
+   - Build: `cd xa11y-python && pip install -e .`
+   - Check: `cd xa11y-python && cargo check` (compile the Rust extension)
+   - Format: `cd xa11y-python && cargo fmt -- --check`
+   - Tests: `cd xa11y-python && python -m pytest tests/ -v`
 
 Common CI failures:
 - `unused import` / `dead_code` — remove the unused code or add `#[allow(dead_code)]` with a reason
 - Formatting diffs — run `cargo fmt`
 - Platform stubs (`xa11y-macos` on Linux, `xa11y-linux` on macOS) — make sure stub modules compile cleanly on all platforms
+- Python binding failures — `xa11y-python` is **not** in the Cargo workspace, so workspace-wide commands skip it. You must build and test it separately (`cd xa11y-python`)
 
 ## Running Tests
 
 ```bash
 # Unit tests (no infrastructure needed)
 cargo test --workspace
+
+# Python binding tests (xa11y-python is excluded from the workspace)
+cd xa11y-python && pip install -e . && python -m pytest tests/ -v
 
 # Integration tests (Linux — needs Xvfb + D-Bus + AT-SPI2)
 ./run_integ_tests.sh
@@ -85,5 +95,6 @@ cd xa11y-fuzz/fuzz && cargo +nightly fuzz run tree_ops -- -max_total_time=60
 - `xa11y-windows/` — Windows backend (stub)
 - `xa11y/` — Umbrella crate, unit tests, integration tests
 - `xa11y-test-app/` — AccessKit + winit app used as target for integration tests
+- `xa11y-python/` — Python bindings via PyO3/maturin (excluded from Cargo workspace)
 - `xa11y-fuzz/` — Fuzz targets for xa11y-core (tree, selector, serde) and macOS platform fuzzer
 - `docs/DESIGN.md` — Full design specification

--- a/xa11y-python/python/xa11y/__init__.py
+++ b/xa11y-python/python/xa11y/__init__.py
@@ -7,7 +7,7 @@ Quick start:
     ...     print(button.name)
     >>> tree.press("button[name='OK']")
 
-With explicit provider:
+With explicit provider (context manager required):
     >>> with xa11y.connect() as provider:
     ...     tree = provider.app("Safari")
     ...     loc = tree.locator("button[name='Submit']")

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -264,7 +264,12 @@ class Tree:
 class Provider:
     """The main entry point for accessibility operations.
 
-    Implements the context manager protocol.
+    Must be used as a context manager::
+
+        with xa11y.connect() as provider:
+            tree = provider.app("Safari")
+
+    Calling methods outside a ``with`` block raises ``RuntimeError``.
     """
 
     def __init__(self) -> None:

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -788,6 +788,7 @@ fn convert_tree(
 #[pyclass]
 struct Provider {
     inner: Arc<dyn xa11y::Provider>,
+    activated: bool,
 }
 
 #[pymethods]
@@ -797,7 +798,18 @@ impl Provider {
         let provider = xa11y::create_provider().map_err(to_py_err)?;
         Ok(Self {
             inner: Arc::from(provider),
+            activated: false,
         })
+    }
+
+    fn _require_active(&self) -> PyResult<()> {
+        if !self.activated {
+            Err(PyRuntimeError::new_err(
+                "Provider must be used as a context manager: `with xa11y.connect() as provider:`",
+            ))
+        } else {
+            Ok(())
+        }
     }
 
     /// Get an application's accessibility tree.
@@ -813,6 +825,7 @@ impl Provider {
         roles: Option<Vec<String>>,
         include_raw: bool,
     ) -> PyResult<Py<Tree>> {
+        self._require_active()?;
         let target = resolve_app_target(name, pid)?;
         let opts = build_query_options(max_depth, max_elements, visible_only, roles, include_raw);
         let inner = self.inner.clone();
@@ -833,6 +846,7 @@ impl Provider {
         roles: Option<Vec<String>>,
         include_raw: bool,
     ) -> PyResult<Py<Tree>> {
+        self._require_active()?;
         let opts = build_query_options(max_depth, max_elements, visible_only, roles, include_raw);
         let inner = self.inner.clone();
         let rust_tree = py
@@ -844,6 +858,7 @@ impl Provider {
 
     /// List running applications.
     fn list_apps(&self, py: Python<'_>) -> PyResult<Vec<AppInfo>> {
+        self._require_active()?;
         let inner = self.inner.clone();
         let apps = py.allow_threads(|| inner.list_apps()).map_err(to_py_err)?;
         Ok(apps
@@ -858,6 +873,7 @@ impl Provider {
 
     /// Check accessibility permissions. Returns "granted" or raises PermissionDeniedError.
     fn check_permissions(&self, py: Python<'_>) -> PyResult<String> {
+        self._require_active()?;
         let inner = self.inner.clone();
         let status = py
             .allow_threads(|| inner.check_permissions())
@@ -883,6 +899,7 @@ impl Provider {
         roles: Option<Vec<String>>,
         include_raw: bool,
     ) -> PyResult<Locator> {
+        self._require_active()?;
         let target = resolve_app_target(name, pid)?;
         let opts = build_query_options(max_depth, max_elements, visible_only, roles, include_raw);
         Ok(Locator {
@@ -894,17 +911,19 @@ impl Provider {
         })
     }
 
-    fn __enter__(self_: Py<Self>) -> Py<Self> {
+    fn __enter__(mut self_: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        self_.activated = true;
         self_
     }
 
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
     fn __exit__(
-        &self,
+        &mut self,
         _exc_type: Option<&Bound<'_, PyAny>>,
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> bool {
+        self.activated = false;
         false
     }
 
@@ -1295,7 +1314,8 @@ fn app(
     roles: Option<Vec<String>>,
     include_raw: bool,
 ) -> PyResult<Py<Tree>> {
-    let provider = Provider::new()?;
+    let mut provider = Provider::new()?;
+    provider.activated = true;
     provider.app(
         py,
         name,
@@ -1311,14 +1331,16 @@ fn app(
 /// List running applications (convenience — creates provider internally).
 #[pyfunction]
 fn list_apps(py: Python<'_>) -> PyResult<Vec<AppInfo>> {
-    let provider = Provider::new()?;
+    let mut provider = Provider::new()?;
+    provider.activated = true;
     provider.list_apps(py)
 }
 
 /// Check accessibility permissions (convenience — creates provider internally).
 #[pyfunction]
 fn check_permissions(py: Python<'_>) -> PyResult<String> {
-    let provider = Provider::new()?;
+    let mut provider = Provider::new()?;
+    provider.activated = true;
     provider.check_permissions(py)
 }
 
@@ -1812,5 +1834,8 @@ fn _make_test_provider() -> PyResult<Provider> {
         tree,
         actions: std::sync::Mutex::new(Vec::new()),
     });
-    Ok(Provider { inner: provider })
+    Ok(Provider {
+        inner: provider,
+        activated: false,
+    })
 }

--- a/xa11y-python/tests/conftest.py
+++ b/xa11y-python/tests/conftest.py
@@ -11,4 +11,5 @@ def tree():
 @pytest.fixture
 def provider():
     """A mock provider that returns the canonical test tree."""
-    return _make_test_provider()
+    with _make_test_provider() as p:
+        yield p

--- a/xa11y-python/tests/test_provider.py
+++ b/xa11y-python/tests/test_provider.py
@@ -1,6 +1,8 @@
 """Tests for Provider: app(), all_apps(), list_apps(), check_permissions(), context manager."""
 
 import pytest
+from xa11y._native import _make_test_provider
+
 
 # ── Provider creation ────────────────────────────────────────────────────────
 
@@ -92,12 +94,26 @@ def test_check_permissions(provider):
 # ── Context manager ──────────────────────────────────────────────────────────
 
 
-def test_context_manager(provider):
-    with provider as p:
+def test_context_manager():
+    with _make_test_provider() as p:
         tree = p.app("TestApp")
         assert len(tree) > 0
 
 
-def test_context_manager_does_not_suppress_exceptions(provider):
-    with pytest.raises(ValueError), provider:
+def test_context_manager_does_not_suppress_exceptions():
+    with pytest.raises(ValueError), _make_test_provider():
         raise ValueError("test")
+
+
+def test_methods_fail_without_context_manager():
+    p = _make_test_provider()
+    with pytest.raises(RuntimeError, match="context manager"):
+        p.app("TestApp")
+
+
+def test_methods_fail_after_exit():
+    p = _make_test_provider()
+    with p:
+        p.app("TestApp")  # works inside
+    with pytest.raises(RuntimeError, match="context manager"):
+        p.app("TestApp")  # fails after exit

--- a/xa11y-python/tests/test_provider.py
+++ b/xa11y-python/tests/test_provider.py
@@ -3,7 +3,6 @@
 import pytest
 from xa11y._native import _make_test_provider
 
-
 # ── Provider creation ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Provider methods now raise RuntimeError if called outside a `with` block.
This enforces deterministic resource cleanup and prepares for future
connection/subscription management in __exit__.

- Added `activated` flag to Provider, set true in __enter__, false in __exit__
- All Provider methods guard on activated state
- Module-level convenience functions (app, list_apps, etc.) activate internally
- Updated tests: fixture uses context manager, added tests for enforcement

https://claude.ai/code/session_01G5wnGqqSkrjgaNaB4g6S18