### PR TITLE
Replace EmbarkStudios/cargo-deny-action with direct cargo-deny install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check licenses
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Check licenses
+        run: cargo deny check licenses
 
   # ── Cross-compilation ──────────────────────────────────────────────
   # Verifies xa11y-core compiles for targets we can't run tests on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache cargo-deny binary
+        id: cache-cargo-deny
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-deny
+          key: cargo-deny-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install cargo-deny
+        if: steps.cache-cargo-deny.outputs.cache-hit != 'true'
         run: cargo install cargo-deny --locked
 
       - name: Check licenses


### PR DESCRIPTION
Removes the external GitHub action dependency for license checking and
instead installs cargo-deny directly via cargo install, then runs it inline.

https://claude.ai/code/session_01XR8Nwe3EeNpC9LdK8jXseb