### PR TITLE
Simplify API to DOM-like Nodes + Locators

### DIFF
--- a/xa11y-core/src/error.rs
+++ b/xa11y-core/src/error.rs
@@ -44,6 +44,10 @@ pub enum Error {
     #[error("Invalid action data: {message}")]
     InvalidActionData { message: String },
 
+    /// The node is detached (no provider) — cannot perform queries or actions.
+    #[error("Node is detached: no provider available for queries or actions")]
+    Detached,
+
     /// A platform-specific error occurred.
     #[error("Platform error ({code}): {message}")]
     Platform { code: i64, message: String },

--- a/xa11y-core/src/event.rs
+++ b/xa11y-core/src/event.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::node::Node;
+use crate::node::RawNode;
 use crate::provider::AppInfo;
 
 /// Categories of accessibility events, normalized across platforms.
@@ -49,7 +49,7 @@ pub struct Event {
     /// The application that produced this event.
     pub app: AppInfo,
     /// A snapshot of the element that triggered the event, if available.
-    pub target: Option<Node>,
+    pub target: Option<RawNode>,
     /// For StateChanged events: which state flag changed.
     pub state_flag: Option<StateFlag>,
     /// For StateChanged events: the new value of the flag.
@@ -172,7 +172,7 @@ impl ElementState {
     /// Evaluate whether the condition is met for the given node.
     ///
     /// `node` is `None` when no element matched the selector.
-    pub fn is_met(self, node: Option<&Node>) -> bool {
+    pub fn is_met(self, node: Option<&RawNode>) -> bool {
         match self {
             Self::Attached => node.is_some(),
             Self::Detached => node.is_none(),

--- a/xa11y-core/src/event_provider.rs
+++ b/xa11y-core/src/event_provider.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::error::Result;
 use crate::event::{ElementState, Event, EventFilter};
-use crate::node::Node;
+use crate::node::RawNode;
 use crate::provider::{AppTarget, Provider};
 
 /// Optional trait for backends that support event subscriptions.
@@ -28,7 +28,7 @@ pub trait EventProvider: Provider {
         selector: &str,
         state: ElementState,
         timeout: Duration,
-    ) -> Result<Node>;
+    ) -> Result<RawNode>;
 }
 
 /// A live event subscription. Drop to unsubscribe.

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -17,7 +17,9 @@ pub use event::{
 };
 pub use event_provider::{CancelHandle, EventProvider, EventReceiver, Subscription};
 pub use locator::Locator;
-pub use node::{Node, RawPlatformData, Rect, StateSet, Toggled};
-pub use provider::{AppInfo, AppTarget, PermissionStatus, Provider, QueryOptions, WindowHandle};
+pub use node::{Node, RawNode, RawPlatformData, Rect, StateSet, Toggled, TreeData};
+pub use provider::{
+    AppInfo, AppTarget, PermissionStatus, Provider, ProviderExt, QueryOptions, WindowHandle,
+};
 pub use role::Role;
 pub use tree::Tree;

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 use crate::action::{Action, ActionData, ScrollDirection};
 use crate::error::{Error, Result};
 use crate::event::ElementState;
-use crate::node::{Node, Rect, StateSet};
+use crate::node::{Node, RawNode, Rect, StateSet, TreeData};
 use crate::provider::{AppTarget, Provider, QueryOptions};
 use crate::role::Role;
-use crate::tree::Tree;
+use crate::selector::Selector;
 
 /// A lazy element descriptor that re-resolves against a fresh accessibility
 /// tree snapshot on every operation.
@@ -39,11 +39,15 @@ pub struct Locator {
     nth: Option<usize>,
 }
 
-/// Snapshot produced by a single resolve call.
-/// Bundles the tree and the index of the matched node so that callers
-/// can use both without lifetime issues.
+/// Snapshot produced by a single resolve call (wraps in Arc<TreeData>).
 struct Resolved {
-    tree: Tree,
+    data: Arc<TreeData>,
+    node_index: u32,
+}
+
+/// Raw resolution for action dispatch (avoids Arc wrapping).
+struct ResolvedRaw {
+    tree: crate::tree::Tree,
     node_index: u32,
 }
 
@@ -81,12 +85,6 @@ impl Locator {
         self
     }
 
-    /// Return a new Locator that selects the first match.
-    /// Equivalent to `.nth(0)` — mainly for readability.
-    pub fn first(self) -> Self {
-        self.nth(0)
-    }
-
     /// Return a new Locator scoped to a direct child matching `child_selector`.
     ///
     /// Appends ` > {child_selector}` to the current selector.
@@ -115,77 +113,92 @@ impl Locator {
     /// Snapshot the tree and resolve the selector to a single node.
     fn resolve(&self) -> Result<Resolved> {
         let tree = self.provider.get_app_tree(&self.target, &self.opts)?;
-        let matches = tree.query(&self.selector)?;
+        let data = Arc::new(TreeData {
+            app_name: tree.app_name,
+            pid: tree.pid,
+            screen_size: tree.screen_size,
+            nodes: tree.nodes,
+            provider: Some(Arc::clone(&self.provider)),
+            target: Some(self.target.clone()),
+        });
+
+        let selector = Selector::parse(&self.selector)?;
+        let matches = selector.match_raw_nodes(&data.nodes);
         let idx = self.nth.unwrap_or(0);
-        let node = matches.get(idx).ok_or_else(|| Error::SelectorNotMatched {
+        let &node_index = matches.get(idx).ok_or_else(|| Error::SelectorNotMatched {
             selector: self.selector.clone(),
         })?;
-        Ok(Resolved {
-            node_index: node.index,
-            tree,
-        })
+        Ok(Resolved { data, node_index })
     }
 
-    /// Resolve and return a clone of the matched node.
-    /// This is the safe way to get node data out without lifetime issues.
+    /// Resolve for action dispatch (returns raw Tree, no Arc wrapping).
+    fn resolve_raw(&self) -> Result<ResolvedRaw> {
+        let tree = self.provider.get_app_tree(&self.target, &self.opts)?;
+        let selector = Selector::parse(&self.selector)?;
+        let matches = selector.match_raw_nodes(&tree.nodes);
+        let idx = self.nth.unwrap_or(0);
+        let &node_index = matches.get(idx).ok_or_else(|| Error::SelectorNotMatched {
+            selector: self.selector.clone(),
+        })?;
+        Ok(ResolvedRaw { tree, node_index })
+    }
+
+    /// Resolve and return a Node cursor for the matched element.
     fn resolve_node(&self) -> Result<Node> {
         let r = self.resolve()?;
-        Ok(r.tree
-            .get(r.node_index)
-            .expect("node_index valid after resolve")
-            .clone())
+        Ok(Node::new(r.data, r.node_index))
     }
 
     // ── Queries (each takes a fresh snapshot) ───────────────────────
 
     /// Get the matched element's role.
     pub fn role(&self) -> Result<Role> {
-        Ok(self.resolve_node()?.role)
+        Ok(self.resolve_node()?.role())
     }
 
     /// Get the matched element's name.
     pub fn name(&self) -> Result<Option<String>> {
-        Ok(self.resolve_node()?.name)
+        Ok(self.resolve_node()?.name().map(|s| s.to_string()))
     }
 
     /// Get the matched element's value.
     pub fn value(&self) -> Result<Option<String>> {
-        Ok(self.resolve_node()?.value)
+        Ok(self.resolve_node()?.value().map(|s| s.to_string()))
     }
 
     /// Get the matched element's description.
     pub fn description(&self) -> Result<Option<String>> {
-        Ok(self.resolve_node()?.description)
+        Ok(self.resolve_node()?.description().map(|s| s.to_string()))
     }
 
     /// Get the matched element's bounding rectangle.
     pub fn bounds(&self) -> Result<Option<Rect>> {
-        Ok(self.resolve_node()?.bounds)
+        Ok(self.resolve_node()?.bounds())
     }
 
     /// Get the matched element's state flags.
     pub fn states(&self) -> Result<StateSet> {
-        Ok(self.resolve_node()?.states)
+        Ok(self.resolve_node()?.states().clone())
     }
 
     /// Get the matched element's numeric value (for range controls).
     pub fn numeric_value(&self) -> Result<Option<f64>> {
-        Ok(self.resolve_node()?.numeric_value)
+        Ok(self.resolve_node()?.numeric_value())
     }
 
     /// Check if the matched element is visible.
     pub fn is_visible(&self) -> Result<bool> {
-        Ok(self.resolve_node()?.states.visible)
+        Ok(self.resolve_node()?.states().visible)
     }
 
     /// Check if the matched element is enabled.
     pub fn is_enabled(&self) -> Result<bool> {
-        Ok(self.resolve_node()?.states.enabled)
+        Ok(self.resolve_node()?.states().enabled)
     }
 
     /// Check if the matched element is focused.
     pub fn is_focused(&self) -> Result<bool> {
-        Ok(self.resolve_node()?.states.focused)
+        Ok(self.resolve_node()?.states().focused)
     }
 
     /// Check if a matching element exists in the current tree.
@@ -200,13 +213,34 @@ impl Locator {
     /// Count matching elements in the current tree.
     pub fn count(&self) -> Result<usize> {
         let tree = self.provider.get_app_tree(&self.target, &self.opts)?;
-        let matches = tree.query(&self.selector)?;
+        let selector = Selector::parse(&self.selector)?;
+        let matches = selector.match_raw_nodes(&tree.nodes);
         Ok(matches.len())
     }
 
-    /// Get a clone of the matched node from a fresh snapshot.
-    pub fn get(&self) -> Result<Node> {
+    /// Resolve and return the first matching element as a [`Node`] snapshot.
+    pub fn first(&self) -> Result<Node> {
         self.resolve_node()
+    }
+
+    /// Resolve and return all matching elements as [`Node`] snapshots.
+    pub fn all(&self) -> Result<Vec<Node>> {
+        let tree = self.provider.get_app_tree(&self.target, &self.opts)?;
+        let data = Arc::new(TreeData {
+            app_name: tree.app_name,
+            pid: tree.pid,
+            screen_size: tree.screen_size,
+            nodes: tree.nodes,
+            provider: Some(Arc::clone(&self.provider)),
+            target: Some(self.target.clone()),
+        });
+
+        let selector = Selector::parse(&self.selector)?;
+        let indices = selector.match_raw_nodes(&data.nodes);
+        Ok(indices
+            .into_iter()
+            .map(|idx| Node::new(Arc::clone(&data), idx))
+            .collect())
     }
 
     // ── Actions (each takes a fresh snapshot) ───────────────────────
@@ -216,12 +250,9 @@ impl Locator {
         if let Some(ref d) = data {
             d.validate(action)?;
         }
-        let r = self.resolve()?;
-        let node = r
-            .tree
-            .get(r.node_index)
-            .expect("node_index valid after resolve");
-        self.provider.perform_action(&r.tree, node, action, data)
+        let r = self.resolve_raw()?;
+        self.provider
+            .perform_action_raw(&r.tree, r.node_index, action, data)
     }
 
     /// Click / invoke the matched element.
@@ -303,8 +334,6 @@ impl Locator {
     }
 
     /// Scroll the matched element upward.
-    ///
-    /// `amount` is in logical scroll units (≈ one mouse wheel notch).
     pub fn scroll_up(&self, amount: f64) -> Result<()> {
         self.perform(
             Action::Scroll,
@@ -316,8 +345,6 @@ impl Locator {
     }
 
     /// Scroll the matched element downward.
-    ///
-    /// `amount` is in logical scroll units (≈ one mouse wheel notch).
     pub fn scroll_down(&self, amount: f64) -> Result<()> {
         self.perform(
             Action::Scroll,
@@ -329,8 +356,6 @@ impl Locator {
     }
 
     /// Scroll the matched element leftward.
-    ///
-    /// `amount` is in logical scroll units (≈ one mouse wheel notch).
     pub fn scroll_left(&self, amount: f64) -> Result<()> {
         self.perform(
             Action::Scroll,
@@ -342,8 +367,6 @@ impl Locator {
     }
 
     /// Scroll the matched element rightward.
-    ///
-    /// `amount` is in logical scroll units (≈ one mouse wheel notch).
     pub fn scroll_right(&self, amount: f64) -> Result<()> {
         self.perform(
             Action::Scroll,
@@ -357,9 +380,6 @@ impl Locator {
     // ── Wait operations ─────────────────────────────────────────────
 
     /// Wait until the element is visible, polling with fresh snapshots.
-    ///
-    /// If the provider implements `EventProvider`, delegates to its
-    /// `wait_for` method. Otherwise, polls at ~100ms intervals.
     pub fn wait_visible(&self, timeout: Duration) -> Result<Node> {
         self.wait_for_state(ElementState::Visible, timeout)
     }
@@ -407,37 +427,20 @@ impl Locator {
     /// Wait until an arbitrary predicate is satisfied, polling with fresh
     /// snapshots at ~100 ms intervals.
     ///
-    /// The predicate receives `Some(&Node)` when the selector matches, or
+    /// The predicate receives `Some(&RawNode)` when the selector matches, or
     /// `None` when no element matches. Return `true` to stop waiting.
-    ///
-    /// # Example
-    /// ```no_run
-    /// # use xa11y_core::*;
-    /// # use std::time::Duration;
-    /// # fn example(loc: &Locator) -> Result<()> {
-    /// // Wait until the element's value becomes "Done":
-    /// let node = loc.wait_until(
-    ///     |n| n.is_some_and(|n| n.value.as_deref() == Some("Done")),
-    ///     Duration::from_secs(5),
-    /// )?;
-    /// # Ok(())
-    /// # }
-    /// ```
     pub fn wait_until(
         &self,
-        predicate: impl Fn(Option<&Node>) -> bool,
+        predicate: impl Fn(Option<&RawNode>) -> bool,
         timeout: Duration,
     ) -> Result<Node> {
         self.poll_until(&predicate, false, timeout)
     }
 
     /// Core polling loop shared by `wait_for_state` and `wait_until`.
-    ///
-    /// `allow_absent`: when true, the condition can be satisfied even when no
-    /// node matches (used for Detached/Hidden states).
     fn poll_until(
         &self,
-        predicate: impl Fn(Option<&Node>) -> bool,
+        predicate: impl Fn(Option<&RawNode>) -> bool,
         allow_absent: bool,
         timeout: Duration,
     ) -> Result<Node> {
@@ -451,15 +454,44 @@ impl Locator {
             }
 
             let tree = self.provider.get_app_tree(&self.target, &self.opts)?;
-            let matches = tree.query(&self.selector).ok();
+            let selector = Selector::parse(&self.selector).ok();
+            let matches = selector.as_ref().map(|s| s.match_raw_nodes(&tree.nodes));
             let idx = self.nth.unwrap_or(0);
-            let node = matches.as_ref().and_then(|m| m.get(idx).copied());
+            let node_index = matches.as_ref().and_then(|m| m.get(idx).copied());
+            let node = node_index.and_then(|i| tree.nodes.get(i as usize));
 
             if predicate(node) {
+                let data = Arc::new(TreeData {
+                    app_name: tree.app_name,
+                    pid: tree.pid,
+                    screen_size: tree.screen_size,
+                    nodes: tree.nodes,
+                    provider: Some(Arc::clone(&self.provider)),
+                    target: Some(self.target.clone()),
+                });
+
                 return if allow_absent {
-                    Ok(node.cloned().unwrap_or_else(Node::synthetic_empty))
+                    Ok(node_index
+                        .map(|idx| Node::new(Arc::clone(&data), idx))
+                        .unwrap_or_else(|| {
+                            // Can't mutate Arc'd data, so create a standalone node
+                            Node::new(
+                                Arc::new(TreeData {
+                                    app_name: data.app_name.clone(),
+                                    pid: data.pid,
+                                    screen_size: data.screen_size,
+                                    nodes: vec![RawNode::synthetic_empty()],
+                                    provider: Some(Arc::clone(&self.provider)),
+                                    target: Some(self.target.clone()),
+                                }),
+                                0,
+                            )
+                        }))
                 } else {
-                    Ok(node.expect("predicate requires node to exist").clone())
+                    Ok(Node::new(
+                        data,
+                        node_index.expect("predicate requires node to exist"),
+                    ))
                 };
             }
 

--- a/xa11y-core/src/node.rs
+++ b/xa11y-core/src/node.rs
@@ -1,17 +1,54 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 
-use crate::action::Action;
+use crate::action::{Action, ActionData, ScrollDirection};
+use crate::error::{Error, Result};
+use crate::provider::{AppTarget, Provider, QueryOptions};
 use crate::role::Role;
+use crate::selector::Selector;
 
 /// Internal index for a node within a snapshot (sequential DFS order).
 /// This is an array index, not a stable identity — it changes between snapshots.
-/// Internal index type for node positions within a snapshot.
 #[doc(hidden)]
 pub type NodeIndex = u32;
 
-/// A single element in the accessibility tree snapshot.
+// ── TreeData ────────────────────────────────────────────────────────────────
+
+/// Internal shared snapshot data backing all `Node` cursors from the same snapshot.
+pub struct TreeData {
+    /// Application name
+    pub app_name: String,
+    /// Process ID. `None` for multi-app snapshots.
+    pub pid: Option<u32>,
+    /// Screen dimensions at capture time (width, height)
+    pub screen_size: (u32, u32),
+    /// All raw nodes in DFS order
+    pub nodes: Vec<RawNode>,
+    /// Provider for re-fetching and actions. `None` for detached/deserialized snapshots.
+    pub provider: Option<Arc<dyn Provider>>,
+    /// App target for re-fetching. `None` for multi-app or detached snapshots.
+    pub target: Option<AppTarget>,
+}
+
+impl std::fmt::Debug for TreeData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TreeData")
+            .field("app_name", &self.app_name)
+            .field("pid", &self.pid)
+            .field("nodes_len", &self.nodes.len())
+            .finish()
+    }
+}
+
+// ── RawNode (the data struct, formerly Node) ────────────────────────────────
+
+/// Raw node data within an accessibility tree snapshot.
+///
+/// This is the internal data representation. Most consumers should use [`Node`]
+/// (a cursor that provides navigation, queries, and actions).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Node {
+pub struct RawNode {
     /// Element role
     pub role: Role,
 
@@ -53,12 +90,14 @@ pub struct Node {
     /// Platform-specific raw data
     pub raw: RawPlatformData,
 
+    /// Process ID. Populated for Application-role nodes.
+    pub pid: Option<u32>,
+
+    /// macOS bundle identifier. Populated for Application-role nodes.
+    pub bundle_id: Option<String>,
+
     // ── Internal fields ──────────────────────────────────────────────────────
-    // Present in serialized output for FFI consumers (Python, JS, LLMs),
-    // but not part of the Rust public API.
     /// Sequential DFS index within the snapshot.
-    /// Internal — present in serialized output for FFI consumers,
-    /// but not intended as part of the primary Rust API.
     #[doc(hidden)]
     pub index: NodeIndex,
 
@@ -71,7 +110,7 @@ pub struct Node {
     pub parent_index: Option<NodeIndex>,
 }
 
-impl Node {
+impl RawNode {
     /// Create a synthetic empty node, used as a placeholder when a wait
     /// condition is satisfied by the *absence* of a node (e.g. Detached/Hidden).
     pub fn synthetic_empty() -> Self {
@@ -88,12 +127,463 @@ impl Node {
             max_value: None,
             stable_id: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 0,
             children_indices: vec![],
             parent_index: None,
         }
     }
 }
+
+// ── Node (public cursor) ────────────────────────────────────────────────────
+
+/// An element in the accessibility tree.
+///
+/// `Node` is a cursor into a shared snapshot. Property access and navigation
+/// (`children`, `parent`) read from the snapshot — fast, no IPC.
+/// [`query()`](Node::query) and action methods (`press()`, `focus()`, etc.)
+/// take a fresh snapshot from the OS.
+///
+/// # Example
+/// ```no_run
+/// # fn example(node: xa11y_core::Node) -> xa11y_core::Result<()> {
+/// // Navigate snapshot (fast, no IPC)
+/// for child in node.children() {
+///     println!("{}: {:?}", child.role().to_snake_case(), child.name());
+/// }
+/// // Query re-fetches from OS
+/// let buttons = node.query("button")?;
+/// // Actions auto-refresh
+/// buttons[0].press()?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct Node {
+    data: Arc<TreeData>,
+    index: u32,
+}
+
+impl std::fmt::Debug for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let raw = self.raw_node();
+        f.debug_struct("Node")
+            .field("role", &raw.role)
+            .field("name", &raw.name)
+            .field("index", &self.index)
+            .finish()
+    }
+}
+
+impl Node {
+    /// Create a Node cursor from shared tree data and an index.
+    pub fn new(data: Arc<TreeData>, index: u32) -> Self {
+        Self { data, index }
+    }
+
+    /// Access the underlying raw node data.
+    pub fn raw_node(&self) -> &RawNode {
+        &self.data.nodes[self.index as usize]
+    }
+
+    /// Access the underlying shared tree data.
+    pub fn tree_data(&self) -> &Arc<TreeData> {
+        &self.data
+    }
+
+    /// Get the node's DFS index within its snapshot.
+    #[doc(hidden)]
+    pub fn node_index(&self) -> u32 {
+        self.index
+    }
+
+    // ── Properties (read from snapshot — fast, no IPC) ──────────────────
+
+    /// Element role.
+    pub fn role(&self) -> Role {
+        self.raw_node().role
+    }
+
+    /// Human-readable name (title, label).
+    pub fn name(&self) -> Option<&str> {
+        self.raw_node().name.as_deref()
+    }
+
+    /// Current value (text content, slider position, etc.).
+    pub fn value(&self) -> Option<&str> {
+        self.raw_node().value.as_deref()
+    }
+
+    /// Supplementary description (tooltip, help text).
+    pub fn description(&self) -> Option<&str> {
+        self.raw_node().description.as_deref()
+    }
+
+    /// Bounding rectangle in screen pixels.
+    pub fn bounds(&self) -> Option<Rect> {
+        self.raw_node().bounds
+    }
+
+    /// Available actions.
+    pub fn actions_list(&self) -> &[Action] {
+        &self.raw_node().actions
+    }
+
+    /// Current state flags.
+    pub fn states(&self) -> &StateSet {
+        &self.raw_node().states
+    }
+
+    /// Numeric value for range controls.
+    pub fn numeric_value(&self) -> Option<f64> {
+        self.raw_node().numeric_value
+    }
+
+    /// Minimum value for range controls.
+    pub fn min_value(&self) -> Option<f64> {
+        self.raw_node().min_value
+    }
+
+    /// Maximum value for range controls.
+    pub fn max_value(&self) -> Option<f64> {
+        self.raw_node().max_value
+    }
+
+    /// Platform-assigned stable identifier for cross-snapshot correlation.
+    pub fn stable_id(&self) -> Option<&str> {
+        self.raw_node().stable_id.as_deref()
+    }
+
+    /// Platform-specific raw data.
+    pub fn raw_platform_data(&self) -> &RawPlatformData {
+        &self.raw_node().raw
+    }
+
+    /// Process ID. Populated for Application-role nodes.
+    pub fn pid(&self) -> Option<u32> {
+        self.raw_node().pid.or(self.data.pid)
+    }
+
+    /// macOS bundle identifier. Populated for Application-role nodes.
+    pub fn bundle_id(&self) -> Option<&str> {
+        self.raw_node().bundle_id.as_deref()
+    }
+
+    /// Application name (from the snapshot metadata).
+    pub fn app_name(&self) -> &str {
+        &self.data.app_name
+    }
+
+    /// Screen dimensions at capture time.
+    pub fn screen_size(&self) -> (u32, u32) {
+        self.data.screen_size
+    }
+
+    // ── Navigation (read from snapshot — fast, no IPC) ──────────────────
+
+    /// Direct children of this node.
+    pub fn children(&self) -> Vec<Node> {
+        self.raw_node()
+            .children_indices
+            .iter()
+            .map(|&idx| Node::new(Arc::clone(&self.data), idx))
+            .collect()
+    }
+
+    /// Parent of this node, if any (root has no parent).
+    pub fn parent(&self) -> Option<Node> {
+        self.raw_node()
+            .parent_index
+            .map(|idx| Node::new(Arc::clone(&self.data), idx))
+    }
+
+    /// All descendants of this node (including itself), in DFS order.
+    pub fn subtree(&self) -> Vec<Node> {
+        let mut result = Vec::new();
+        self.collect_subtree(self.index, &mut result);
+        result
+    }
+
+    fn collect_subtree(&self, index: u32, result: &mut Vec<Node>) {
+        if let Some(raw) = self.data.nodes.get(index as usize) {
+            result.push(Node::new(Arc::clone(&self.data), index));
+            for &child_idx in &raw.children_indices {
+                self.collect_subtree(child_idx, result);
+            }
+        }
+    }
+
+    /// Number of nodes in this node's subtree (including itself).
+    pub fn subtree_size(&self) -> usize {
+        fn count(nodes: &[RawNode], index: u32) -> usize {
+            let Some(raw) = nodes.get(index as usize) else {
+                return 0;
+            };
+            1 + raw
+                .children_indices
+                .iter()
+                .map(|&idx| count(nodes, idx))
+                .sum::<usize>()
+        }
+        count(&self.data.nodes, self.index)
+    }
+
+    // ── Query (re-fetches fresh tree from OS) ───────────────────────────
+
+    /// Query for elements matching a CSS-like selector within this node's app.
+    ///
+    /// **Takes a fresh snapshot** from the OS, then runs the selector.
+    /// Returns nodes from the fresh snapshot.
+    pub fn query(&self, selector_str: &str) -> Result<Vec<Node>> {
+        let provider = self.data.provider.as_ref().ok_or(Error::Detached)?;
+        let target = self.data.target.as_ref().ok_or(Error::Detached)?;
+
+        let tree = provider.get_app_tree(target, &QueryOptions::default())?;
+        let data = Arc::new(TreeData {
+            app_name: tree.app_name.clone(),
+            pid: tree.pid,
+            screen_size: tree.screen_size,
+            nodes: tree.nodes,
+            provider: Some(Arc::clone(provider)),
+            target: Some(target.clone()),
+        });
+
+        let selector = Selector::parse(selector_str)?;
+        let indices = selector.match_raw_nodes(&data.nodes);
+        Ok(indices
+            .into_iter()
+            .map(|idx| Node::new(Arc::clone(&data), idx))
+            .collect())
+    }
+
+    /// Create a [`Locator`](crate::locator::Locator) scoped to this node's app.
+    pub fn locator(&self, selector: &str) -> Result<crate::locator::Locator> {
+        let provider = self.data.provider.as_ref().ok_or(Error::Detached)?;
+        let target = self.data.target.as_ref().ok_or(Error::Detached)?;
+
+        Ok(crate::locator::Locator::new(
+            Arc::clone(provider),
+            target.clone(),
+            selector,
+        ))
+    }
+
+    // ── Actions (re-fetch + re-locate + act) ────────────────────────────
+
+    /// Re-fetch the tree, re-locate this node, and perform an action.
+    fn perform_action_impl(&self, action: Action, data: Option<ActionData>) -> Result<()> {
+        if let Some(ref d) = data {
+            d.validate(action)?;
+        }
+        let provider = self.data.provider.as_ref().ok_or(Error::Detached)?;
+        let target = self.data.target.as_ref().ok_or(Error::Detached)?;
+
+        let tree = provider.get_app_tree(target, &QueryOptions::default())?;
+        let fresh_index = relocate_node(self.raw_node(), &tree.nodes)?;
+        provider.perform_action_raw(&tree, fresh_index, action, data)
+    }
+
+    /// Click / invoke this element.
+    pub fn press(&self) -> Result<()> {
+        self.perform_action_impl(Action::Press, None)
+    }
+
+    /// Set keyboard focus on this element.
+    pub fn focus(&self) -> Result<()> {
+        self.perform_action_impl(Action::Focus, None)
+    }
+
+    /// Toggle this element (checkbox, switch).
+    pub fn toggle(&self) -> Result<()> {
+        self.perform_action_impl(Action::Toggle, None)
+    }
+
+    /// Select this element (list item, etc.).
+    pub fn select(&self) -> Result<()> {
+        self.perform_action_impl(Action::Select, None)
+    }
+
+    /// Expand this element.
+    pub fn expand(&self) -> Result<()> {
+        self.perform_action_impl(Action::Expand, None)
+    }
+
+    /// Collapse this element.
+    pub fn collapse(&self) -> Result<()> {
+        self.perform_action_impl(Action::Collapse, None)
+    }
+
+    /// Set the text value of this element.
+    pub fn set_value(&self, value: &str) -> Result<()> {
+        self.perform_action_impl(Action::SetValue, Some(ActionData::Value(value.to_string())))
+    }
+
+    /// Set the numeric value of this element (slider, spinner).
+    pub fn set_numeric_value(&self, value: f64) -> Result<()> {
+        self.perform_action_impl(Action::SetValue, Some(ActionData::NumericValue(value)))
+    }
+
+    /// Increment this element (slider, spinner).
+    pub fn increment(&self) -> Result<()> {
+        self.perform_action_impl(Action::Increment, None)
+    }
+
+    /// Decrement this element (slider, spinner).
+    pub fn decrement(&self) -> Result<()> {
+        self.perform_action_impl(Action::Decrement, None)
+    }
+
+    /// Show the context menu for this element.
+    pub fn show_menu(&self) -> Result<()> {
+        self.perform_action_impl(Action::ShowMenu, None)
+    }
+
+    /// Scroll this element into view.
+    pub fn scroll_into_view(&self) -> Result<()> {
+        self.perform_action_impl(Action::ScrollIntoView, None)
+    }
+
+    /// Type text character-by-character on this element.
+    pub fn type_text(&self, text: &str) -> Result<()> {
+        self.perform_action_impl(Action::TypeText, Some(ActionData::Value(text.to_string())))
+    }
+
+    /// Select a text range within this element.
+    pub fn select_text(&self, start: u32, end: u32) -> Result<()> {
+        self.perform_action_impl(
+            Action::SetTextSelection,
+            Some(ActionData::TextSelection { start, end }),
+        )
+    }
+
+    /// Remove keyboard focus from this element.
+    pub fn blur(&self) -> Result<()> {
+        self.perform_action_impl(Action::Blur, None)
+    }
+
+    /// Scroll upward.
+    pub fn scroll_up(&self, amount: f64) -> Result<()> {
+        self.perform_action_impl(
+            Action::Scroll,
+            Some(ActionData::ScrollAmount {
+                direction: ScrollDirection::Up,
+                amount,
+            }),
+        )
+    }
+
+    /// Scroll downward.
+    pub fn scroll_down(&self, amount: f64) -> Result<()> {
+        self.perform_action_impl(
+            Action::Scroll,
+            Some(ActionData::ScrollAmount {
+                direction: ScrollDirection::Down,
+                amount,
+            }),
+        )
+    }
+
+    /// Scroll leftward.
+    pub fn scroll_left(&self, amount: f64) -> Result<()> {
+        self.perform_action_impl(
+            Action::Scroll,
+            Some(ActionData::ScrollAmount {
+                direction: ScrollDirection::Left,
+                amount,
+            }),
+        )
+    }
+
+    /// Scroll rightward.
+    pub fn scroll_right(&self, amount: f64) -> Result<()> {
+        self.perform_action_impl(
+            Action::Scroll,
+            Some(ActionData::ScrollAmount {
+                direction: ScrollDirection::Right,
+                amount,
+            }),
+        )
+    }
+
+    // ── Debug ───────────────────────────────────────────────────────────
+
+    /// Render this node's subtree as indented text for debugging.
+    pub fn dump(&self) -> String {
+        let subtree = self.subtree();
+        // Compute depths relative to this node
+        let base_depth = self.depth();
+        let mut output = String::new();
+        for node in &subtree {
+            let depth = node.depth().saturating_sub(base_depth);
+            let indent = "  ".repeat(depth as usize);
+            let name_part = node
+                .name()
+                .map(|n| format!(" \"{}\"", n))
+                .unwrap_or_default();
+            let value_part = node
+                .value()
+                .map(|v| format!(" value=\"{}\"", v))
+                .unwrap_or_default();
+            output.push_str(&format!(
+                "{}[{}] {}{}{}\n",
+                indent,
+                node.index,
+                node.role().to_snake_case(),
+                name_part,
+                value_part,
+            ));
+        }
+        output
+    }
+
+    /// Compute depth of this node by walking parent chain.
+    fn depth(&self) -> u32 {
+        let mut depth = 0u32;
+        let mut idx = self.index;
+        while let Some(parent_idx) = self
+            .data
+            .nodes
+            .get(idx as usize)
+            .and_then(|n| n.parent_index)
+        {
+            depth += 1;
+            idx = parent_idx;
+        }
+        depth
+    }
+}
+
+/// Re-locate a node in a fresh tree by stable_id or index+role verification.
+fn relocate_node(old: &RawNode, fresh_nodes: &[RawNode]) -> Result<u32> {
+    // 1. Try stable_id match
+    if let Some(sid) = &old.stable_id {
+        if let Some(node) = fresh_nodes
+            .iter()
+            .find(|n| n.stable_id.as_ref() == Some(sid))
+        {
+            return Ok(node.index);
+        }
+    }
+    // 2. Fallback: same index + verify role match
+    if let Some(node) = fresh_nodes.get(old.index as usize) {
+        if node.role == old.role {
+            return Ok(node.index);
+        }
+    }
+    Err(Error::ElementStale {
+        selector: format!(
+            "{}{}",
+            old.role.to_snake_case(),
+            old.name
+                .as_ref()
+                .map(|n| format!("[name=\"{}\"]", n))
+                .unwrap_or_default()
+        ),
+    })
+}
+
+// ── Supporting types ────────────────────────────────────────────────────────
 
 /// Boolean state flags for a node.
 ///

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::action::{Action, ActionData};
 use crate::error::Result;
-use crate::node::Node;
+use crate::node::RawNode;
 use crate::role::Role;
 use crate::tree::Tree;
 
@@ -14,15 +14,14 @@ pub trait Provider: Send + Sync {
     /// Snapshot all running applications (shallow).
     fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree>;
 
-    /// Perform an action on an element from a specific snapshot.
+    /// Perform an action on an element identified by its index in the tree.
     ///
     /// `Ok(())` means the platform API accepted the request without error.
-    /// It does **not** guarantee the action had an observable effect — use
-    /// tree queries or `Locator::wait_*` methods to verify state changes.
-    fn perform_action(
+    /// It does **not** guarantee the action had an observable effect.
+    fn perform_action_raw(
         &self,
         tree: &Tree,
-        node: &Node,
+        node_index: u32,
         action: Action,
         data: Option<ActionData>,
     ) -> Result<()>;
@@ -31,6 +30,8 @@ pub trait Provider: Send + Sync {
     fn check_permissions(&self) -> Result<PermissionStatus>;
 
     /// List running applications with their PIDs.
+    ///
+    /// Deprecated: use `get_all_apps` + query for `application` nodes instead.
     fn list_apps(&self) -> Result<Vec<AppInfo>>;
 }
 
@@ -85,4 +86,33 @@ pub struct AppInfo {
     pub pid: u32,
     /// macOS bundle identifier
     pub bundle_id: Option<String>,
+}
+
+// ── Compatibility shim ──────────────────────────────────────────────────────
+
+/// Extension trait providing the old `perform_action(&Tree, &RawNode, ...)` signature
+/// by delegating to `perform_action_raw`.
+///
+/// This allows backends that haven't migrated yet to keep working through
+/// a blanket impl, and also allows callers with `&RawNode` to dispatch easily.
+pub trait ProviderExt: Provider {
+    fn perform_action(
+        &self,
+        tree: &Tree,
+        node: &RawNode,
+        action: Action,
+        data: Option<ActionData>,
+    ) -> Result<()>;
+}
+
+impl<T: Provider + ?Sized> ProviderExt for T {
+    fn perform_action(
+        &self,
+        tree: &Tree,
+        node: &RawNode,
+        action: Action,
+        data: Option<ActionData>,
+    ) -> Result<()> {
+        self.perform_action_raw(tree, node.index, action, data)
+    }
 }

--- a/xa11y-core/src/role.rs
+++ b/xa11y-core/src/role.rs
@@ -63,7 +63,7 @@ impl Role {
         match s {
             "unknown" => Some(Role::Unknown),
             "window" => Some(Role::Window),
-            "application" => Some(Role::Application),
+            "application" | "app" => Some(Role::Application),
             "button" => Some(Role::Button),
             "check_box" => Some(Role::CheckBox),
             "radio_button" => Some(Role::RadioButton),

--- a/xa11y-core/src/selector.rs
+++ b/xa11y-core/src/selector.rs
@@ -5,8 +5,8 @@
 //! selector      := simple_selector (combinator simple_selector)*
 //! combinator    := " "          // descendant (any depth)
 //!                | " > "       // direct child
-//! simple_selector := role_name? attr_filter* pseudo?
-//! role_name     := [a-z_]+     // snake_case role name
+//! simple_selector := ("*" | role_name)? attr_filter* pseudo?
+//! role_name     := [a-z_]+     // snake_case role name ("app" is an alias for "application")
 //! attr_filter   := "[" attr_name op value "]"
 //! attr_name     := "name" | "value" | "description" | "role"
 //! op            := "=" | "*=" | "^=" | "$="
@@ -16,9 +16,8 @@
 //! ```
 
 use crate::error::{Error, Result};
-use crate::node::Node;
+use crate::node::RawNode;
 use crate::role::Role;
-use crate::tree::Tree;
 
 /// A parsed CSS-like selector for matching accessibility tree nodes.
 #[derive(Debug, Clone)]
@@ -48,6 +47,8 @@ pub(crate) struct SimpleSelector {
     pub role: Option<Role>,
     pub filters: Vec<AttrFilter>,
     pub nth: Option<usize>,
+    /// True for the `*` wildcard selector (matches any role)
+    pub wildcard: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -148,21 +149,28 @@ impl Selector {
         let mut role = None;
         let mut filters = Vec::new();
         let mut nth = None;
+        let mut wildcard = false;
 
-        // Try to parse role name (sequence of [a-z_])
-        let start = pos;
-        while pos < chars.len() && (chars[pos].is_ascii_lowercase() || chars[pos] == '_') {
+        // Check for wildcard `*`
+        if pos < chars.len() && chars[pos] == '*' {
+            wildcard = true;
             pos += 1;
-        }
-        if pos > start {
-            let role_str: String = chars[start..pos].iter().collect();
-            match Role::from_snake_case(&role_str) {
-                Some(r) => role = Some(r),
-                None => {
-                    return Err(Error::InvalidSelector {
-                        selector: input.to_string(),
-                        message: format!("unknown role '{}'", role_str),
-                    });
+        } else {
+            // Try to parse role name (sequence of [a-z_])
+            let start = pos;
+            while pos < chars.len() && (chars[pos].is_ascii_lowercase() || chars[pos] == '_') {
+                pos += 1;
+            }
+            if pos > start {
+                let role_str: String = chars[start..pos].iter().collect();
+                match Role::from_snake_case(&role_str) {
+                    Some(r) => role = Some(r),
+                    None => {
+                        return Err(Error::InvalidSelector {
+                            selector: input.to_string(),
+                            message: format!("unknown role '{}'", role_str),
+                        });
+                    }
                 }
             }
         }
@@ -216,14 +224,22 @@ impl Selector {
             }
         }
 
-        if role.is_none() && filters.is_empty() && nth.is_none() {
+        if !wildcard && role.is_none() && filters.is_empty() && nth.is_none() {
             return Err(Error::InvalidSelector {
                 selector: input.to_string(),
                 message: "empty simple selector".to_string(),
             });
         }
 
-        Ok((SimpleSelector { role, filters, nth }, pos))
+        Ok((
+            SimpleSelector {
+                role,
+                filters,
+                nth,
+                wildcard,
+            },
+            pos,
+        ))
     }
 
     fn parse_attr_filter(
@@ -306,47 +322,73 @@ impl Selector {
         Ok((AttrFilter { attr, op, value }, pos))
     }
 
-    /// Match nodes in the tree against this selector.
-    pub fn match_nodes<'a>(&self, tree: &'a Tree) -> Vec<&'a Node> {
+    /// Match against a flat slice of raw nodes, returning matched indices.
+    ///
+    /// This is the primary matching method. It works directly on `&[RawNode]`
+    /// without requiring a `Tree` wrapper.
+    pub fn match_raw_nodes(&self, nodes: &[RawNode]) -> Vec<u32> {
         if self.segments.is_empty() {
             return vec![];
         }
 
         // Start with all nodes matching the first simple selector
         let first = &self.segments[0].simple;
-        let mut candidates: Vec<&Node> = tree
+        let mut candidates: Vec<u32> = nodes
             .iter()
             .filter(|n| Self::matches_simple(n, first))
+            .map(|n| n.index)
             .collect();
 
         // Apply subsequent segments with combinators
         for segment in &self.segments[1..] {
             let mut next_candidates = Vec::new();
-            for candidate in &candidates {
+            for &candidate_idx in &candidates {
+                let Some(candidate) = nodes.get(candidate_idx as usize) else {
+                    continue;
+                };
                 match segment.combinator {
                     Combinator::Child => {
                         // Direct children of candidate that match
-                        for child in tree.children(candidate) {
-                            if Self::matches_simple(child, &segment.simple) {
-                                next_candidates.push(child);
+                        for &child_idx in &candidate.children_indices {
+                            if let Some(child) = nodes.get(child_idx as usize) {
+                                if Self::matches_simple(child, &segment.simple) {
+                                    next_candidates.push(child.index);
+                                }
                             }
                         }
                     }
                     Combinator::Descendant => {
                         // All descendants of candidate that match
-                        let subtree = tree.subtree(candidate);
-                        for node in subtree.into_iter().skip(1) {
-                            if Self::matches_simple(node, &segment.simple) {
-                                next_candidates.push(node);
+                        fn collect_descendants(
+                            nodes: &[RawNode],
+                            index: u32,
+                            simple: &SimpleSelector,
+                            result: &mut Vec<u32>,
+                        ) {
+                            if let Some(node) = nodes.get(index as usize) {
+                                for &child_idx in &node.children_indices {
+                                    if let Some(child) = nodes.get(child_idx as usize) {
+                                        if Selector::matches_simple(child, simple) {
+                                            result.push(child.index);
+                                        }
+                                    }
+                                    collect_descendants(nodes, child_idx, simple, result);
+                                }
                             }
                         }
+                        collect_descendants(
+                            nodes,
+                            candidate_idx,
+                            &segment.simple,
+                            &mut next_candidates,
+                        );
                     }
                     Combinator::Root => unreachable!(),
                 }
             }
             // Deduplicate while preserving order
             let mut seen = std::collections::HashSet::new();
-            next_candidates.retain(|n| seen.insert(n.index));
+            next_candidates.retain(|idx| seen.insert(*idx));
             candidates = next_candidates;
         }
 
@@ -362,11 +404,14 @@ impl Selector {
         candidates
     }
 
-    fn matches_simple(node: &Node, simple: &SimpleSelector) -> bool {
-        // Check role
-        if let Some(role) = simple.role {
-            if node.role != role {
-                return false;
+    fn matches_simple(node: &RawNode, simple: &SimpleSelector) -> bool {
+        // Wildcard matches everything (no role check)
+        if !simple.wildcard {
+            // Check role
+            if let Some(role) = simple.role {
+                if node.role != role {
+                    return false;
+                }
             }
         }
 
@@ -395,8 +440,6 @@ impl Selector {
                 }
             };
 
-            // For Role attr, the value is always Some (from to_snake_case)
-            // but for other attrs it might be None — which means no match
             if !matches {
                 return false;
             }
@@ -499,5 +542,27 @@ mod tests {
     #[test]
     fn parse_nth_zero_error() {
         assert!(Selector::parse("button:nth(0)").is_err());
+    }
+
+    #[test]
+    fn parse_wildcard() {
+        let sel = Selector::parse("*").unwrap();
+        assert_eq!(sel.segments.len(), 1);
+        assert!(sel.segments[0].simple.wildcard);
+        assert!(sel.segments[0].simple.role.is_none());
+    }
+
+    #[test]
+    fn parse_app_alias() {
+        let sel = Selector::parse("app").unwrap();
+        assert_eq!(sel.segments[0].simple.role, Some(Role::Application));
+    }
+
+    #[test]
+    fn parse_app_with_name_filter() {
+        let sel = Selector::parse(r#"app[name*="Slack"]"#).unwrap();
+        assert_eq!(sel.segments[0].simple.role, Some(Role::Application));
+        assert_eq!(sel.segments[0].simple.filters[0].op, MatchOp::Contains);
+        assert_eq!(sel.segments[0].simple.filters[0].value, "Slack");
     }
 }

--- a/xa11y-core/src/tree.rs
+++ b/xa11y-core/src/tree.rs
@@ -1,14 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
-use crate::node::{Node, NodeIndex};
+use crate::node::{NodeIndex, RawNode};
 use crate::selector::Selector;
 
-/// A snapshot of an application's accessibility tree.
+/// Internal snapshot of an application's accessibility tree.
 ///
-/// The tree is a flattened snapshot — nodes are stored in DFS order and
-/// reference each other by internal indices. Navigation is done through
-/// `Tree` methods that accept `&Node` references.
+/// Nodes are stored in DFS order and reference each other by internal indices.
+/// This type is used internally by providers. The public API exposes [`Node`](crate::node::Node)
+/// cursors instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tree {
     /// Application name
@@ -20,17 +20,17 @@ pub struct Tree {
     /// Screen dimensions at capture time (width, height)
     pub screen_size: (u32, u32),
 
-    /// All nodes in DFS order (access through methods)
-    nodes: Vec<Node>,
+    /// All nodes in DFS order
+    pub nodes: Vec<RawNode>,
 }
 
 impl Tree {
-    /// Create a new Tree from a list of nodes.
+    /// Create a new Tree from a list of raw nodes.
     pub fn new(
         app_name: String,
         pid: Option<u32>,
         screen_size: (u32, u32),
-        nodes: Vec<Node>,
+        nodes: Vec<RawNode>,
     ) -> Self {
         Self {
             app_name,
@@ -40,24 +40,24 @@ impl Tree {
         }
     }
 
-    /// Get a node by its internal index. Primarily for FFI consumers.
-    pub fn get(&self, index: u32) -> Option<&Node> {
+    /// Get a node by its internal index.
+    pub fn get(&self, index: u32) -> Option<&RawNode> {
         self.nodes.get(index as usize)
     }
 
     /// Get the root node.
-    pub fn root(&self) -> &Node {
+    pub fn root(&self) -> &RawNode {
         &self.nodes[0]
     }
 
     /// Get the parent of a node.
-    pub fn parent(&self, node: &Node) -> Option<&Node> {
+    pub fn parent(&self, node: &RawNode) -> Option<&RawNode> {
         node.parent_index
             .and_then(|idx| self.nodes.get(idx as usize))
     }
 
     /// Get direct children of a node.
-    pub fn children(&self, node: &Node) -> Vec<&Node> {
+    pub fn children(&self, node: &RawNode) -> Vec<&RawNode> {
         node.children_indices
             .iter()
             .filter_map(|&idx| self.nodes.get(idx as usize))
@@ -65,13 +65,13 @@ impl Tree {
     }
 
     /// Get the subtree rooted at a node (including the node itself).
-    pub fn subtree(&self, node: &Node) -> Vec<&Node> {
+    pub fn subtree(&self, node: &RawNode) -> Vec<&RawNode> {
         let mut result = Vec::new();
         self.collect_subtree(node.index, &mut result);
         result
     }
 
-    fn collect_subtree<'a>(&'a self, index: NodeIndex, result: &mut Vec<&'a Node>) {
+    fn collect_subtree<'a>(&'a self, index: NodeIndex, result: &mut Vec<&'a RawNode>) {
         if let Some(node) = self.nodes.get(index as usize) {
             result.push(node);
             for &child_idx in &node.children_indices {
@@ -81,19 +81,23 @@ impl Tree {
     }
 
     /// Iterate all nodes.
-    pub fn iter(&self) -> impl Iterator<Item = &Node> {
+    pub fn iter(&self) -> impl Iterator<Item = &RawNode> {
         self.nodes.iter()
     }
 
     /// Query nodes matching a CSS-like selector string.
-    pub fn query(&self, selector_str: &str) -> Result<Vec<&Node>> {
+    pub fn query(&self, selector_str: &str) -> Result<Vec<&RawNode>> {
         let selector = Selector::parse(selector_str)?;
-        Ok(selector.match_nodes(self))
+        let indices = selector.match_raw_nodes(&self.nodes);
+        Ok(indices
+            .into_iter()
+            .filter_map(|idx| self.nodes.get(idx as usize))
+            .collect())
     }
 
     /// Render the tree as an indented text representation for debugging.
     pub fn dump(&self) -> String {
-        // Compute depth from parent_index so Node doesn't need a depth field.
+        // Compute depth from parent_index so RawNode doesn't need a depth field.
         let mut depths = vec![0u32; self.nodes.len()];
         for node in &self.nodes {
             let d = depths[node.index as usize];
@@ -143,7 +147,7 @@ impl Tree {
     /// Get the internal node index for a node. Used by platform providers
     /// to look up cached element handles.
     #[doc(hidden)]
-    pub fn node_index(&self, node: &Node) -> NodeIndex {
+    pub fn node_index(&self, node: &RawNode) -> NodeIndex {
         node.index
     }
 }

--- a/xa11y-fuzz/fuzz/fuzz_targets/query.rs
+++ b/xa11y-fuzz/fuzz/fuzz_targets/query.rs
@@ -4,7 +4,7 @@
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use xa11y_core::{Node, RawPlatformData, Role, StateSet, Tree};
+use xa11y_core::{RawNode, RawPlatformData, Role, StateSet, Tree};
 
 const ROLES: [Role; 33] = [
     Role::Unknown,
@@ -64,11 +64,11 @@ fn build_tree(fuzz_nodes: &[FuzzNode]) -> Tree {
         return Tree::new("fuzz-app".to_string(), None, (1920, 1080), vec![]);
     }
 
-    let mut nodes: Vec<Node> = Vec::with_capacity(node_count);
+    let mut nodes: Vec<RawNode> = Vec::with_capacity(node_count);
     for i in 0..node_count {
         let fuzz = &fuzz_nodes[i];
         let role = ROLES[fuzz.role_idx as usize % ROLES.len()];
-        nodes.push(Node {
+        nodes.push(RawNode {
             role,
             name: fuzz.name.clone(),
             value: fuzz.value.clone(),
@@ -81,6 +81,8 @@ fn build_tree(fuzz_nodes: &[FuzzNode]) -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: i as u32,
             children_indices: vec![],
             parent_index: None,

--- a/xa11y-fuzz/fuzz/fuzz_targets/tree_ops.rs
+++ b/xa11y-fuzz/fuzz/fuzz_targets/tree_ops.rs
@@ -5,7 +5,7 @@
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use xa11y_core::{Node, RawPlatformData, Role, StateSet, Tree};
+use xa11y_core::{RawNode, RawPlatformData, Role, StateSet, Tree};
 
 /// Roles indexed by u8 for fuzzer-driven selection.
 const ROLES: [Role; 33] = [
@@ -82,11 +82,11 @@ fn build_tree(input: &FuzzInput) -> Tree {
         );
     }
 
-    let mut nodes: Vec<Node> = Vec::with_capacity(node_count);
+    let mut nodes: Vec<RawNode> = Vec::with_capacity(node_count);
     for i in 0..node_count {
         let fuzz = &input.fuzz_nodes[i];
         let role = ROLES[fuzz.role_idx as usize % ROLES.len()];
-        nodes.push(Node {
+        nodes.push(RawNode {
             role,
             name: fuzz.name.clone(),
             value: fuzz.value.clone(),
@@ -99,6 +99,8 @@ fn build_tree(input: &FuzzInput) -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: i as u32,
             children_indices: vec![],
             parent_index: None,

--- a/xa11y-fuzz/src/bin/provider_fuzz.rs
+++ b/xa11y-fuzz/src/bin/provider_fuzz.rs
@@ -272,7 +272,7 @@ mod provider_fuzz {
 
     // ── ActionData Generation ────────────────────────────────────────────────
 
-    fn random_action_data(rng: &mut StdRng, action: Action, _node: &Node) -> Option<ActionData> {
+    fn random_action_data(rng: &mut StdRng, action: Action, _node: &RawNode) -> Option<ActionData> {
         match action {
             Action::SetValue => {
                 let kind: u8 = rng.random_range(0..10);

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use xa11y_core::{
     Action, ActionData, AppInfo, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
-    EventKind, EventProvider, EventReceiver, Node, PermissionStatus, Provider, QueryOptions, Rect,
-    Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
+    EventKind, EventProvider, EventReceiver, PermissionStatus, Provider, QueryOptions, RawNode,
+    Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
 use zbus::blocking::{Connection, Proxy};
 
@@ -307,7 +307,7 @@ impl LinuxProvider {
         &self,
         aref: &AccessibleRef,
         opts: &QueryOptions,
-        nodes: &mut Vec<Node>,
+        nodes: &mut Vec<RawNode>,
         refs: &mut Vec<AccessibleRef>,
         parent_idx: Option<u32>,
         depth: u32,
@@ -423,7 +423,12 @@ impl LinuxProvider {
         };
 
         let node_idx = nodes.len() as u32;
-        nodes.push(Node {
+        let node_pid = if role == Role::Application {
+            self.get_app_pid(aref)
+        } else {
+            None
+        };
+        nodes.push(RawNode {
             role,
             name,
             value,
@@ -436,6 +441,8 @@ impl LinuxProvider {
             max_value,
             stable_id: Some(aref.path.clone()),
             raw,
+            pid: node_pid,
+            bundle_id: None,
             index: node_idx,
             children_indices: vec![], // filled in below
             parent_index: parent_idx,
@@ -743,7 +750,7 @@ impl Provider for LinuxProvider {
         let screen_size = Self::detect_screen_size();
         let mut nodes = Vec::new();
 
-        nodes.push(Node {
+        nodes.push(RawNode {
             role: Role::Application,
             name: Some("Desktop".to_string()),
             value: None,
@@ -761,6 +768,8 @@ impl Provider for LinuxProvider {
             max_value: None,
             stable_id: None,
             raw: xa11y_core::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 0,
             children_indices: vec![],
             parent_index: None,
@@ -799,14 +808,14 @@ impl Provider for LinuxProvider {
         Ok(Tree::new("Desktop".to_string(), None, screen_size, nodes))
     }
 
-    fn perform_action(
+    fn perform_action_raw(
         &self,
-        tree: &Tree,
-        node: &Node,
+        _tree: &Tree,
+        node_index: u32,
         action: Action,
         data: Option<ActionData>,
     ) -> Result<()> {
-        let node_idx = tree.node_index(node);
+        let node_idx = node_index;
 
         // Look up cached accessible ref for action dispatch
         let cache = self.cached_refs.lock().unwrap();
@@ -1239,7 +1248,7 @@ impl EventProvider for LinuxProvider {
         selector: &str,
         state: ElementState,
         timeout: Duration,
-    ) -> Result<Node> {
+    ) -> Result<RawNode> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -1254,7 +1263,7 @@ impl EventProvider for LinuxProvider {
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
             if state.is_met(node) {
-                return Ok(node.cloned().unwrap_or_else(Node::synthetic_empty));
+                return Ok(node.cloned().unwrap_or_else(RawNode::synthetic_empty));
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y-linux/src/stub.rs
+++ b/xa11y-linux/src/stub.rs
@@ -1,7 +1,7 @@
 //! Stub backend for non-Linux platforms (allows compilation on all targets).
 
 use xa11y_core::{
-    Action, ActionData, AppInfo, AppTarget, Error, Node, PermissionStatus, Provider, QueryOptions,
+    Action, ActionData, AppInfo, AppTarget, Error, PermissionStatus, Provider, QueryOptions,
     Result, Tree,
 };
 
@@ -29,10 +29,10 @@ impl Provider for LinuxProvider {
         })
     }
 
-    fn perform_action(
+    fn perform_action_raw(
         &self,
         _tree: &Tree,
-        _node: &Node,
+        _node_index: u32,
         _action: Action,
         _data: Option<ActionData>,
     ) -> Result<()> {

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -11,7 +11,7 @@ use core_foundation::string::CFString;
 
 use xa11y_core::{
     Action, ActionData, AppInfo, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
-    EventKind, EventProvider, EventReceiver, Node, PermissionStatus, Provider, QueryOptions,
+    EventKind, EventProvider, EventReceiver, PermissionStatus, Provider, QueryOptions, RawNode,
     RawPlatformData, Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
 
@@ -732,7 +732,7 @@ impl MacOSProvider {
         &self,
         element: &AXElement,
         opts: &QueryOptions,
-        nodes: &mut Vec<Node>,
+        nodes: &mut Vec<RawNode>,
         elements: &mut Vec<AXElement>,
         parent_idx: Option<u32>,
         depth: u32,
@@ -887,7 +887,7 @@ impl MacOSProvider {
 
         let node_idx = nodes.len() as u32;
         let name_ref = name.clone(); // keep for window chrome filter below
-        nodes.push(Node {
+        nodes.push(RawNode {
             role,
             name,
             value,
@@ -900,6 +900,8 @@ impl MacOSProvider {
             min_value,
             max_value,
             raw,
+            pid: None,
+            bundle_id: None,
             index: node_idx,
             children_indices: vec![], // filled below
             parent_index: parent_idx,
@@ -1005,6 +1007,11 @@ impl Provider for MacOSProvider {
             });
         }
 
+        // Set pid on the root Application node
+        if nodes[0].role == Role::Application {
+            nodes[0].pid = Some(pid as u32);
+        }
+
         // Cache elements for action dispatch
         *self.cached_elements.lock().unwrap() = elements;
 
@@ -1017,7 +1024,7 @@ impl Provider for MacOSProvider {
         let mut elements = Vec::new();
 
         // Desktop root
-        nodes.push(Node {
+        nodes.push(RawNode {
             index: 0,
             role: Role::Application,
             name: Some("Desktop".to_string()),
@@ -1038,6 +1045,8 @@ impl Provider for MacOSProvider {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
         });
         elements.push(AXElement(std::ptr::null())); // placeholder
 
@@ -1062,6 +1071,12 @@ impl Provider for MacOSProvider {
                 screen_size,
                 &mut visited,
             );
+            // Set pid on the Application-role node for this app
+            if let Some(app_node) = nodes.get_mut(child_idx as usize) {
+                if app_node.role == Role::Application {
+                    app_node.pid = Some(*pid as u32);
+                }
+            }
         }
 
         nodes[0].children_indices = root_children;
@@ -1071,14 +1086,14 @@ impl Provider for MacOSProvider {
         Ok(Tree::new("Desktop".to_string(), None, screen_size, nodes))
     }
 
-    fn perform_action(
+    fn perform_action_raw(
         &self,
         tree: &Tree,
-        node: &Node,
+        node_index: u32,
         action: Action,
         data: Option<ActionData>,
     ) -> Result<()> {
-        let node_idx = tree.node_index(node);
+        let node_idx = node_index;
 
         // Look up cached element
         let cache = self.cached_elements.lock().unwrap();
@@ -1374,7 +1389,7 @@ unsafe extern "C" fn ax_observer_callback(
         let role_str = ax_string(element, "AXRole").unwrap_or_default();
         let subrole = ax_string(element, "AXSubrole");
         let role = map_ax_role(&role_str, subrole.as_deref());
-        Some(Node {
+        Some(RawNode {
             role,
             name: ax_string(element, "AXTitle"),
             value: ax_value_string(element),
@@ -1387,6 +1402,8 @@ unsafe extern "C" fn ax_observer_callback(
             max_value: None,
             stable_id: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 0,
             children_indices: vec![],
             parent_index: None,
@@ -1565,7 +1582,7 @@ impl EventProvider for MacOSProvider {
         selector: &str,
         state: ElementState,
         timeout: Duration,
-    ) -> Result<Node> {
+    ) -> Result<RawNode> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -1580,7 +1597,7 @@ impl EventProvider for MacOSProvider {
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
             if state.is_met(node) {
-                return Ok(node.cloned().unwrap_or_else(Node::synthetic_empty));
+                return Ok(node.cloned().unwrap_or_else(RawNode::synthetic_empty));
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -31,10 +31,10 @@ mod stub {
         fn get_all_apps(&self, _: &QueryOptions) -> Result<Tree> {
             unreachable!()
         }
-        fn perform_action(
+        fn perform_action_raw(
             &self,
             _: &Tree,
-            _: &Node,
+            _: u32,
             _: Action,
             _: Option<ActionData>,
         ) -> Result<()> {

--- a/xa11y-python/Cargo.lock
+++ b/xa11y-python/Cargo.lock
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "xa11y-core",
  "xa11y-linux",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-core"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-linux"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "xa11y-core",
  "zbus",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-macos"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "cc",
  "core-foundation",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-python"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "pyo3",
  "xa11y",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-windows"
-version = "0.1.1"
+version = "0.2.1"
 dependencies = [
  "windows",
  "xa11y-core",

--- a/xa11y-python/python/xa11y/__init__.py
+++ b/xa11y-python/python/xa11y/__init__.py
@@ -13,7 +13,9 @@ Reuse a locator for lazy resolution:
 """
 
 from xa11y._native import (
+    # Exceptions
     ActionNotSupportedError,
+    # Data classes
     AppInfo,
     AppNotFoundError,
     InvalidSelectorError,
@@ -25,14 +27,15 @@ from xa11y._native import (
     SelectorNotMatchedError,
     TimeoutError,
     Tree,
-    # Exceptions
     XA11yError,
+    # Functions
     all_apps,
     app,
+    apps,
     check_permissions,
     list_apps,
-    # Functions
     locator,
+    query,
 )
 
 __all__ = [
@@ -51,7 +54,9 @@ __all__ = [
     "XA11yError",
     "all_apps",
     "app",
+    "apps",
     "check_permissions",
     "list_apps",
     "locator",
+    "query",
 ]

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -245,9 +245,11 @@ class Locator:
     def selector(self) -> str:
         """The CSS-like selector string for this locator."""
     def nth(self, n: int) -> Locator:
-        """Select the *n*-th match (0-indexed)."""
-    def first(self) -> Locator:
-        """Select the first match (shorthand for ``nth(0)``)."""
+        """Select the *n*-th match (0-indexed). Returns a narrowed Locator."""
+    def first(self) -> Node:
+        """Resolve and return the first matching Node snapshot (Playwright-style)."""
+    def all(self) -> list[Node]:
+        """Resolve and return all matching Node snapshots (Playwright-style)."""
     def child(self, selector: str) -> Locator:
         """Narrow to direct children matching *selector*."""
     def descendant(self, selector: str) -> Locator:
@@ -371,6 +373,25 @@ def all_apps(
     roles: list[str] | None = None,
 ) -> Tree:
     """Get a combined accessibility tree for all running applications."""
+
+def apps(
+    *,
+    max_depth: int | None = None,
+    max_elements: int | None = None,
+    visible_only: bool = False,
+    roles: list[str] | None = None,
+) -> list[Node]:
+    """Get all running applications as Node snapshots (sugar for ``query("app")``)."""
+
+def query(
+    selector: str,
+    *,
+    max_depth: int | None = None,
+    max_elements: int | None = None,
+    visible_only: bool = False,
+    roles: list[str] | None = None,
+) -> list[Node]:
+    """Query across all running applications."""
 
 def locator(
     name: str | None = None,

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -51,6 +51,7 @@ fn to_py_err(e: xa11y::Error) -> PyErr {
         xa11y::Error::InvalidActionData { message } => {
             PyValueError::new_err(format!("Invalid action data: {message}"))
         }
+        xa11y::Error::Detached => PlatformError::new_err("Node is detached: no provider available"),
         xa11y::Error::Platform { code, message } => {
             PlatformError::new_err(format!("Platform error ({code}): {message}"))
         }
@@ -177,8 +178,8 @@ fn build_action_data(
     Ok(data)
 }
 
-/// Create a Python Node from a Rust Node. No tree back-reference.
-fn make_py_node(py: Python<'_>, n: &xa11y::Node) -> PyResult<Py<Node>> {
+/// Create a Python Node from a Rust RawNode. No tree back-reference.
+fn make_py_node(py: Python<'_>, n: &xa11y::RawNode) -> PyResult<Py<Node>> {
     let checked = n.states.checked.map(|t| match t {
         xa11y::Toggled::Off => "off".to_string(),
         xa11y::Toggled::On => "on".to_string(),
@@ -467,12 +468,8 @@ impl Tree {
             end,
         )?;
         let node_index = self.resolve_target_index(target)?;
-        let rust_node = self
-            .rust_tree
-            .get(node_index)
-            .ok_or_else(|| PyValueError::new_err("Invalid node reference"))?;
         self.provider
-            .perform_action(&self.rust_tree, rust_node, rust_action, data)
+            .perform_action_raw(&self.rust_tree, node_index, rust_action, data)
             .map_err(to_py_err)
     }
 
@@ -524,14 +521,10 @@ impl Tree {
 
     fn set_value(&self, target: &Bound<'_, PyAny>, value: &str) -> PyResult<()> {
         let node_index = self.resolve_target_index(target)?;
-        let rust_node = self
-            .rust_tree
-            .get(node_index)
-            .ok_or_else(|| PyValueError::new_err("Invalid node reference"))?;
         self.provider
-            .perform_action(
+            .perform_action_raw(
                 &self.rust_tree,
-                rust_node,
+                node_index,
                 xa11y::Action::SetValue,
                 Some(xa11y::ActionData::Value(value.to_string())),
             )
@@ -540,14 +533,10 @@ impl Tree {
 
     fn set_numeric_value(&self, target: &Bound<'_, PyAny>, value: f64) -> PyResult<()> {
         let node_index = self.resolve_target_index(target)?;
-        let rust_node = self
-            .rust_tree
-            .get(node_index)
-            .ok_or_else(|| PyValueError::new_err("Invalid node reference"))?;
         self.provider
-            .perform_action(
+            .perform_action_raw(
                 &self.rust_tree,
-                rust_node,
+                node_index,
                 xa11y::Action::SetValue,
                 Some(xa11y::ActionData::NumericValue(value)),
             )
@@ -556,14 +545,10 @@ impl Tree {
 
     fn type_text(&self, target: &Bound<'_, PyAny>, text: &str) -> PyResult<()> {
         let node_index = self.resolve_target_index(target)?;
-        let rust_node = self
-            .rust_tree
-            .get(node_index)
-            .ok_or_else(|| PyValueError::new_err("Invalid node reference"))?;
         self.provider
-            .perform_action(
+            .perform_action_raw(
                 &self.rust_tree,
-                rust_node,
+                node_index,
                 xa11y::Action::TypeText,
                 Some(xa11y::ActionData::Value(text.to_string())),
             )
@@ -574,14 +559,10 @@ impl Tree {
     fn scroll(&self, target: &Bound<'_, PyAny>, direction: &str, amount: f64) -> PyResult<()> {
         let dir = parse_scroll_direction(direction)?;
         let node_index = self.resolve_target_index(target)?;
-        let rust_node = self
-            .rust_tree
-            .get(node_index)
-            .ok_or_else(|| PyValueError::new_err("Invalid node reference"))?;
         self.provider
-            .perform_action(
+            .perform_action_raw(
                 &self.rust_tree,
-                rust_node,
+                node_index,
                 xa11y::Action::Scroll,
                 Some(xa11y::ActionData::ScrollAmount {
                     direction: dir,
@@ -593,14 +574,10 @@ impl Tree {
 
     fn select_text(&self, target: &Bound<'_, PyAny>, start: u32, end: u32) -> PyResult<()> {
         let node_index = self.resolve_target_index(target)?;
-        let rust_node = self
-            .rust_tree
-            .get(node_index)
-            .ok_or_else(|| PyValueError::new_err("Invalid node reference"))?;
         self.provider
-            .perform_action(
+            .perform_action_raw(
                 &self.rust_tree,
-                rust_node,
+                node_index,
                 xa11y::Action::SetTextSelection,
                 Some(xa11y::ActionData::TextSelection { start, end }),
             )
@@ -661,12 +638,8 @@ impl Tree {
 impl Tree {
     fn perform_simple(&self, target: &Bound<'_, PyAny>, action: xa11y::Action) -> PyResult<()> {
         let node_index = self.resolve_target_index(target)?;
-        let rust_node = self
-            .rust_tree
-            .get(node_index)
-            .ok_or_else(|| PyValueError::new_err("Invalid node reference"))?;
         self.provider
-            .perform_action(&self.rust_tree, rust_node, action, None)
+            .perform_action_raw(&self.rust_tree, node_index, action, None)
             .map_err(to_py_err)
     }
 
@@ -748,8 +721,21 @@ impl Locator {
         loc
     }
 
-    fn first(&self) -> Self {
-        self.nth(0)
+    /// Resolve the locator to the first matching Node snapshot (Playwright-style).
+    fn first(&self, py: Python<'_>) -> PyResult<Py<Node>> {
+        let (tree, node_index) = self.resolve_at(0)?;
+        let n = tree.get(node_index).expect("valid after resolve");
+        make_py_node(py, n)
+    }
+
+    /// Resolve the locator to all matching Node snapshots (Playwright-style).
+    fn all(&self, py: Python<'_>) -> PyResult<Vec<Py<Node>>> {
+        let tree = self
+            .provider
+            .get_app_tree(&self.target, &self.opts)
+            .map_err(to_py_err)?;
+        let matches = tree.query(&self.selector).map_err(to_py_err)?;
+        matches.iter().map(|n| make_py_node(py, n)).collect()
     }
 
     fn child(&self, selector: &str) -> Self {
@@ -1028,12 +1014,15 @@ enum WaitState {
 
 impl Locator {
     fn resolve(&self) -> PyResult<(xa11y::Tree, u32)> {
+        self.resolve_at(self.nth.unwrap_or(0))
+    }
+
+    fn resolve_at(&self, idx: usize) -> PyResult<(xa11y::Tree, u32)> {
         let tree = self
             .provider
             .get_app_tree(&self.target, &self.opts)
             .map_err(to_py_err)?;
         let matches = tree.query(&self.selector).map_err(to_py_err)?;
-        let idx = self.nth.unwrap_or(0);
         let node = matches.get(idx).ok_or_else(|| {
             to_py_err(xa11y::Error::SelectorNotMatched {
                 selector: self.selector.clone(),
@@ -1043,7 +1032,7 @@ impl Locator {
         Ok((tree, node_index))
     }
 
-    fn resolve_node(&self) -> PyResult<xa11y::Node> {
+    fn resolve_node(&self) -> PyResult<xa11y::RawNode> {
         let (tree, idx) = self.resolve()?;
         Ok(tree.get(idx).expect("valid after resolve").clone())
     }
@@ -1057,9 +1046,8 @@ impl Locator {
             d.validate(action).map_err(to_py_err)?;
         }
         let (tree, node_index) = self.resolve()?;
-        let node = tree.get(node_index).expect("valid after resolve");
         self.provider
-            .perform_action(&tree, node, action, data)
+            .perform_action_raw(&tree, node_index, action, data)
             .map_err(to_py_err)
     }
 
@@ -1073,7 +1061,7 @@ impl Locator {
                 return Err(to_py_err(xa11y::Error::Timeout { elapsed }));
             }
 
-            let node: Option<xa11y::Node> = (|| {
+            let node: Option<xa11y::RawNode> = (|| {
                 let tree = self.provider.get_app_tree(&self.target, &self.opts).ok()?;
                 let matches = tree.query(&self.selector).ok()?;
                 let idx = self.nth.unwrap_or(0);
@@ -1237,6 +1225,47 @@ fn check_permissions(py: Python<'_>) -> PyResult<String> {
     }
 }
 
+/// Get all running applications as nodes (sugar for query("app")).
+#[pyfunction]
+#[pyo3(signature = (*, max_depth=None, max_elements=None, visible_only=false, roles=None))]
+fn apps(
+    py: Python<'_>,
+    max_depth: Option<u32>,
+    max_elements: Option<u32>,
+    visible_only: bool,
+    roles: Option<Vec<String>>,
+) -> PyResult<Vec<Py<Node>>> {
+    let provider = get_provider()?;
+    let opts = build_query_options(max_depth, max_elements, visible_only, roles);
+    let p = provider.clone();
+    let rust_tree = py
+        .allow_threads(|| p.get_all_apps(&opts))
+        .map_err(to_py_err)?;
+    let matches = rust_tree.query("app").map_err(to_py_err)?;
+    matches.iter().map(|n| make_py_node(py, n)).collect()
+}
+
+/// Query across all running applications.
+#[pyfunction]
+#[pyo3(signature = (selector, *, max_depth=None, max_elements=None, visible_only=false, roles=None))]
+fn query(
+    py: Python<'_>,
+    selector: &str,
+    max_depth: Option<u32>,
+    max_elements: Option<u32>,
+    visible_only: bool,
+    roles: Option<Vec<String>>,
+) -> PyResult<Vec<Py<Node>>> {
+    let provider = get_provider()?;
+    let opts = build_query_options(max_depth, max_elements, visible_only, roles);
+    let p = provider.clone();
+    let rust_tree = py
+        .allow_threads(|| p.get_all_apps(&opts))
+        .map_err(to_py_err)?;
+    let matches = rust_tree.query(selector).map_err(to_py_err)?;
+    matches.iter().map(|n| make_py_node(py, n)).collect()
+}
+
 // ── Module definition ───────────────────────────────────────────────────────
 
 #[pymodule]
@@ -1270,6 +1299,8 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(app, m)?)?;
     m.add_function(wrap_pyfunction!(all_apps, m)?)?;
+    m.add_function(wrap_pyfunction!(apps, m)?)?;
+    m.add_function(wrap_pyfunction!(query, m)?)?;
     m.add_function(wrap_pyfunction!(locator, m)?)?;
     m.add_function(wrap_pyfunction!(list_apps, m)?)?;
     m.add_function(wrap_pyfunction!(check_permissions, m)?)?;
@@ -1303,10 +1334,10 @@ impl xa11y::Provider for MockProvider {
         Ok(self.tree.clone())
     }
 
-    fn perform_action(
+    fn perform_action_raw(
         &self,
         _tree: &xa11y::Tree,
-        node: &xa11y::Node,
+        node_index: u32,
         action: xa11y::Action,
         data: Option<xa11y::ActionData>,
     ) -> xa11y::Result<()> {
@@ -1314,7 +1345,7 @@ impl xa11y::Provider for MockProvider {
         self.actions
             .lock()
             .unwrap()
-            .push((node.index, format!("{action}"), data_debug));
+            .push((node_index, format!("{action}"), data_debug));
         Ok(())
     }
 
@@ -1361,7 +1392,7 @@ fn build_test_tree() -> xa11y::Tree {
 
     let nodes = vec![
         // [0] application "TestApp"
-        Node {
+        RawNode {
             role: Role::Application,
             name: Some("TestApp".to_string()),
             value: None,
@@ -1381,12 +1412,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: Some("app-root".to_string()),
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: Some(1234),
+            bundle_id: Some("com.test.app".to_string()),
             index: 0,
             children_indices: vec![1],
             parent_index: None,
         },
         // [1] window "Main Window"
-        Node {
+        RawNode {
             role: Role::Window,
             name: Some("Main Window".to_string()),
             value: None,
@@ -1409,12 +1442,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 1,
             children_indices: vec![2, 5],
             parent_index: Some(0),
         },
         // [2] toolbar "Navigation"
-        Node {
+        RawNode {
             role: Role::Toolbar,
             name: Some("Navigation".to_string()),
             value: None,
@@ -1429,12 +1464,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 2,
             children_indices: vec![3, 4],
             parent_index: Some(1),
         },
         // [3] button "Back"
-        Node {
+        RawNode {
             role: Role::Button,
             name: Some("Back".to_string()),
             value: None,
@@ -1457,12 +1494,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: Some("btn-back".to_string()),
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 3,
             children_indices: vec![],
             parent_index: Some(2),
         },
         // [4] button "Forward" (disabled)
-        Node {
+        RawNode {
             role: Role::Button,
             name: Some("Forward".to_string()),
             value: None,
@@ -1486,12 +1525,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 4,
             children_indices: vec![],
             parent_index: Some(2),
         },
         // [5] group "Content"
-        Node {
+        RawNode {
             role: Role::Group,
             name: Some("Content".to_string()),
             value: None,
@@ -1506,12 +1547,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 5,
             children_indices: vec![6, 7, 8, 9, 10],
             parent_index: Some(1),
         },
         // [6] text_field "Search"
-        Node {
+        RawNode {
             role: Role::TextField,
             name: Some("Search".to_string()),
             value: Some("hello".to_string()),
@@ -1539,12 +1582,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 6,
             children_indices: vec![],
             parent_index: Some(5),
         },
         // [7] check_box "Agree" (checked=on)
-        Node {
+        RawNode {
             role: Role::CheckBox,
             name: Some("Agree".to_string()),
             value: None,
@@ -1563,12 +1608,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 7,
             children_indices: vec![],
             parent_index: Some(5),
         },
         // [8] slider "Volume"
-        Node {
+        RawNode {
             role: Role::Slider,
             name: Some("Volume".to_string()),
             value: Some("75".to_string()),
@@ -1591,12 +1638,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: Some(100.0),
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 8,
             children_indices: vec![],
             parent_index: Some(5),
         },
         // [9] static_text "Status" (hidden)
-        Node {
+        RawNode {
             role: Role::StaticText,
             name: Some("Status".to_string()),
             value: Some("Loading...".to_string()),
@@ -1614,12 +1663,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 9,
             children_indices: vec![],
             parent_index: Some(5),
         },
         // [10] list "Items"
-        Node {
+        RawNode {
             role: Role::List,
             name: Some("Items".to_string()),
             value: None,
@@ -1637,12 +1688,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 10,
             children_indices: vec![11, 12],
             parent_index: Some(5),
         },
         // [11] list_item "Item 1" (selected)
-        Node {
+        RawNode {
             role: Role::ListItem,
             name: Some("Item 1".to_string()),
             value: None,
@@ -1661,12 +1714,14 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 11,
             children_indices: vec![],
             parent_index: Some(10),
         },
         // [12] list_item "Item 2"
-        Node {
+        RawNode {
             role: Role::ListItem,
             name: Some("Item 2".to_string()),
             value: None,
@@ -1684,6 +1739,8 @@ fn build_test_tree() -> xa11y::Tree {
             max_value: None,
             stable_id: None,
             raw: xa11y::RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 12,
             children_indices: vec![],
             parent_index: Some(10),

--- a/xa11y-python/tests/test_locator.py
+++ b/xa11y-python/tests/test_locator.py
@@ -26,8 +26,17 @@ def test_nth(tree):
 
 
 def test_first(tree):
-    loc = tree.locator("button").first()
-    assert loc.name() == "Back"
+    node = tree.locator("button").first()
+    assert isinstance(node, xa11y.Node)
+    assert node.name == "Back"
+
+
+def test_all(tree):
+    nodes = tree.locator("button").all()
+    assert len(nodes) == 2
+    assert all(isinstance(n, xa11y.Node) for n in nodes)
+    assert nodes[0].name == "Back"
+    assert nodes[1].name == "Forward"
 
 
 def test_child(tree):

--- a/xa11y-windows/src/stub.rs
+++ b/xa11y-windows/src/stub.rs
@@ -1,7 +1,7 @@
 //! Stub backend for non-Windows platforms (allows compilation on all targets).
 
 use xa11y_core::{
-    Action, ActionData, AppInfo, AppTarget, Error, Node, PermissionStatus, Provider, QueryOptions,
+    Action, ActionData, AppInfo, AppTarget, Error, PermissionStatus, Provider, QueryOptions,
     Result, Tree,
 };
 
@@ -24,7 +24,7 @@ impl Provider for WindowsProvider {
     fn get_all_apps(&self, _: &QueryOptions) -> Result<Tree> {
         unreachable!()
     }
-    fn perform_action(&self, _: &Tree, _: &Node, _: Action, _: Option<ActionData>) -> Result<()> {
+    fn perform_action_raw(&self, _: &Tree, _: u32, _: Action, _: Option<ActionData>) -> Result<()> {
         unreachable!()
     }
     fn check_permissions(&self) -> Result<PermissionStatus> {

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -12,7 +12,7 @@ use windows::Win32::UI::Accessibility::*;
 
 use xa11y_core::{
     Action, ActionData, AppInfo, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
-    EventKind, EventProvider, EventReceiver, Node, PermissionStatus, Provider, QueryOptions,
+    EventKind, EventProvider, EventReceiver, PermissionStatus, Provider, QueryOptions, RawNode,
     RawPlatformData, Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
 
@@ -236,7 +236,7 @@ impl WindowsProvider {
         &self,
         element: &IUIAutomationElement,
         opts: &QueryOptions,
-        nodes: &mut Vec<Node>,
+        nodes: &mut Vec<RawNode>,
         elements: &mut Vec<IUIAutomationElement>,
         parent_idx: Option<u32>,
         depth: u32,
@@ -421,7 +421,7 @@ impl WindowsProvider {
         };
 
         let node_idx = nodes.len() as u32;
-        nodes.push(Node {
+        nodes.push(RawNode {
             role,
             name,
             value,
@@ -434,6 +434,8 @@ impl WindowsProvider {
             min_value,
             max_value,
             raw,
+            pid: None,
+            bundle_id: None,
             index: node_idx,
             children_indices: vec![],
             parent_index: parent_idx,
@@ -515,7 +517,7 @@ impl WindowsProvider {
         &self,
         element: &IUIAutomationElement,
         opts: &QueryOptions,
-        nodes: &mut Vec<Node>,
+        nodes: &mut Vec<RawNode>,
         elements: &mut Vec<IUIAutomationElement>,
         parent_idx: Option<u32>,
         depth: u32,
@@ -593,7 +595,7 @@ impl Provider for WindowsProvider {
         let mut nodes = Vec::new();
         let mut elements = Vec::new();
 
-        nodes.push(Node {
+        nodes.push(RawNode {
             role: Role::Application,
             name: Some("Desktop".to_string()),
             value: None,
@@ -611,6 +613,8 @@ impl Provider for WindowsProvider {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 0,
             children_indices: vec![],
             parent_index: None,
@@ -677,14 +681,15 @@ impl Provider for WindowsProvider {
         Ok(Tree::new("Desktop".to_string(), None, screen_size, nodes))
     }
 
-    fn perform_action(
+    fn perform_action_raw(
         &self,
         tree: &Tree,
-        node: &Node,
+        node_index: u32,
         action: Action,
         data: Option<ActionData>,
     ) -> Result<()> {
-        let node_idx = tree.node_index(node);
+        let node_idx = node_index;
+        let node_role = tree.get(node_idx).map(|n| n.role).unwrap_or(Role::Unknown);
 
         let cache = self.cached_elements.lock().unwrap();
         let element = cache.get(node_idx as usize).ok_or(Error::ElementStale {
@@ -725,7 +730,7 @@ impl Provider for WindowsProvider {
                 }
                 Err(Error::ActionNotSupported {
                     action,
-                    role: node.role,
+                    role: node_role,
                 })
             }
 
@@ -836,7 +841,7 @@ impl Provider for WindowsProvider {
                 }
                 Err(Error::ActionNotSupported {
                     action,
-                    role: node.role,
+                    role: node_role,
                 })
             }
 
@@ -857,7 +862,7 @@ impl Provider for WindowsProvider {
                 }
                 Err(Error::ActionNotSupported {
                     action,
-                    role: node.role,
+                    role: node_role,
                 })
             }
 
@@ -865,7 +870,7 @@ impl Provider for WindowsProvider {
                 // No direct UIA equivalent; try context menu via legacy
                 Err(Error::ActionNotSupported {
                     action,
-                    role: node.role,
+                    role: node_role,
                 })
             }
 
@@ -930,7 +935,7 @@ impl Provider for WindowsProvider {
                 }
                 Err(Error::ActionNotSupported {
                     action,
-                    role: node.role,
+                    role: node_role,
                 })
             }
 
@@ -971,7 +976,7 @@ impl Provider for WindowsProvider {
                 }
                 Err(Error::ActionNotSupported {
                     action,
-                    role: node.role,
+                    role: node_role,
                 })
             }
 
@@ -1450,7 +1455,7 @@ impl EventProvider for WindowsProvider {
         selector: &str,
         state: ElementState,
         timeout: Duration,
-    ) -> Result<Node> {
+    ) -> Result<RawNode> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -1465,7 +1470,7 @@ impl EventProvider for WindowsProvider {
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
             if state.is_met(node) {
-                return Ok(node.cloned().unwrap_or_else(Node::synthetic_empty));
+                return Ok(node.cloned().unwrap_or_else(RawNode::synthetic_empty));
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -12,12 +12,10 @@
 //!
 //! match status {
 //!     PermissionStatus::Granted => {
-//!         let tree = app(
-//!             &AppTarget::ByName("Safari".to_string()),
-//!             &QueryOptions::default(),
-//!         ).expect("Failed to get tree");
+//!         let slack = app("Slack", &QueryOptions::default())
+//!             .expect("Failed to get app");
 //!
-//!         let buttons = tree.query("button").expect("Query failed");
+//!         let buttons = slack.query("button").expect("Query failed");
 //!         println!("Found {} buttons", buttons.len());
 //!     }
 //!     PermissionStatus::Denied { instructions } => {
@@ -63,14 +61,14 @@ impl Provider for StaticProviderRef {
     fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree> {
         self.0.get_all_apps(opts)
     }
-    fn perform_action(
+    fn perform_action_raw(
         &self,
         tree: &Tree,
-        node: &Node,
+        node_index: u32,
         action: Action,
         data: Option<ActionData>,
     ) -> Result<()> {
-        self.0.perform_action(tree, node, action, data)
+        self.0.perform_action_raw(tree, node_index, action, data)
     }
     fn check_permissions(&self) -> Result<PermissionStatus> {
         self.0.check_permissions()
@@ -82,7 +80,7 @@ impl Provider for StaticProviderRef {
 
 /// Get the global provider as an `Arc<dyn Provider>`.
 ///
-/// Returns a handle to the same singleton used by `app()`, `all_apps()`, etc.
+/// Returns a handle to the same singleton used by `app()`, `apps()`, etc.
 /// Useful when you need to pass a provider to objects that store it (e.g. `Locator`).
 pub fn provider() -> Result<Arc<dyn Provider>> {
     Ok(Arc::new(StaticProviderRef(get_provider_ref()?)))
@@ -90,25 +88,94 @@ pub fn provider() -> Result<Arc<dyn Provider>> {
 
 // ── Module-level API ────────────────────────────────────────────────────────
 
-/// Snapshot a specific application's accessibility tree.
-pub fn app(target: &AppTarget, opts: &QueryOptions) -> Result<Tree> {
-    get_provider_ref()?.get_app_tree(target, opts)
+/// Helper to convert a Tree into a root Node cursor with provider attached.
+fn tree_to_node(tree: Tree, target: Option<AppTarget>) -> Node {
+    let data = Arc::new(TreeData {
+        app_name: tree.app_name,
+        pid: tree.pid,
+        screen_size: tree.screen_size,
+        nodes: tree.nodes,
+        provider: provider().ok(),
+        target,
+    });
+    Node::new(data, 0)
 }
 
-/// Snapshot all running applications (shallow).
-pub fn all_apps(opts: &QueryOptions) -> Result<Tree> {
-    get_provider_ref()?.get_all_apps(opts)
+/// Snapshot a specific application by name.
+///
+/// Returns the root Node of the application's accessibility tree.
+///
+/// # Example
+/// ```no_run
+/// let slack = xa11y::app("Slack", &xa11y::QueryOptions::default()).unwrap();
+/// for btn in slack.query("button").unwrap() {
+///     println!("{:?}", btn.name());
+/// }
+/// ```
+pub fn app(name: &str, opts: &QueryOptions) -> Result<Node> {
+    let target = AppTarget::ByName(name.to_string());
+    let tree = get_provider_ref()?.get_app_tree(&target, opts)?;
+    Ok(tree_to_node(tree, Some(target)))
+}
+
+/// Snapshot a specific application by process ID.
+pub fn app_by_pid(pid: u32, opts: &QueryOptions) -> Result<Node> {
+    let target = AppTarget::ByPid(pid);
+    let tree = get_provider_ref()?.get_app_tree(&target, opts)?;
+    Ok(tree_to_node(tree, Some(target)))
+}
+
+/// Get all running applications as nodes.
+///
+/// Returns a list of application nodes (role = Application).
+/// Syntactic sugar for `query("app")`.
+pub fn apps(opts: &QueryOptions) -> Result<Vec<Node>> {
+    query("app", opts)
+}
+
+/// Query across all running applications.
+///
+/// Takes a fresh snapshot of all apps and runs the selector against it.
+///
+/// # Example
+/// ```no_run
+/// // All buttons across all apps
+/// let buttons = xa11y::query("button", &xa11y::QueryOptions::default()).unwrap();
+///
+/// // All apps
+/// let apps = xa11y::query("app", &xa11y::QueryOptions::default()).unwrap();
+/// for app in &apps {
+///     println!("{}: pid={:?}", app.name().unwrap_or("?"), app.pid());
+/// }
+/// ```
+pub fn query(selector_str: &str, opts: &QueryOptions) -> Result<Vec<Node>> {
+    let tree = get_provider_ref()?.get_all_apps(opts)?;
+    let data = Arc::new(TreeData {
+        app_name: tree.app_name,
+        pid: tree.pid,
+        screen_size: tree.screen_size,
+        nodes: tree.nodes,
+        provider: provider().ok(),
+        target: None,
+    });
+
+    let selector = xa11y_core::selector::Selector::parse(selector_str)?;
+    let indices = selector.match_raw_nodes(&data.nodes);
+    Ok(indices
+        .into_iter()
+        .map(|idx| Node::new(Arc::clone(&data), idx))
+        .collect())
 }
 
 /// Perform an action on an element from a specific snapshot.
 #[cfg(feature = "testing")]
 pub fn perform_action(
     tree: &Tree,
-    node: &Node,
+    node: &RawNode,
     action: Action,
     data: Option<ActionData>,
 ) -> Result<()> {
-    get_provider_ref()?.perform_action(tree, node, action, data)
+    get_provider_ref()?.perform_action_raw(tree, node.index, action, data)
 }
 
 /// Check if accessibility permissions are granted.
@@ -117,6 +184,8 @@ pub fn check_permissions() -> Result<PermissionStatus> {
 }
 
 /// List running applications with their PIDs.
+///
+/// Deprecated: use `apps()` instead.
 pub fn list_apps() -> Result<Vec<AppInfo>> {
     get_provider_ref()?.list_apps()
 }

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -10,7 +10,8 @@ pub fn app_tree() -> Tree {
 /// Get the test app tree with custom QueryOptions, retrying for registration.
 pub fn app_tree_with(opts: &QueryOptions) -> Tree {
     for attempt in 0..3 {
-        match xa11y::app(&AppTarget::ByName("xa11y".to_string()), opts) {
+        match provider().and_then(|p| p.get_app_tree(&AppTarget::ByName("xa11y".to_string()), opts))
+        {
             Ok(tree) => return tree,
             Err(_) if attempt < 2 => {
                 std::thread::sleep(std::time::Duration::from_millis(200));
@@ -21,8 +22,13 @@ pub fn app_tree_with(opts: &QueryOptions) -> Tree {
     unreachable!()
 }
 
+/// Create a platform provider for direct use.
+pub fn provider() -> Result<std::sync::Arc<dyn Provider>> {
+    xa11y::create_provider()
+}
+
 /// Find exactly one node by selector. Panics with tree dump on failure.
-pub fn one<'a>(tree: &'a Tree, selector: &str) -> &'a Node {
+pub fn one<'a>(tree: &'a Tree, selector: &str) -> &'a RawNode {
     let results = tree.query(selector).unwrap_or_else(|e| {
         panic!(
             "Selector '{}' failed: {}. Tree:\n{}",
@@ -42,7 +48,7 @@ pub fn one<'a>(tree: &'a Tree, selector: &str) -> &'a Node {
 }
 
 /// Find first node whose name contains `substring` (case-insensitive).
-pub fn named<'a>(tree: &'a Tree, substring: &str) -> &'a Node {
+pub fn named<'a>(tree: &'a Tree, substring: &str) -> &'a RawNode {
     let selector = format!("[name*=\"{}\"]", substring);
     let results = tree.query(&selector).unwrap_or_else(|e| {
         panic!(
@@ -62,14 +68,14 @@ pub fn named<'a>(tree: &'a Tree, substring: &str) -> &'a Node {
 }
 
 /// Try to perform an action on a node. Returns the result without panicking.
-pub fn try_act(tree: &Tree, node: &Node, action: Action) -> Result<()> {
+pub fn try_act(tree: &Tree, node: &RawNode, action: Action) -> Result<()> {
     try_act_with(tree, node, action, None)
 }
 
 /// Try to perform an action with data on a node. Returns the result without panicking.
 pub fn try_act_with(
     tree: &Tree,
-    node: &Node,
+    node: &RawNode,
     action: Action,
     data: Option<ActionData>,
 ) -> Result<()> {
@@ -77,12 +83,12 @@ pub fn try_act_with(
 }
 
 /// Perform an action on a node, wait briefly, then re-read the tree.
-pub fn act(tree: &Tree, node: &Node, action: Action) -> Tree {
+pub fn act(tree: &Tree, node: &RawNode, action: Action) -> Tree {
     act_with(tree, node, action, None)
 }
 
 /// Perform an action with data on a node, wait, then re-read the tree.
-pub fn act_with(tree: &Tree, node: &Node, action: Action, data: Option<ActionData>) -> Tree {
+pub fn act_with(tree: &Tree, node: &RawNode, action: Action, data: Option<ActionData>) -> Tree {
     try_act_with(tree, node, action, data)
         .unwrap_or_else(|e| panic!("Action {:?} failed: {}", action, e));
     std::thread::sleep(std::time::Duration::from_millis(100));

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -57,12 +57,14 @@ mod tests {
     #[ignore]
     fn get_all_apps_returns_nonempty() {
         // Limit depth/elements to avoid traversing every app on the system
-        let tree = xa11y::all_apps(&QueryOptions {
-            max_depth: Some(2),
-            max_elements: Some(200),
-            ..QueryOptions::default()
-        })
-        .unwrap();
+        let provider = xa11y::provider().unwrap();
+        let tree = provider
+            .get_all_apps(&QueryOptions {
+                max_depth: Some(2),
+                max_elements: Some(200),
+                ..QueryOptions::default()
+            })
+            .unwrap();
         assert!(!tree.is_empty(), "get_all_apps should return nodes");
         assert_eq!(tree.app_name, "Desktop");
         assert!(tree.pid.is_none(), "Multi-app tree should have no PID");
@@ -87,7 +89,10 @@ mod tests {
         let test_app = apps.iter().find(|a| a.name.contains("xa11y")).unwrap();
         let pid = test_app.pid;
         assert!(pid > 0);
-        let tree = xa11y::app(&AppTarget::ByPid(pid), &QueryOptions::default()).unwrap();
+        let provider = xa11y::provider().unwrap();
+        let tree = provider
+            .get_app_tree(&AppTarget::ByPid(pid), &QueryOptions::default())
+            .unwrap();
         assert!(!tree.is_empty());
         assert_eq!(tree.pid, Some(pid));
     }
@@ -179,7 +184,7 @@ mod tests {
         let tree = h::app_tree();
         // Prior action tests (TypeText, SetValue) may have changed or cleared the value.
         // Just verify a text field exists (by role + name), value may or may not be present.
-        let text_nodes: Vec<&Node> = tree
+        let text_nodes: Vec<&RawNode> = tree
             .iter()
             .filter(|n| {
                 (n.role == Role::TextField || n.role == Role::TextArea)
@@ -722,7 +727,7 @@ mod tests {
     fn state_expanded_collapsed_on_expander() {
         let tree = h::app_tree();
         // Look for expandable nodes or expander by name
-        let expandable: Vec<&Node> = tree
+        let expandable: Vec<&RawNode> = tree
             .iter()
             .filter(|n| n.states.expanded.is_some())
             .collect();
@@ -745,7 +750,7 @@ mod tests {
         let tree = h::app_tree();
         // Prior action tests (TypeText, SetValue) may have changed or cleared the value.
         // Find text field by role + name, not by value presence.
-        let text: Vec<&Node> = tree
+        let text: Vec<&RawNode> = tree
             .iter()
             .filter(|n| {
                 (n.role == Role::TextField || n.role == Role::TextArea)
@@ -1427,7 +1432,8 @@ mod tests {
     #[test]
     #[ignore]
     fn error_app_not_found() {
-        let result = xa11y::app(
+        let provider = xa11y::provider().unwrap();
+        let result = provider.get_app_tree(
             &AppTarget::ByName("nonexistent_app_12345".to_string()),
             &QueryOptions::default(),
         );

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -9,7 +9,7 @@ use xa11y::*;
 /// Helper to build a sample accessibility tree for testing.
 fn sample_tree() -> Tree {
     let nodes = vec![
-        Node {
+        RawNode {
             role: Role::Window,
             name: Some("My App".to_string()),
             value: None,
@@ -29,11 +29,13 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 0,
             children_indices: vec![1, 4],
             parent_index: None,
         },
-        Node {
+        RawNode {
             role: Role::Toolbar,
             name: Some("Main Toolbar".to_string()),
             value: None,
@@ -53,11 +55,13 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 1,
             children_indices: vec![2, 3],
             parent_index: Some(0),
         },
-        Node {
+        RawNode {
             role: Role::Button,
             name: Some("Back".to_string()),
             value: None,
@@ -81,11 +85,13 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 2,
             children_indices: vec![],
             parent_index: Some(1),
         },
-        Node {
+        RawNode {
             role: Role::TextField,
             name: Some("Address Bar".to_string()),
             value: Some("https://example.com".to_string()),
@@ -110,11 +116,13 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 3,
             children_indices: vec![],
             parent_index: Some(1),
         },
-        Node {
+        RawNode {
             role: Role::WebArea,
             name: None,
             value: None,
@@ -134,11 +142,13 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 4,
             children_indices: vec![5, 6, 7, 8],
             parent_index: Some(0),
         },
-        Node {
+        RawNode {
             role: Role::Heading,
             name: Some("Welcome".to_string()),
             value: None,
@@ -153,11 +163,13 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 5,
             children_indices: vec![],
             parent_index: Some(4),
         },
-        Node {
+        RawNode {
             role: Role::Button,
             name: Some("Submit".to_string()),
             value: None,
@@ -176,11 +188,13 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 6,
             children_indices: vec![],
             parent_index: Some(4),
         },
-        Node {
+        RawNode {
             role: Role::Button,
             name: Some("Cancel".to_string()),
             value: None,
@@ -199,11 +213,13 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 7,
             children_indices: vec![],
             parent_index: Some(4),
         },
-        Node {
+        RawNode {
             role: Role::CheckBox,
             name: Some("I agree to terms".to_string()),
             value: None,
@@ -223,6 +239,8 @@ fn sample_tree() -> Tree {
             min_value: None,
             max_value: None,
             raw: RawPlatformData::Synthetic,
+            pid: None,
+            bundle_id: None,
             index: 8,
             children_indices: vec![],
             parent_index: Some(4),
@@ -661,7 +679,7 @@ fn tree_json_roundtrip() {
 
 #[test]
 fn node_json_serialization() {
-    let node = Node {
+    let node = RawNode {
         role: Role::Button,
         name: Some("Submit".to_string()),
         value: None,
@@ -684,13 +702,15 @@ fn node_json_serialization() {
         min_value: None,
         max_value: None,
         raw: RawPlatformData::Synthetic,
+        pid: None,
+        bundle_id: None,
         index: 0,
         children_indices: vec![],
         parent_index: None,
     };
 
     let json = serde_json::to_string_pretty(&node).unwrap();
-    let deserialized: Node = serde_json::from_str(&json).unwrap();
+    let deserialized: RawNode = serde_json::from_str(&json).unwrap();
     assert_eq!(deserialized.role, Role::Button);
     assert_eq!(deserialized.name.as_deref(), Some("Submit"));
     assert!(deserialized.states.focused);
@@ -917,14 +937,14 @@ impl Provider for MockProvider {
         Ok(self.tree.clone())
     }
 
-    fn perform_action(
+    fn perform_action_raw(
         &self,
         _tree: &Tree,
-        node: &Node,
+        node_index: u32,
         action: Action,
         _data: Option<ActionData>,
     ) -> xa11y::Result<()> {
-        *self.last_action.lock().unwrap() = Some((node.index, action));
+        *self.last_action.lock().unwrap() = Some((node_index, action));
         Ok(())
     }
 


### PR DESCRIPTION
Restructure the public API around two core concepts: Node (a cursor into
a snapshot) and Locator (a lazy element reference). Key changes:

- Rename Node → RawNode (internal), introduce cursor Node with
  properties, navigation, query (re-fetch), and action methods
- Add TreeData to hold shared snapshot + provider reference
- Provider::perform_action → perform_action_raw(tree, node_index, ...)
- Add "app" alias for "application" role, "*" wildcard selector
- Locator::first() now returns Node snapshot (Playwright-style),
  add Locator::all() for all matching snapshots
- Add xa11y::app(), apps(), query() module-level functions
- Update all backends (macOS, Linux, Windows) for new signatures
- Update Python bindings: RawNode, perform_action_raw, first/all,
  apps()/query() module functions
- Update tests, fuzz targets, integration test helpers

https://claude.ai/code/session_011BiCdKj3YzbQH9SsQomeRH