### PR TITLE
fix: sync Python package version in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Bump version
         run: cargo release ${{ inputs.level }} --execute --no-confirm
 
+      - name: Sync Python package version
+        run: |
+          VERSION=$(sed -n '/\[workspace\.package\]/,/\[/{s/^version = "\(.*\)"/\1/p}' Cargo.toml)
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" xa11y-python/Cargo.toml
+          git add xa11y-python/Cargo.toml
+          git commit -m "chore: sync xa11y-python version to $VERSION"
+          git push
+
   publish-crates:
     name: Publish to crates.io
     needs: [version-bump]

--- a/xa11y-python/Cargo.toml
+++ b/xa11y-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xa11y-python"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 publish = false # Published to PyPI, not crates.io


### PR DESCRIPTION
xa11y-python is excluded from the Cargo workspace, so cargo-release
never bumps its version. This caused PyPI publish to fail with a
duplicate version error on the second release.

- Update xa11y-python version from 0.1.0 to 0.2.0 to match workspace
- Add a post-bump step in publish.yml to sync xa11y-python/Cargo.toml
  version with the workspace version after cargo-release runs

https://claude.ai/code/session_01EBCPcXssC4Q4dxA9Deo1gH