### PR TITLE
Add missing Locator query methods to Python bindings

### DIFF
--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -260,12 +260,32 @@ class Locator:
         """Get the current value of the matched element."""
     def description(self) -> str | None:
         """Get the accessible description of the matched element."""
+    def bounds(self) -> Rect | None:
+        """Get the bounding rectangle of the matched element."""
+    def numeric_value(self) -> float | None:
+        """Get the numeric value of the matched element (e.g. slider position)."""
     def is_visible(self) -> bool:
         """Check whether the matched element is visible."""
     def is_enabled(self) -> bool:
         """Check whether the matched element is enabled."""
     def is_focused(self) -> bool:
         """Check whether the matched element has keyboard focus."""
+    def is_selected(self) -> bool:
+        """Check whether the matched element is selected."""
+    def checked(self) -> str | None:
+        """Check state: ``"on"``, ``"off"``, ``"mixed"``, or ``None``."""
+    def is_expanded(self) -> bool | None:
+        """Expansion state (``None`` if not expandable)."""
+    def is_editable(self) -> bool:
+        """Check whether the matched element supports text editing."""
+    def is_focusable(self) -> bool:
+        """Check whether the matched element can receive focus."""
+    def is_modal(self) -> bool:
+        """Check whether the matched element is a modal dialog."""
+    def is_required(self) -> bool:
+        """Check whether the matched element is a required form field."""
+    def is_busy(self) -> bool:
+        """Check whether the matched element is in a busy/loading state."""
     def exists(self) -> bool:
         """Check whether the selector matches any element."""
     def count(self) -> int:

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -784,6 +784,19 @@ impl Locator {
         Ok(self.resolve_node()?.description.clone())
     }
 
+    fn bounds(&self) -> PyResult<Option<Rect>> {
+        Ok(self.resolve_node()?.bounds.as_ref().map(|r| Rect {
+            x: r.x,
+            y: r.y,
+            width: r.width,
+            height: r.height,
+        }))
+    }
+
+    fn numeric_value(&self) -> PyResult<Option<f64>> {
+        Ok(self.resolve_node()?.numeric_value)
+    }
+
     fn is_visible(&self) -> PyResult<bool> {
         Ok(self.resolve_node()?.states.visible)
     }
@@ -794,6 +807,42 @@ impl Locator {
 
     fn is_focused(&self) -> PyResult<bool> {
         Ok(self.resolve_node()?.states.focused)
+    }
+
+    fn is_selected(&self) -> PyResult<bool> {
+        Ok(self.resolve_node()?.states.selected)
+    }
+
+    fn checked(&self) -> PyResult<Option<String>> {
+        Ok(self.resolve_node()?.states.checked.map(|t| match t {
+            xa11y::Toggled::Off => "off".to_string(),
+            xa11y::Toggled::On => "on".to_string(),
+            xa11y::Toggled::Mixed => "mixed".to_string(),
+        }))
+    }
+
+    fn is_expanded(&self) -> PyResult<Option<bool>> {
+        Ok(self.resolve_node()?.states.expanded)
+    }
+
+    fn is_editable(&self) -> PyResult<bool> {
+        Ok(self.resolve_node()?.states.editable)
+    }
+
+    fn is_focusable(&self) -> PyResult<bool> {
+        Ok(self.resolve_node()?.states.focusable)
+    }
+
+    fn is_modal(&self) -> PyResult<bool> {
+        Ok(self.resolve_node()?.states.modal)
+    }
+
+    fn is_required(&self) -> PyResult<bool> {
+        Ok(self.resolve_node()?.states.required)
+    }
+
+    fn is_busy(&self) -> PyResult<bool> {
+        Ok(self.resolve_node()?.states.busy)
     }
 
     fn exists(&self) -> PyResult<bool> {

--- a/xa11y-python/tests/test_locator.py
+++ b/xa11y-python/tests/test_locator.py
@@ -70,6 +70,28 @@ def test_description(tree):
     assert loc.description() == "Go back"
 
 
+def test_bounds(tree):
+    loc = tree.locator("window")
+    b = loc.bounds()
+    assert b is not None
+    assert isinstance(b, xa11y.Rect)
+
+
+def test_bounds_none(tree):
+    loc = tree.locator("static_text")
+    assert loc.bounds() is None
+
+
+def test_numeric_value(tree):
+    loc = tree.locator("slider")
+    assert loc.numeric_value() == 75.0
+
+
+def test_numeric_value_none(tree):
+    loc = tree.locator('button[name="Back"]')
+    assert loc.numeric_value() is None
+
+
 def test_is_visible(tree):
     assert tree.locator('button[name="Back"]').is_visible() is True
     assert tree.locator("static_text").is_visible() is False
@@ -83,6 +105,43 @@ def test_is_enabled(tree):
 def test_is_focused(tree):
     assert tree.locator("window").is_focused() is True
     assert tree.locator('button[name="Back"]').is_focused() is False
+
+
+def test_is_selected(tree):
+    assert tree.locator('list_item[name="Item 1"]').is_selected() is True
+    assert tree.locator('list_item[name="Item 2"]').is_selected() is False
+
+
+def test_checked(tree):
+    assert tree.locator("check_box").checked() == "on"
+    assert tree.locator('button[name="Back"]').checked() is None
+
+
+def test_is_expanded(tree):
+    assert tree.locator("list").is_expanded() is True
+    assert tree.locator('button[name="Back"]').is_expanded() is None
+
+
+def test_is_editable(tree):
+    assert tree.locator("text_field").is_editable() is True
+    assert tree.locator('button[name="Back"]').is_editable() is False
+
+
+def test_is_focusable(tree):
+    assert tree.locator("text_field").is_focusable() is True
+    assert tree.locator("static_text").is_focusable() is False
+
+
+def test_is_modal(tree):
+    assert tree.locator('button[name="Back"]').is_modal() is False
+
+
+def test_is_required(tree):
+    assert tree.locator('button[name="Back"]').is_required() is False
+
+
+def test_is_busy(tree):
+    assert tree.locator('button[name="Back"]').is_busy() is False
 
 
 def test_exists_true(tree):


### PR DESCRIPTION
Add bounds(), numeric_value(), and state accessors (is_selected, checked,
is_expanded, is_editable, is_focusable, is_modal, is_required, is_busy)
to the Python Locator class, matching the Rust Locator public API.

https://claude.ai/code/session_01WYJfodN2tW55cw3fR8e7Z4