### PR TITLE
Add Python pytest integration tests and docs example

### DIFF
--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -5,6 +5,50 @@ description: Get up and running with xa11y in Rust or Python.
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
+## Testing with pytest
+
+xa11y is designed for accessibility testing. Here's a real-world example using pytest:
+
+```python
+import xa11y
+import pytest
+
+@pytest.fixture
+def app():
+    """Get the accessibility tree for your app under test."""
+    return xa11y.app("MyApp")
+
+def test_submit_form(app):
+    # Fill in the name field
+    app.set_value("text_input[name='Name']", "Alice")
+
+    # Check the terms checkbox
+    app.press("check_box[name='I agree to terms']")
+
+    # Click Submit
+    app.press("button[name='Submit']")
+
+    # Re-read the tree and verify the status changed
+    app = xa11y.app("MyApp")
+    status = app.find_by_name("Submitted")
+    assert len(status) >= 1, "Form should show 'Submitted' status"
+
+def test_slider_adjustment(app):
+    # Use a locator for richer assertions
+    slider = app.locator("slider[name='Volume']")
+    assert slider.is_enabled()
+    assert slider.get().numeric_value == 50.0
+
+    # Increment and verify
+    slider.increment()
+    app = xa11y.app("MyApp")
+    assert app.locator("slider[name='Volume']").get().numeric_value == 51.0
+
+def test_disabled_button(app):
+    cancel = app.locator("button[name='Cancel']")
+    assert not cancel.is_enabled(), "Cancel should be disabled until terms are accepted"
+```
+
 ## Installation
 
 <Tabs syncKey="lang">

