### PR TITLE
Fix 404s for Rust API docs by removing incorrect /xa11y/ path prefix

### DIFF
--- a/docs/site/src/content/docs/api/rust.mdx
+++ b/docs/site/src/content/docs/api/rust.mdx
@@ -7,7 +7,7 @@ The full Rust API documentation is generated from source with `cargo doc` and ho
 
 ## Browse the Docs
 
-<a href="/xa11y/rustdoc/xa11y/" class="sl-flex" style="display:inline-flex;align-items:center;gap:0.5rem;padding:0.5rem 1rem;background:var(--sl-color-accent);color:var(--sl-color-black);border-radius:0.5rem;text-decoration:none;font-weight:600;">
+<a href="/rustdoc/xa11y/" class="sl-flex" style="display:inline-flex;align-items:center;gap:0.5rem;padding:0.5rem 1rem;background:var(--sl-color-accent);color:var(--sl-color-black);border-radius:0.5rem;text-decoration:none;font-weight:600;">
   Open Rust API Docs →
 </a>
 
@@ -15,11 +15,11 @@ The full Rust API documentation is generated from source with `cargo doc` and ho
 
 | Crate | Description |
 | ----- | ----------- |
-| [`xa11y`](/xa11y/rustdoc/xa11y/) | Umbrella crate — re-exports all core types and provides `create_provider()` |
-| [`xa11y_core`](/xa11y/rustdoc/xa11y_core/) | Platform-independent types, traits, selector engine |
-| [`xa11y_linux`](/xa11y/rustdoc/xa11y_linux/) | Linux AT-SPI2 backend |
-| [`xa11y_macos`](/xa11y/rustdoc/xa11y_macos/) | macOS AXUIElement backend |
-| [`xa11y_windows`](/xa11y/rustdoc/xa11y_windows/) | Windows UI Automation backend |
+| [`xa11y`](/rustdoc/xa11y/) | Umbrella crate — re-exports all core types and provides `create_provider()` |
+| [`xa11y_core`](/rustdoc/xa11y_core/) | Platform-independent types, traits, selector engine |
+| [`xa11y_linux`](/rustdoc/xa11y_linux/) | Linux AT-SPI2 backend |
+| [`xa11y_macos`](/rustdoc/xa11y_macos/) | macOS AXUIElement backend |
+| [`xa11y_windows`](/rustdoc/xa11y_windows/) | Windows UI Automation backend |
 
 ## Key Types
 


### PR DESCRIPTION
The docs site is served from the root of xa11y.dev with no base path,
but rustdoc links had a /xa11y/ prefix (e.g., /xa11y/rustdoc/xa11y/).
The rustdoc files are copied to dist/rustdoc/, so the correct paths
are /rustdoc/<crate>/.

https://claude.ai/code/session_011B1pv5BXRvPJ5VTMbHdhDB