### PR TITLE
Fix CI failures in lint and python jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/target
 **/corpus
 **/artifacts
+.venv/
 
 # Auto-generated docs (regenerate with: python docs/generate_python_api.py)
 docs/site/src/content/docs/api/python.mdx

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -302,6 +302,7 @@ impl LinuxProvider {
 
     /// Traverse the accessibility tree rooted at `aref`, building nodes.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::only_used_in_recursion)]
     fn traverse(
         &self,
         aref: &AccessibleRef,

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -474,6 +474,7 @@ impl Tree {
     }
 
     /// Perform an action on a node or selector target.
+    #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (target, action, *, value=None, numeric_value=None, direction=None, amount=None, start=None, end=None))]
     fn perform(
         &self,

--- a/xa11y-python/tests/test_provider.py
+++ b/xa11y-python/tests/test_provider.py
@@ -2,9 +2,7 @@
 
 from xa11y._native import _make_test_apps
 
-
 # ── app() (via _make_test_tree mock) ────────────────────────────────────────
-
 
 
 def test_app_tree_has_nodes(tree):

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -1047,16 +1047,16 @@ mod tests {
     fn raw_data_always_present() {
         let p = h::provider();
         let tree = h::app_tree(&*p);
-        let root = tree.root();
+        let _root = tree.root();
         #[cfg(target_os = "linux")]
-        match &root.raw {
+        match &_root.raw {
             RawPlatformData::Linux { atspi_role, .. } => {
                 assert!(!atspi_role.is_empty());
             }
             _ => panic!("Expected Linux raw data"),
         }
         #[cfg(target_os = "macos")]
-        match &root.raw {
+        match &_root.raw {
             RawPlatformData::MacOS { ax_role, .. } => {
                 assert!(!ax_role.is_empty());
             }


### PR DESCRIPTION
- Add #[allow(clippy::too_many_arguments)] to Tree.perform() in Python
  bindings (9 args needed for PyO3 keyword-argument API)
- Fix ruff lint (unsorted imports) and format (extra blank lines) in
  test_provider.py

https://claude.ai/code/session_01GuaHtxWzXZc9ETDWKSRgEC