--- a/run_python_integ_tests.sh
+++ b/run_python_integ_tests.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Integration test harness for xa11y Python bindings on Linux.
+#
+# Sets up Xvfb, D-Bus session, AT-SPI2, launches the accesskit+winit test app,
+# builds the Python package via maturin, then runs pytest integration tests.
+#
+# Usage: ./run_python_integ_tests.sh
+#        ./run_python_integ_tests.sh test_toggle  # run a single test
+
+set -euo pipefail
+
+# If we're not already inside a D-Bus session, re-exec under dbus-run-session.
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    echo "No D-Bus session found, re-launching under dbus-run-session..."
+    exec dbus-run-session -- bash "$0" "$@"
+fi
+
+CLEANUP_PIDS=()
+
+cleanup() {
+    echo "Cleaning up..."
+    for pid in "${CLEANUP_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+    # Deactivate virtualenv if active
+    if [ -n "${VIRTUAL_ENV:-}" ]; then
+        deactivate 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "=== xa11y Python integration test harness ==="
+echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+
+# 1. Find a free display number and start Xvfb
+XVFB_DISPLAY=":99"
+for d in 99 98 97 96 95; do
+    if [ ! -e "/tmp/.X${d}-lock" ]; then
+        XVFB_DISPLAY=":${d}"
+        break
+    fi
+done
+
+echo "Starting Xvfb on $XVFB_DISPLAY..."
+Xvfb "$XVFB_DISPLAY" -screen 0 1280x1024x24 -ac &
+CLEANUP_PIDS+=($!)
+sleep 1
+
+export DISPLAY="$XVFB_DISPLAY"
+echo "DISPLAY=$DISPLAY"
+
+# 2. Start AT-SPI2 bus launcher and registryd
+echo "Starting AT-SPI2 infrastructure..."
+
+export NO_AT_BRIDGE=0
+export AT_SPI_CLIENT=true
+export ACCESSIBILITY_ENABLED=1
+
+if command -v /usr/libexec/at-spi-bus-launcher &>/dev/null; then
+    /usr/libexec/at-spi-bus-launcher --launch-immediately &
+    CLEANUP_PIDS+=($!)
+elif command -v at-spi-bus-launcher &>/dev/null; then
+    at-spi-bus-launcher --launch-immediately &
+    CLEANUP_PIDS+=($!)
+else
+    echo "WARNING: at-spi-bus-launcher not found, AT-SPI2 may not work"
+fi
+
+sleep 1
+
+if command -v /usr/libexec/at-spi2-registryd &>/dev/null; then
+    /usr/libexec/at-spi2-registryd &
+    CLEANUP_PIDS+=($!)
+elif command -v at-spi2-registryd &>/dev/null; then
+    at-spi2-registryd &
+    CLEANUP_PIDS+=($!)
+else
+    echo "WARNING: at-spi2-registryd not found"
+fi
+
+sleep 1
+
+# 2b. Enable accessibility on the AT-SPI bus
+echo "Enabling AT-SPI accessibility..."
+dbus-send --session --print-reply --dest=org.a11y.Bus /org/a11y/bus \
+    org.freedesktop.DBus.Properties.Set \
+    string:org.a11y.Status string:IsEnabled variant:boolean:true \
+    2>/dev/null || true
+dbus-send --session --print-reply --dest=org.a11y.Bus /org/a11y/bus \
+    org.freedesktop.DBus.Properties.Set \
+    string:org.a11y.Status string:ScreenReaderEnabled variant:boolean:true \
+    2>/dev/null || true
+
+# 3. Build the Rust workspace (test app + Python bindings)
+echo "Building workspace..."
+cargo build --workspace 2>&1
+
+# 4. Set up Python virtualenv and install xa11y
+echo "Setting up Python environment..."
+python3 -m venv .venv-integ 2>/dev/null || python -m venv .venv-integ
+source .venv-integ/bin/activate
+pip install --quiet maturin pytest
+
+echo "Building xa11y Python package..."
+(cd xa11y-python && maturin develop --release 2>&1)
+
+# 5. Launch the test application
+echo "Launching xa11y-test-app..."
+./target/debug/xa11y-test-app --headless &
+CLEANUP_PIDS+=($!)
+
+echo "Waiting for test app to register with AT-SPI..."
+sleep 3
+
+# 6. Run Python integration tests
+echo "Running Python integration tests..."
+TEST_FILTER="${1:-}"
+set +e
+if [ -n "$TEST_FILTER" ]; then
+    pytest xa11y-python/tests/test_integ.py -v -m integ -k "$TEST_FILTER" 2>&1
+else
+    pytest xa11y-python/tests/test_integ.py -v -m integ 2>&1
+fi
+TEST_EXIT=$?
+set -e
+
+echo "=== Python integration tests finished (exit code: $TEST_EXIT) ==="
+exit $TEST_EXIT

--- a/xa11y-python/pyproject.toml
+++ b/xa11y-python/pyproject.toml
@@ -51,3 +51,6 @@ select = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "integ: integration tests requiring live test app + AT-SPI2 (run via run_python_integ_tests.sh)",
+]

--- a/xa11y-python/python/xa11y/__init__.py
+++ b/xa11y-python/python/xa11y/__init__.py
@@ -12,6 +12,30 @@ With explicit provider:
     ...     tree = provider.app("Safari")
     ...     loc = tree.locator("button[name='Submit']")
     ...     loc.press()
