### PR TITLE
Fix broken doc links and add link checker

### DIFF
--- a/docs/check_links.py
+++ b/docs/check_links.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Check internal links in documentation .mdx files.
+
+Scans all .mdx files under docs/site/src/content/docs/ for internal links
+(markdown links starting with /) and validates that they resolve to either:
+  - An existing content page (.mdx file)
+  - A known build-time asset path (e.g. /api/rust/reference/...)
+
+Exit code 0 if all links are valid, 1 if any are broken.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).parent / "site" / "src" / "content" / "docs"
+
+# Paths served by build-time assets (cargo doc, sphinx), not content pages.
+ASSET_PATH_PREFIXES = [
+    "/api/rust/reference/",
+    "/api/python/reference/",
+]
+
+# Regex for markdown links: [text](/path/) and HTML href="/path/"
+MARKDOWN_LINK = re.compile(r'\]\((/[^)]+)\)')
+HTML_HREF = re.compile(r'href="(/[^"]+)"')
+
+
+def slug_to_file(slug: str) -> Path:
+    """Convert a Starlight content slug like /guides/overview/ to a file path."""
+    slug = slug.strip("/")
+    return DOCS_DIR / f"{slug}.mdx"
+
+
+def check_file(filepath: Path) -> list[tuple[int, str, str]]:
+    """Return list of (line_number, link, reason) for broken links in a file."""
+    errors = []
+    text = filepath.read_text()
+    for i, line in enumerate(text.splitlines(), start=1):
+        for match in MARKDOWN_LINK.finditer(line):
+            link = match.group(1)
+            err = validate_link(link)
+            if err:
+                errors.append((i, link, err))
+        for match in HTML_HREF.finditer(line):
+            link = match.group(1)
+            err = validate_link(link)
+            if err:
+                errors.append((i, link, err))
+    return errors
+
+
+def validate_link(link: str) -> str | None:
+    """Return an error message if the link is broken, or None if valid."""
+    # Allow anchor-only links
+    if link.startswith("#"):
+        return None
+
+    # Allow known asset paths
+    for prefix in ASSET_PATH_PREFIXES:
+        if link.startswith(prefix):
+            return None
+
+    # Must resolve to an existing content page
+    target = slug_to_file(link)
+    if not target.exists():
+        return f"no content page at {target.relative_to(DOCS_DIR)}"
+    return None
+
+
+def main() -> int:
+    mdx_files = sorted(DOCS_DIR.rglob("*.mdx"))
+    if not mdx_files:
+        print(f"ERROR: no .mdx files found in {DOCS_DIR}", file=sys.stderr)
+        return 1
+
+    all_errors: list[tuple[Path, int, str, str]] = []
+    for filepath in mdx_files:
+        for lineno, link, reason in check_file(filepath):
+            all_errors.append((filepath, lineno, link, reason))
+
+    if all_errors:
+        print(f"Found {len(all_errors)} broken link(s):\n")
+        for filepath, lineno, link, reason in all_errors:
+            rel = filepath.relative_to(DOCS_DIR)
+            print(f"  {rel}:{lineno}: {link}")
+            print(f"    -> {reason}")
+        print()
+        return 1
+
+    print(f"All links OK ({len(mdx_files)} files checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -227,6 +227,6 @@ xa11y supports CSS-like selectors to find elements in the tree.
 
 ## Next Steps
 
-- [Overview](/xa11y/guides/overview/) — architecture and design principles
-- [Rust API Reference](/xa11y/api/rust/) — full Rust API documentation
-- [Python API Reference](/xa11y/api/python/) — full Python API documentation
+- [Overview](/guides/overview/) — architecture and design principles
+- [Rust API Reference](/api/rust/) — full Rust API documentation
+- [Python API Reference](/api/python/) — full Python API documentation

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -193,8 +193,14 @@ fn do_test_integ_container(args: &[String]) -> bool {
 }
 
 fn do_docs() -> bool {
-    heading("Generate Python API docs");
+    heading("Check doc links");
     let root = project_root();
+    let links_ok = run_in("python", &["docs/check_links.py"], &root);
+    if !links_ok {
+        return false;
+    }
+
+    heading("Generate Python API docs");
     let gen_ok = run_in("python", &["docs/generate_python_api.py"], &root);
     if !gen_ok {
         return false;


### PR DESCRIPTION
The quick-start guide had an erroneous /xa11y/ prefix on internal links,
causing them to 404. Added docs/check_links.py that validates internal
links in .mdx files and integrated it into `cargo xtask docs`.

https://claude.ai/code/session_01XThpWTv3kGNHrrJtpDUfNu