### PR TITLE
Add user-facing README with per-platform variants for crates.io/PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Generate crates.io README
+        run: cargo xtask sync-readmes
+
       - name: Publish xa11y-core
         run: cargo publish -p xa11y-core
         env:
@@ -114,6 +117,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Generate PyPI README
+        run: cargo xtask sync-readmes
+
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
@@ -150,6 +156,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Generate PyPI README
+        run: cargo xtask sync-readmes
+
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
@@ -175,6 +184,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Generate PyPI README
+        run: cargo xtask sync-readmes
+
       - uses: PyO3/maturin-action@v1
         with:
           target: x86_64
@@ -195,6 +207,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
+
+      - name: Generate PyPI README
+        run: cargo xtask sync-readmes
 
       - uses: PyO3/maturin-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 **/corpus
 **/artifacts
 .venv/
+
+# Generated READMEs for crates.io and PyPI (built from root README.md)
+xa11y/README.md
+xa11y-python/README.md

--- a/README.md
+++ b/README.md
@@ -1,43 +1,134 @@
 # xa11y
 
-Cross-platform accessibility library for reading and interacting with accessibility trees.
+[![Crates.io](https://img.shields.io/crates/v/xa11y)](https://crates.io/crates/xa11y)
+[![PyPI](https://img.shields.io/pypi/v/xa11y)](https://pypi.org/project/xa11y/)
+[![CI](https://github.com/xa11y/xa11y/actions/workflows/ci.yml/badge.svg)](https://github.com/xa11y/xa11y/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
 
-## Quick Start
+Cross-platform accessibility library for reading and interacting with accessibility trees. One API for macOS, Windows, and Linux.
+
+**Use cases:** UI testing, AI agent tooling, assistive technology, desktop automation.
+
+**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
+
+## Quick Example
+
+<!-- rust-only -->
+```rust
+use xa11y::*;
+
+fn main() -> Result<()> {
+    let provider = create_provider()?;
+
+    // Get the accessibility tree for an app
+    let tree = provider.get_app_tree(
+        &AppTarget::ByName("Safari".to_string()),
+        &QueryOptions::default(),
+    )?;
+
+    // Find elements with CSS-like selectors
+    let buttons = tree.query("button[name='Submit']")?;
+    println!("Found {} buttons", buttons.len());
+
+    // Interact with elements
+    let submit = Locator::new(&*provider, AppTarget::ByName("Safari".to_string()), "button[name='Submit']");
+    submit.press()?;
+
+    Ok(())
+}
+```
+<!-- /rust-only -->
+
+<!-- python-only -->
+```python
+import xa11y
+
+# Get the accessibility tree for an app
+tree = xa11y.app("Safari")
+
+# Find elements with CSS-like selectors
+for button in tree.query("button"):
+    print(button.name)
+
+# Interact with elements
+tree.press("button[name='Submit']")
+
+search = tree.locator("textfield[name^='Search']")
+search.set_value("hello world")
+```
+<!-- /python-only -->
+
+## Installation
+
+<!-- rust-only -->
+```toml
+[dependencies]
+xa11y = "0.2"
+```
+<!-- /rust-only -->
+
+<!-- python-only -->
+```bash
+pip install xa11y
+```
+
+Requires Python 3.9+. Pre-built wheels available for Linux, macOS, and Windows.
+<!-- /python-only -->
+
+> **macOS:** Grant accessibility permissions to your terminal in **System Settings > Privacy & Security > Accessibility**.
+>
+> **Linux:** AT-SPI2 must be running (default on GNOME/most DEs). No special permissions needed.
+>
+> **Windows:** No special permissions needed.
+
+## Selector Syntax
+
+Query accessibility trees with CSS-like selectors:
+
+| Pattern | Meaning |
+| --- | --- |
+| `button` | Elements with role Button |
+| `button[name='OK']` | Button named exactly "OK" |
+| `textfield[name^='Search']` | Text field whose name starts with "Search" |
+| `textfield[name*='email']` | Text field whose name contains "email" |
+| `group > button` | Buttons that are direct children of a group |
+| `window button` | Buttons anywhere inside a window |
+| `button:nth(2)` | The 2nd button match |
+
+## Supported Actions
+
+| Action | Description |
+| --- | --- |
+| `press` | Click / activate |
+| `focus` / `blur` | Move or remove keyboard focus |
+| `toggle` | Toggle a checkbox or switch |
+| `expand` / `collapse` | Expand or collapse a disclosure |
+| `select` | Select an item |
+| `set_value` | Set a text field's value |
+| `type_text` | Type text into an element |
+| `increment` / `decrement` | Adjust a slider or stepper |
+| `scroll` | Scroll in a direction |
+| `show_menu` | Open a context menu |
+
+## Platform Support
+
+| Platform | Backend |
+| --- | --- |
+| macOS | AXUIElement |
+| Linux | AT-SPI2 (D-Bus) |
+| Windows | UI Automation |
+
+## Contributing
 
 ```bash
+git clone https://github.com/xa11y/xa11y && cd xa11y
 cargo build --workspace
-cargo xtask test              # unit tests
-cargo xtask check             # all pre-PR checks (fmt, lint, test, python)
+cargo xtask check   # fmt, lint, test, python bindings
 ```
 
-## Development Commands
-
-All workflow commands are available via `cargo xtask`:
-
-```bash
-cargo xtask fmt               # format Rust + Python
-cargo xtask lint              # clippy + ruff
-cargo xtask test              # unit tests
-cargo xtask test-python       # build + test Python bindings
-cargo xtask test-integ        # integration tests (auto-detects OS)
-cargo xtask test-integ-container              # Linux tests via Finch container
-cargo xtask test-integ-container tree_has_buttons  # single test
-cargo xtask fuzz              # provider fuzzer
-cargo xtask coverage          # code coverage report
-cargo xtask docs              # build documentation
-cargo xtask check             # ALL pre-PR checks
-```
-
-## Project Structure
-
-- `xa11y-core/` — Platform-independent types, traits, selector engine
-- `xa11y-linux/` — AT-SPI2 backend via zbus
-- `xa11y-macos/` — macOS backend (AXUIElement)
-- `xa11y-windows/` — Windows backend (stub)
-- `xa11y/` — Umbrella crate with unit + integration tests
-- `xa11y-test-app/` — AccessKit + winit test application
-- `xa11y-fuzz/` — Fuzz targets for xa11y-core
+See the [development docs](https://xa11y.dev/guides/overview/) for architecture and setup.
 
 ## License
 
-All dependencies are permissively licensed (MIT, Apache-2.0, BSD, or similar). License compliance is enforced in CI via `cargo-deny`.
+MIT. All dependencies are permissively licensed (MIT, Apache-2.0, BSD, or similar), enforced via `cargo-deny`.

--- a/xa11y-python/pyproject.toml
+++ b/xa11y-python/pyproject.toml
@@ -7,6 +7,7 @@ name = "xa11y"
 requires-python = ">=3.9"
 dynamic = ["version"]
 description = "Cross-platform accessibility client library"
+readme = "README.md"
 license = "MIT"
 keywords = ["accessibility", "a11y", "automation", "screen-reader"]
 classifiers = [

--- a/xa11y/Cargo.toml
+++ b/xa11y/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Cross-platform accessibility client library — unified API for reading and interacting with accessibility trees"
+readme = "README.md"
 
 [dependencies]
 xa11y-core = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fs;
 use std::process::{Command, ExitCode};
 
 const HELP: &str = "\
@@ -17,6 +18,7 @@ COMMANDS:
     docs                Build documentation
     coverage            Generate code coverage report
     fuzz [ARGS..]       Run provider fuzzer (pass-through args)
+    sync-readmes        Generate crates.io/PyPI READMEs from root README.md
     check               Run ALL pre-PR checks (fmt, lint, test, test-python, docs)
     help                Show this help
 ";
@@ -36,6 +38,7 @@ fn main() -> ExitCode {
         "docs" => do_docs(),
         "coverage" => do_coverage(),
         "fuzz" => do_fuzz(rest),
+        "sync-readmes" => do_sync_readmes(),
         "check" => do_check(),
         "help" | "--help" | "-h" => {
             print!("{HELP}");
@@ -226,6 +229,73 @@ fn do_fuzz(args: &[String]) -> bool {
     let mut cmd_args = vec!["scripts/run_provider_fuzz.sh"];
     cmd_args.extend(&str_args);
     run("bash", &cmd_args)
+}
+
+fn do_sync_readmes() -> bool {
+    heading("Sync READMEs");
+    let root = project_root();
+    let source = match fs::read_to_string(root.join("README.md")) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Failed to read README.md: {e}");
+            return false;
+        }
+    };
+
+    let targets: &[(&str, &str)] = &[
+        ("rust", "xa11y/README.md"),
+        ("python", "xa11y-python/README.md"),
+    ];
+
+    let mut ok = true;
+    for &(keep, dest) in targets {
+        let remove = if keep == "rust" { "python" } else { "rust" };
+        let text = strip_lang_blocks(&source, keep, remove);
+
+        let path = root.join(dest);
+        if let Err(e) = fs::write(&path, &text) {
+            eprintln!("Failed to write {dest}: {e}");
+            ok = false;
+        } else {
+            eprintln!("Wrote {dest}");
+        }
+    }
+    ok
+}
+
+/// Remove `<!-- {remove}-only -->...<!-- /{remove}-only -->` blocks entirely,
+/// and unwrap `<!-- {keep}-only -->...<!-- /{keep}-only -->` markers (keeping content).
+fn strip_lang_blocks(source: &str, keep: &str, remove: &str) -> String {
+    let open_remove = format!("<!-- {remove}-only -->\n");
+    let close_remove = format!("<!-- /{remove}-only -->\n");
+    let open_keep = format!("<!-- {keep}-only -->\n");
+    let close_keep = format!("<!-- /{keep}-only -->\n");
+
+    // Remove the other language's blocks
+    let mut result = String::with_capacity(source.len());
+    let mut rest = source;
+    while let Some(start) = rest.find(&open_remove) {
+        result.push_str(&rest[..start]);
+        rest = &rest[start + open_remove.len()..];
+        if let Some(end) = rest.find(&close_remove) {
+            rest = &rest[end + close_remove.len()..];
+        } else {
+            // Unclosed marker — keep the rest as-is
+            break;
+        }
+    }
+    result.push_str(rest);
+
+    // Unwrap the kept language's markers
+    result = result.replace(&open_keep, "");
+    result = result.replace(&close_keep, "");
+
+    // Collapse triple+ blank lines
+    while result.contains("\n\n\n") {
+        result = result.replace("\n\n\n", "\n\n");
+    }
+
+    result
 }
 
 fn do_check() -> bool {


### PR DESCRIPTION
Root README.md is the single source of truth with <!-- rust-only --> and <!-- python-only --> comment markers. `cargo xtask sync-readmes` strips the irrelevant blocks to generate xa11y/README.md (crates.io) and xa11y-python/README.md (PyPI). Generated files are gitignored and produced on-demand during publishing.