+
+Testing with pytest::
+
+    import xa11y
+    import pytest
+
+    @pytest.fixture
+    def app():
+        return xa11y.app("MyApp")
+
+    def test_submit_form(app):
+        app.set_value("text_input[name='Name']", "Alice")
+        app.press("check_box[name='I agree']")
+        app.press("button[name='Submit']")
+
+        app = xa11y.app("MyApp")
+        assert app.find_by_name("Submitted")
+
+    def test_slider(app):
+        slider = app.locator("slider[name='Volume']")
+        assert slider.get().numeric_value == 50.0
+        slider.increment()
+        app = xa11y.app("MyApp")
+        assert app.locator("slider[name='Volume']").get().numeric_value == 51.0
 """
 
 from xa11y._native import (

--- a/xa11y-python/tests/test_integ.py
+++ b/xa11y-python/tests/test_integ.py
@@ -1,0 +1,309 @@
+"""Integration tests for xa11y Python bindings.
+
+These tests run against the xa11y-test-app (AccessKit + winit) and verify
+that the Python API works end-to-end through the real AT-SPI2 accessibility
+stack on Linux.
+
+Run with: ./run_python_integ_tests.sh
+All tests are marked with @pytest.mark.integ and skipped by default.
+"""
+
+import pytest
+import xa11y
+
+# All tests in this file require the live test app + AT-SPI2 infrastructure.
+pytestmark = pytest.mark.integ
+
+APP_NAME = "xa11y-test-app"
+
+
+@pytest.fixture(scope="module")
+def provider():
+    """Create a real platform provider (AT-SPI2 on Linux)."""
+    return xa11y.connect()
+
+
+@pytest.fixture
+def app(provider):
+    """Get the test app's accessibility tree."""
+    return provider.app(APP_NAME)
+
+
+# ── Discovery ────────────────────────────────────────────────────────────────
+
+
+def test_list_apps_includes_test_app(provider):
+    apps = provider.list_apps()
+    names = [a.name for a in apps]
+    assert any("xa11y" in n for n in names), f"Test app not found in: {names}"
+
+
+def test_app_tree_has_nodes(app):
+    assert len(app) > 10, f"Expected many nodes, got {len(app)}"
+    assert app.root.role == "window"
+
+
+# ── Tree queries ─────────────────────────────────────────────────────────────
+
+
+def test_find_buttons_by_role(app):
+    buttons = app.query("button")
+    names = {b.name for b in buttons}
+    assert "Submit" in names
+    assert "Cancel" in names
+
+
+def test_find_by_name(app):
+    results = app.find_by_name("Submit")
+    assert len(results) >= 1
+    assert results[0].role == "button"
+
+
+def test_query_text_field(app):
+    fields = app.query("text_input")
+    assert len(fields) >= 1
+    name_field = next(f for f in fields if f.name == "Name")
+    assert name_field.value == "John Doe"
+
+
+def test_query_checkbox(app):
+    cbs = app.query("check_box")
+    assert len(cbs) >= 1
+    cb = cbs[0]
+    assert cb.name == "I agree to terms"
+    # Initially unchecked
+    assert cb.checked in ("off", False, None) or cb.checked != "on"
+
+
+def test_query_slider(app):
+    sliders = app.query("slider")
+    assert len(sliders) >= 1
+    slider = next(s for s in sliders if s.name == "Volume")
+    assert slider.numeric_value == 50.0
+    assert slider.min_value == 0.0
+    assert slider.max_value == 100.0
+
+
+def test_query_descendant_combinator(app):
+    """toolbar > button finds buttons inside the toolbar."""
+    results = app.query("toolbar > button")
+    names = {b.name for b in results}
+    assert "New" in names
+
+
+# ── Locator API ──────────────────────────────────────────────────────────────
+
+
+def test_locator_exists(app):
+    assert app.locator("button[name='Submit']").exists()
+    assert not app.locator("button[name='DoesNotExist']").exists()
+
+
+def test_locator_name_and_role(app):
+    loc = app.locator("button[name='Submit']")
+    assert loc.name() == "Submit"
+    assert loc.role() == "button"
+
+
+def test_locator_is_enabled(app):
+    assert app.locator("button[name='Submit']").is_enabled()
+    assert not app.locator("button[name='Cancel']").is_enabled()
+
+
+def test_locator_count(app):
+    assert app.locator("button").count() >= 4  # Submit, Cancel, New, OpenTool, ...
+
+
+def test_locator_nth(app):
+    buttons = app.locator("toolbar > button")
+    first = buttons.first()
+    second = buttons.nth(1)
+    assert first.name() != second.name()
+
+
+# ── Actions: checkbox toggle ─────────────────────────────────────────────────
+
+
+def test_toggle_checkbox_enables_cancel(provider):
+    """Toggle the checkbox and verify Cancel button becomes enabled."""
+    tree = provider.app(APP_NAME)
+
+    # Checkbox starts unchecked, Cancel starts disabled
+    cancel = tree.locator("button[name='Cancel']")
+    assert not cancel.is_enabled(), "Cancel should start disabled"
+
+    # Toggle the checkbox
+    tree.press("check_box[name='I agree to terms']")
+
+    # Re-read tree to see updated state
+    tree = provider.app(APP_NAME)
+    cancel = tree.locator("button[name='Cancel']")
+    assert cancel.is_enabled(), "Cancel should be enabled after checking the checkbox"
+
+    # Toggle back to restore initial state
+    tree.press("check_box[name='I agree to terms']")
+
+
+# ── Actions: text field ──────────────────────────────────────────────────────
+
+
+def test_set_value_on_text_field(provider):
+    """Set the Name field's value and verify it changed."""
+    tree = provider.app(APP_NAME)
+    name_field = tree.locator("text_input[name='Name']")
+    original = name_field.value()
+
+    tree.set_value("text_input[name='Name']", "Alice")
+
+    tree = provider.app(APP_NAME)
+    assert tree.locator("text_input[name='Name']").value() == "Alice"
+
+    # Restore original value
+    tree.set_value("text_input[name='Name']", original or "John Doe")
+
+
+# ── Actions: slider ──────────────────────────────────────────────────────────
+
+
+def test_increment_slider(provider):
+    """Increment the slider and verify the value increased."""
+    tree = provider.app(APP_NAME)
+    slider = tree.locator("slider[name='Volume']")
+    before = slider.get().numeric_value
+
+    tree.increment("slider[name='Volume']")
+
+    tree = provider.app(APP_NAME)
+    after = tree.locator("slider[name='Volume']").get().numeric_value
+    assert after == before + 1.0, f"Expected {before + 1.0}, got {after}"
+
+
+def test_decrement_slider(provider):
+    """Decrement the slider and verify the value decreased."""
+    tree = provider.app(APP_NAME)
+    slider = tree.locator("slider[name='Volume']")
+    before = slider.get().numeric_value
+
+    tree.decrement("slider[name='Volume']")
+
+    tree = provider.app(APP_NAME)
+    after = tree.locator("slider[name='Volume']").get().numeric_value
+    assert after == before - 1.0, f"Expected {before - 1.0}, got {after}"
+
+
+# ── Actions: list item selection ─────────────────────────────────────────────
+
+
+def test_select_list_item(provider):
+    """Click a list item and verify it becomes selected."""
+    tree = provider.app(APP_NAME)
+
+    # Initially no fruit is selected
+    apple = tree.locator("list_item[name='Apple']")
+    assert not apple.get().selected, "Apple should not be selected initially"
+
+    # Click Apple
+    apple.press()
+
+    tree = provider.app(APP_NAME)
+    apple = tree.locator("list_item[name='Apple']")
+    assert apple.get().selected, "Apple should be selected after clicking"
+
+
+# ── Actions: expand / collapse ───────────────────────────────────────────────
+
+
+def test_expand_and_collapse(provider):
+    """Expand the expander group and verify, then collapse it back."""
+    tree = provider.app(APP_NAME)
+    expander = tree.locator("group[name='Expander']")
+
+    # Initially collapsed
+    assert not expander.get().expanded, "Expander should start collapsed"
+
+    # Expand
+    tree.expand("group[name='Expander']")
+
+    tree = provider.app(APP_NAME)
+    expander = tree.locator("group[name='Expander']")
+    assert expander.get().expanded, "Expander should be expanded"
+
+    # Collapse
+    tree.collapse("group[name='Expander']")
+
+    tree = provider.app(APP_NAME)
+    expander = tree.locator("group[name='Expander']")
+    assert not expander.get().expanded, "Expander should be collapsed again"
+
+
+# ── Actions: submit workflow ─────────────────────────────────────────────────
+
+
+def test_submit_without_checkbox_shows_warning(provider):
+    """Clicking Submit without checking the box shows a warning status."""
+    # Make sure checkbox is unchecked first
+    tree = provider.app(APP_NAME)
+    cb = tree.query("check_box[name='I agree to terms']")
+    if cb and cb[0].checked == "on":
+        tree.press("check_box[name='I agree to terms']")
+        tree = provider.app(APP_NAME)
+
+    tree.press("button[name='Submit']")
+
+    tree = provider.app(APP_NAME)
+    status = tree.find_by_name("Please agree")
+    assert len(status) >= 1, "Should show 'Please agree to terms' message"
+
+
+def test_full_submit_workflow(provider):
+    """Check the box, submit, and verify the status changes to 'Submitted'."""
+    tree = provider.app(APP_NAME)
+
+    # Ensure checkbox is checked
+    cb = tree.query("check_box[name='I agree to terms']")
+    if cb and cb[0].checked != "on":
+        tree.press("check_box[name='I agree to terms']")
+        tree = provider.app(APP_NAME)
+
+    # Click Submit
+    tree.press("button[name='Submit']")
+
+    tree = provider.app(APP_NAME)
+    status = tree.find_by_name("Submitted")
+    assert len(status) >= 1, "Should show 'Submitted' status after checking box + submit"
+
+
+# ── Navigation ───────────────────────────────────────────────────────────────
+
+
+def test_parent_child_navigation(app):
+    """Navigate the tree structure via parent/children properties."""
+    root = app.root
+    assert len(root.children) > 0
+
+    # Find the toolbar and verify we can navigate back up
+    toolbars = app.query("toolbar")
+    assert len(toolbars) >= 1
+    toolbar = toolbars[0]
+    assert toolbar.parent is not None
+    assert toolbar.parent.role == "window"
+
+    # Toolbar should have button children
+    btn_children = [c for c in toolbar.children if c.role == "button"]
+    assert len(btn_children) >= 2
+
+
+# ── Tree printing / repr ─────────────────────────────────────────────────────
+
+
+def test_tree_str_contains_structure(app):
+    """str(tree) should produce a readable dump of the tree."""
+    dump = str(app)
+    assert "window" in dump
+    assert "button" in dump
+    assert "Submit" in dump
+
+
+def test_tree_repr(app):
+    r = repr(app)
+    assert "xa11y" in r.lower() or "Tree" in r


### PR DESCRIPTION
## Summary

- Adds **24 pytest integration tests** (`xa11y-python/tests/test_integ.py`) that run against the xa11y-test-app via AT-SPI2, covering:
  - App discovery and tree queries (roles, names, selectors, combinators)
  - Locator API (exists, count, nth, enabled state)
  - Interactive actions: checkbox toggle, text field set_value, slider increment/decrement, list item selection, expand/collapse, full submit workflow
  - Tree navigation (parent/children) and repr/str output
- Adds **`run_python_integ_tests.sh`** runner script (mirrors `run_integ_tests.sh` — sets up Xvfb, D-Bus, AT-SPI2, builds Python package via maturin, launches test app, runs pytest)
- Adds **pytest marker** `integ` in `pyproject.toml` so integration tests are skipped during normal `pytest` runs
- Adds **pytest usage example** to quick-start docs and module docstring showing idiomatic xa11y + pytest patterns

## Test plan

- [x] Existing 198 Python unit tests pass (`pytest tests/ -m "not integ"`)
- [x] Ruff lint + format checks pass on all Python files
- [x] `cargo check --workspace` passes with `-Dwarnings`
- [x] Integration tests are properly collected but deselected without `-m integ`
- [ ] Run `./run_python_integ_tests.sh` on Linux with AT-SPI2 infrastructure to verify end-to-end

https://claude.ai/code/session_0199YoD4rb1k4LPwAPGyNayk