### PR TITLE
Remove list_apps/AppInfo, rename all_apps to apps

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -340,7 +340,7 @@ Inspired by Playwright's Locator pattern.
 
 | Operation | Refetches? |
 |-----------|-----------|
-| `app()` / `all_apps()` | Yes — captures fresh snapshot |
+| `app()` / `apps()` | Yes — captures fresh snapshot |
 | `node.parent()` / `node.children()` / `node.query()` | No — uses snapshot |
 | `node.role` / `node.name` / `node.to_string()` | No — uses snapshot |
 | `locator.press()` / `locator.set_value()` | Yes — refetches every time |
@@ -403,7 +403,7 @@ pub trait Provider: Send + Sync {
     fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree>;
 
     /// Snapshot all running applications (shallow).
-    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree>;
+    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree>;
 
     /// Perform an action on an element from a specific snapshot.
     ///
@@ -423,9 +423,6 @@ pub trait Provider: Send + Sync {
 
     /// Check if accessibility permissions are granted.
     fn check_permissions(&self) -> Result<PermissionStatus>;
-
-    /// List running applications with their PIDs.
-    fn list_apps(&self) -> Result<Vec<AppInfo>>;
 }
 
 pub enum AppTarget {
@@ -467,11 +464,6 @@ pub enum PermissionStatus {
     Denied { instructions: String },
 }
 
-pub struct AppInfo {
-    pub name: String,
-    pub pid: u32,
-    pub bundle_id: Option<String>,  // macOS
-}
 ```
 
 ### 8. `Error` — Structured error type
@@ -833,7 +825,8 @@ pub struct Event {
     pub kind: EventKind,
 
     /// The application that produced this event.
-    pub app: AppInfo,
+    pub app_name: String,
+    pub app_pid: u32,
 
     /// A snapshot of the element that triggered the event, if available.
     /// None if the element was destroyed or is not capturable.

--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -169,7 +169,7 @@ def _classify_class(cls: ast.ClassDef) -> str:
             "BaseException",
         ):
             return "exception"
-    if cls.name in ("Rect", "AppInfo"):
+    if cls.name in ("Rect",):
         return "data"
     return "main"
 

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -194,11 +194,13 @@ xa11y supports CSS-like selectors to find elements in the tree.
     ```rust
     use xa11y::*;
 
-    let provider = create_provider()?;
-    let apps = provider.list_apps()?;
+    let root = apps(&QueryOptions {
+        max_depth: Some(1),
+        ..QueryOptions::default()
+    })?;
 
-    for app in &apps {
-        println!("{} (pid: {})", app.name, app.pid);
+    for child in root.children() {
+        println!("{} (pid: {:?})", child.name.as_deref().unwrap_or("?"), child.pid());
     }
     ```
   </TabItem>
@@ -206,9 +208,9 @@ xa11y supports CSS-like selectors to find elements in the tree.
     ```python
     import xa11y
 
-    apps = xa11y.list_apps()
-    for app in apps:
-        print(f"{app.name} (pid: {app.pid})")
+    root = xa11y.apps(max_depth=1)
+    for child in root.children:
+        print(f"{child.name} (pid: {child.pid})")
     ```
   </TabItem>
 </Tabs>

--- a/xa11y-core/src/event.rs
+++ b/xa11y-core/src/event.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 use crate::node::NodeData;
-use crate::provider::AppInfo;
 
 /// Categories of accessibility events, normalized across platforms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -46,8 +45,10 @@ pub enum EventKind {
 pub struct Event {
     /// What kind of event occurred.
     pub kind: EventKind,
-    /// The application that produced this event.
-    pub app: AppInfo,
+    /// Name of the application that produced this event.
+    pub app_name: String,
+    /// PID of the application that produced this event.
+    pub app_pid: u32,
     /// A snapshot of the element that triggered the event, if available.
     pub target: Option<NodeData>,
     /// For StateChanged events: which state flag changed.

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -18,6 +18,6 @@ pub use event::{
 pub use event_provider::{CancelHandle, EventProvider, EventReceiver, Subscription};
 pub use locator::Locator;
 pub use node::{Node, NodeData, RawPlatformData, Rect, StateSet, Toggled};
-pub use provider::{AppInfo, AppTarget, PermissionStatus, Provider, QueryOptions, WindowHandle};
+pub use provider::{AppTarget, PermissionStatus, Provider, QueryOptions, WindowHandle};
 pub use role::Role;
 pub use tree::Tree;

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -12,7 +12,7 @@ pub trait Provider: Send + Sync {
     fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree>;
 
     /// Snapshot all running applications (shallow).
-    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree>;
+    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree>;
 
     /// Perform an action on an element from a specific snapshot.
     ///
@@ -29,9 +29,6 @@ pub trait Provider: Send + Sync {
 
     /// Check if accessibility permissions are granted.
     fn check_permissions(&self) -> Result<PermissionStatus>;
-
-    /// List running applications with their PIDs.
-    fn list_apps(&self) -> Result<Vec<AppInfo>>;
 }
 
 /// Target for identifying an application.
@@ -76,13 +73,4 @@ pub enum PermissionStatus {
     Granted,
     /// Permissions denied, with platform-specific instructions.
     Denied { instructions: String },
-}
-
-/// Information about a running application.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AppInfo {
-    pub name: String,
-    pub pid: u32,
-    /// macOS bundle identifier
-    pub bundle_id: Option<String>,
 }

--- a/xa11y-fuzz/src/bin/provider_fuzz.rs
+++ b/xa11y-fuzz/src/bin/provider_fuzz.rs
@@ -435,12 +435,12 @@ mod provider_fuzz {
         state.errors += 1;
     }
 
-    fn op_get_all_apps(state: &mut FuzzState) {
+    fn op_get_apps(state: &mut FuzzState) {
         let mut opts = random_query_options(&mut state.rng);
         opts.max_depth = Some(opts.max_depth.map_or(3, |d| d.min(3)));
         opts.max_elements = Some(opts.max_elements.map_or(100, |n| n.min(100)));
-        state.log(&format!("get_all_apps({:?})", opts));
-        match state.provider.get_all_apps(&opts) {
+        state.log(&format!("get_apps({:?})", opts));
+        match state.provider.get_apps(&opts) {
             Ok(tree) => {
                 state.log(&format!("  -> {} nodes", tree.len()));
                 let _ = tree.root_data();
@@ -470,18 +470,6 @@ mod provider_fuzz {
                 );
             }
         }
-    }
-
-    fn op_list_apps(state: &mut FuzzState) {
-        state.log("list_apps()");
-        let apps = state.provider.list_apps().unwrap();
-        assert!(!apps.is_empty(), "list_apps returned empty");
-        let has_test_app = apps.iter().any(|a| a.name.contains("xa11y"));
-        state.log(&format!(
-            "  -> {} apps, test_app_present={}",
-            apps.len(),
-            has_test_app
-        ));
     }
 
     fn op_action_on_node(state: &mut FuzzState) {
@@ -737,10 +725,21 @@ mod provider_fuzz {
 
         let mut test_app_pid = 0u32;
         for attempt in 0..10 {
-            if let Ok(apps) = provider.list_apps() {
-                if let Some(app) = apps.iter().find(|a| a.name.contains("xa11y")) {
-                    test_app_pid = app.pid;
-                    eprintln!("Test app:   {} (PID {})", app.name, app.pid);
+            if let Ok(tree) = provider.get_apps(&QueryOptions {
+                max_depth: Some(1),
+                max_elements: Some(200),
+                ..QueryOptions::default()
+            }) {
+                if let Some(app) = tree
+                    .iter()
+                    .find(|n| n.name.as_deref().is_some_and(|name| name.contains("xa11y")))
+                {
+                    test_app_pid = app.pid.unwrap_or(0);
+                    eprintln!(
+                        "Test app:   {} (PID {})",
+                        app.name.as_deref().unwrap_or("?"),
+                        test_app_pid
+                    );
                     break;
                 }
             }
@@ -777,9 +776,8 @@ mod provider_fuzz {
             ),
             (1, "get_tree_by_pid_not_found", op_get_tree_by_pid_not_found),
             (1, "get_tree_by_window", op_get_tree_by_window),
-            (1, "get_all_apps", op_get_all_apps),
+            (1, "get_apps", op_get_apps),
             (1, "check_permissions", op_check_permissions),
-            (2, "list_apps", op_list_apps),
             (20, "action_on_node", op_action_on_node),
             (3, "action_press", op_action_press),
             (15, "query_tree", op_query_tree),

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use xa11y_core::{
-    Action, ActionData, AppInfo, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
+    Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
     EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, QueryOptions,
     Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
@@ -740,7 +740,7 @@ impl Provider for LinuxProvider {
         Ok(Tree::new(app_name, pid, screen_size, nodes))
     }
 
-    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree> {
         let screen_size = Self::detect_screen_size();
         let mut nodes = Vec::new();
 
@@ -1083,33 +1083,6 @@ impl Provider for LinuxProvider {
             }),
         }
     }
-
-    fn list_apps(&self) -> Result<Vec<AppInfo>> {
-        let registry = AccessibleRef {
-            bus_name: "org.a11y.atspi.Registry".to_string(),
-            path: "/org/a11y/atspi/accessible/root".to_string(),
-        };
-        let children = self.get_children(&registry)?;
-        let mut apps = Vec::new();
-
-        for child in &children {
-            if child.path == "/org/a11y/atspi/null" {
-                continue;
-            }
-            let name = self.get_name(child).unwrap_or_default();
-            if name.is_empty() {
-                continue;
-            }
-            let pid = self.get_app_pid(child);
-            apps.push(AppInfo {
-                name,
-                pid: pid.unwrap_or(0),
-                bundle_id: None,
-            });
-        }
-
-        Ok(apps)
-    }
 }
 
 // ── EventProvider ────────────────────────────────────────────────────────────
@@ -1118,23 +1091,15 @@ impl EventProvider for LinuxProvider {
     fn subscribe(&self, target: &AppTarget, filter: EventFilter) -> Result<Subscription> {
         let (tx, rx) = std::sync::mpsc::channel();
 
-        let app_info = match target {
+        let (app_name, app_pid) = match target {
             AppTarget::ByName(name) => {
                 let app_ref = self.find_app_by_name(name)?;
                 let pid = self.get_app_pid(&app_ref).unwrap_or(0);
-                AppInfo {
-                    name: self.get_name(&app_ref).unwrap_or_default(),
-                    pid,
-                    bundle_id: None,
-                }
+                (self.get_name(&app_ref).unwrap_or_default(), pid)
             }
             AppTarget::ByPid(pid) => {
                 let app_ref = self.find_app_by_pid(*pid)?;
-                AppInfo {
-                    name: self.get_name(&app_ref).unwrap_or_default(),
-                    pid: *pid,
-                    bundle_id: None,
-                }
+                (self.get_name(&app_ref).unwrap_or_default(), *pid)
             }
             AppTarget::ByWindow(_) => {
                 return Err(Error::Platform {
@@ -1175,7 +1140,8 @@ impl EventProvider for LinuxProvider {
                         if filter.kinds.is_empty() || filter.kinds.contains(&kind) {
                             let _ = tx.send(Event {
                                 kind,
-                                app: app_info.clone(),
+                                app_name: app_name.clone(),
+                                app_pid,
                                 target: tree.iter().find(|n| n.states.focused).cloned(),
                                 state_flag: None,
                                 state_value: None,
@@ -1194,7 +1160,8 @@ impl EventProvider for LinuxProvider {
                     if filter.kinds.is_empty() || filter.kinds.contains(&kind) {
                         let _ = tx.send(Event {
                             kind,
-                            app: app_info.clone(),
+                            app_name: app_name.clone(),
+                            app_pid,
                             target: None,
                             state_flag: None,
                             state_value: None,

--- a/xa11y-linux/src/stub.rs
+++ b/xa11y-linux/src/stub.rs
@@ -1,8 +1,8 @@
 //! Stub backend for non-Linux platforms (allows compilation on all targets).
 
 use xa11y_core::{
-    Action, ActionData, AppInfo, AppTarget, Error, NodeData, PermissionStatus, Provider,
-    QueryOptions, Result, Tree,
+    Action, ActionData, AppTarget, Error, NodeData, PermissionStatus, Provider, QueryOptions,
+    Result, Tree,
 };
 
 #[derive(Default)]
@@ -22,7 +22,7 @@ impl Provider for LinuxProvider {
         })
     }
 
-    fn get_all_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
         Err(Error::Platform {
             code: -1,
             message: "Linux backend not available on this platform".to_string(),
@@ -45,13 +45,6 @@ impl Provider for LinuxProvider {
     fn check_permissions(&self) -> Result<PermissionStatus> {
         Ok(PermissionStatus::Denied {
             instructions: "Linux AT-SPI2 backend not available on this platform".to_string(),
-        })
-    }
-
-    fn list_apps(&self) -> Result<Vec<AppInfo>> {
-        Err(Error::Platform {
-            code: -1,
-            message: "Linux backend not available on this platform".to_string(),
         })
     }
 }

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -10,7 +10,7 @@ use core_foundation::number::CFNumber;
 use core_foundation::string::CFString;
 
 use xa11y_core::{
-    Action, ActionData, AppInfo, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
+    Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
     EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, QueryOptions,
     RawPlatformData, Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
@@ -1012,7 +1012,7 @@ impl Provider for MacOSProvider {
         Ok(Tree::new(app_name, Some(pid as u32), screen_size, nodes))
     }
 
-    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree> {
         let screen_size = Self::detect_screen_size();
         let mut nodes = Vec::new();
         let mut elements = Vec::new();
@@ -1316,18 +1316,6 @@ impl Provider for MacOSProvider {
             })
         }
     }
-
-    fn list_apps(&self) -> Result<Vec<AppInfo>> {
-        let apps = Self::list_gui_apps();
-        Ok(apps
-            .into_iter()
-            .map(|(pid, name)| AppInfo {
-                name,
-                pid: pid as u32,
-                bundle_id: None,
-            })
-            .collect())
-    }
 }
 
 // ── EventProvider ────────────────────────────────────────────────────────────
@@ -1336,7 +1324,8 @@ impl Provider for MacOSProvider {
 struct ObserverContext {
     sender: std::sync::mpsc::Sender<Event>,
     filter: EventFilter,
-    app_info: AppInfo,
+    app_name: String,
+    app_pid: u32,
 }
 
 /// AXObserver callback: maps AX notifications to xa11y events and sends them.
@@ -1400,7 +1389,8 @@ unsafe extern "C" fn ax_observer_callback(
 
     let event = Event {
         kind,
-        app: ctx.app_info.clone(),
+        app_name: ctx.app_name.clone(),
+        app_pid: ctx.app_pid,
         target,
         state_flag: None,
         state_value: None,
@@ -1441,11 +1431,8 @@ impl EventProvider for MacOSProvider {
         let ctx = Box::new(ObserverContext {
             sender: tx,
             filter,
-            app_info: AppInfo {
-                name: app_name,
-                pid: pid as u32,
-                bundle_id: None,
-            },
+            app_name,
+            app_pid: pid as u32,
         });
         let ctx_ptr = Box::into_raw(ctx) as *mut c_void;
 

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -28,7 +28,7 @@ mod stub {
         fn get_app_tree(&self, _: &AppTarget, _: &QueryOptions) -> Result<Tree> {
             unreachable!()
         }
-        fn get_all_apps(&self, _: &QueryOptions) -> Result<Tree> {
+        fn get_apps(&self, _: &QueryOptions) -> Result<Tree> {
             unreachable!()
         }
         fn perform_action(
@@ -41,9 +41,6 @@ mod stub {
             unreachable!()
         }
         fn check_permissions(&self) -> Result<PermissionStatus> {
-            unreachable!()
-        }
-        fn list_apps(&self) -> Result<Vec<AppInfo>> {
             unreachable!()
         }
     }

--- a/xa11y-python/python/xa11y/__init__.py
+++ b/xa11y-python/python/xa11y/__init__.py
@@ -13,7 +13,6 @@ Reuse a locator for lazy resolution:
 
 from xa11y._native import (
     ActionNotSupportedError,
-    AppInfo,
     AppNotFoundError,
     InvalidSelectorError,
     Locator,
@@ -25,17 +24,15 @@ from xa11y._native import (
     TimeoutError,
     # Exceptions
     XA11yError,
-    all_apps,
     app,
+    apps,
     check_permissions,
-    list_apps,
     # Functions
     locator,
 )
 
 __all__ = [
     "ActionNotSupportedError",
-    "AppInfo",
     "AppNotFoundError",
     "InvalidSelectorError",
     "Locator",
@@ -46,9 +43,8 @@ __all__ = [
     "SelectorNotMatchedError",
     "TimeoutError",
     "XA11yError",
-    "all_apps",
     "app",
+    "apps",
     "check_permissions",
-    "list_apps",
     "locator",
 ]

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -50,20 +50,6 @@ class Rect:
     def __repr__(self) -> str: ...
     def __eq__(self, other: object) -> bool: ...
 
-class AppInfo:
-    """Information about a running application."""
-
-    @property
-    def name(self) -> str:
-        """Application name."""
-    @property
-    def pid(self) -> int:
-        """Process ID."""
-    @property
-    def bundle_id(self) -> str | None:
-        """Bundle identifier (macOS only, ``None`` on other platforms)."""
-    def __repr__(self) -> str: ...
-
 # ── Node ─────────────────────────────────────────────────────────────────────
 
 class Node:
@@ -292,7 +278,7 @@ def app(
     Identify the app by *name* (substring match) or *pid* (exact).
     """
 
-def all_apps(
+def apps(
     *,
     max_depth: int | None = None,
     max_elements: int | None = None,
@@ -313,9 +299,6 @@ def locator(
 ) -> Locator:
     """Create a :class:`Locator` for lazy element resolution."""
 
-def list_apps() -> list[AppInfo]:
-    """List all running applications that expose accessibility trees."""
-
 def check_permissions() -> str:
     """Check whether accessibility permissions are granted.
 
@@ -325,4 +308,3 @@ def check_permissions() -> str:
 # ── Test helpers ─────────────────────────────────────────────────────────────
 
 def _make_test_tree() -> Node: ...
-def _make_test_apps() -> list[AppInfo]: ...

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -195,30 +195,6 @@ impl Rect {
     }
 }
 
-#[pyclass(frozen)]
-#[derive(Clone)]
-struct AppInfo {
-    #[pyo3(get)]
-    name: String,
-    #[pyo3(get)]
-    pid: u32,
-    #[pyo3(get)]
-    bundle_id: Option<String>,
-}
-
-#[pymethods]
-impl AppInfo {
-    fn __repr__(&self) -> String {
-        match &self.bundle_id {
-            Some(bid) => format!(
-                "AppInfo(name='{}', pid={}, bundle_id='{}')",
-                self.name, self.pid, bid
-            ),
-            None => format!("AppInfo(name='{}', pid={})", self.name, self.pid),
-        }
-    }
-}
-
 // ── Node ────────────────────────────────────────────────────────────────────
 
 /// A node in the accessibility tree snapshot.
@@ -890,7 +866,7 @@ fn app(
 /// Snapshot all running apps and return the root Node.
 #[pyfunction]
 #[pyo3(signature = (*, max_depth=None, max_elements=None, visible_only=false, roles=None))]
-fn all_apps(
+fn apps(
     py: Python<'_>,
     max_depth: Option<u32>,
     max_elements: Option<u32>,
@@ -900,9 +876,7 @@ fn all_apps(
     let provider = get_provider()?;
     let opts = build_query_options(max_depth, max_elements, visible_only, roles);
     let p = provider.clone();
-    let rust_tree = py
-        .allow_threads(|| p.get_all_apps(&opts))
-        .map_err(to_py_err)?;
+    let rust_tree = py.allow_threads(|| p.get_apps(&opts)).map_err(to_py_err)?;
     let target = xa11y::AppTarget::ByName(String::new());
     convert_to_root_node(py, rust_tree, provider, target)
 }
@@ -931,23 +905,6 @@ fn locator(
     })
 }
 
-/// List running applications.
-#[pyfunction]
-fn list_apps(py: Python<'_>) -> PyResult<Vec<AppInfo>> {
-    let provider = get_provider()?;
-    let apps = py
-        .allow_threads(|| provider.list_apps())
-        .map_err(to_py_err)?;
-    Ok(apps
-        .into_iter()
-        .map(|a| AppInfo {
-            name: a.name,
-            pid: a.pid,
-            bundle_id: a.bundle_id,
-        })
-        .collect())
-}
-
 /// Check accessibility permissions. Returns "granted" or raises PermissionDeniedError.
 #[pyfunction]
 fn check_permissions(py: Python<'_>) -> PyResult<String> {
@@ -970,7 +927,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Node>()?;
     m.add_class::<Locator>()?;
     m.add_class::<Rect>()?;
-    m.add_class::<AppInfo>()?;
 
     m.add("XA11yError", m.py().get_type::<XA11yError>())?;
     m.add(
@@ -994,14 +950,12 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("PlatformError", m.py().get_type::<PlatformError>())?;
 
     m.add_function(wrap_pyfunction!(app, m)?)?;
-    m.add_function(wrap_pyfunction!(all_apps, m)?)?;
+    m.add_function(wrap_pyfunction!(apps, m)?)?;
     m.add_function(wrap_pyfunction!(locator, m)?)?;
-    m.add_function(wrap_pyfunction!(list_apps, m)?)?;
     m.add_function(wrap_pyfunction!(check_permissions, m)?)?;
 
     // Test helpers
     m.add_function(wrap_pyfunction!(_make_test_tree, m)?)?;
-    m.add_function(wrap_pyfunction!(_make_test_apps, m)?)?;
 
     Ok(())
 }
@@ -1024,7 +978,7 @@ impl xa11y::Provider for MockProvider {
         Ok(self.tree.clone())
     }
 
-    fn get_all_apps(&self, _opts: &xa11y::QueryOptions) -> xa11y::Result<xa11y::Tree> {
+    fn get_apps(&self, _opts: &xa11y::QueryOptions) -> xa11y::Result<xa11y::Tree> {
         Ok(self.tree.clone())
     }
 
@@ -1045,21 +999,6 @@ impl xa11y::Provider for MockProvider {
 
     fn check_permissions(&self) -> xa11y::Result<xa11y::PermissionStatus> {
         Ok(xa11y::PermissionStatus::Granted)
-    }
-
-    fn list_apps(&self) -> xa11y::Result<Vec<xa11y::AppInfo>> {
-        Ok(vec![
-            xa11y::AppInfo {
-                name: "TestApp".to_string(),
-                pid: 1234,
-                bundle_id: Some("com.test.app".to_string()),
-            },
-            xa11y::AppInfo {
-                name: "OtherApp".to_string(),
-                pid: 5678,
-                bundle_id: None,
-            },
-        ])
     }
 }
 
@@ -1441,21 +1380,4 @@ fn _make_test_tree(py: Python<'_>) -> PyResult<Py<Node>> {
     });
     let target = xa11y::AppTarget::ByName("TestApp".to_string());
     convert_to_root_node(py, tree, provider, target)
-}
-
-/// Create a mock-backed list of apps (for Python unit tests).
-#[pyfunction]
-fn _make_test_apps() -> Vec<AppInfo> {
-    vec![
-        AppInfo {
-            name: "TestApp".to_string(),
-            pid: 1234,
-            bundle_id: Some("com.test.app".to_string()),
-        },
-        AppInfo {
-            name: "OtherApp".to_string(),
-            pid: 5678,
-            bundle_id: None,
-        },
-    ]
 }

--- a/xa11y-python/tests/test_module.py
+++ b/xa11y-python/tests/test_module.py
@@ -9,7 +9,6 @@ def test_all_classes_exported():
     assert hasattr(xa11y, "Node")
     assert hasattr(xa11y, "Locator")
     assert hasattr(xa11y, "Rect")
-    assert hasattr(xa11y, "AppInfo")
 
 
 def test_all_exceptions_exported():
@@ -25,9 +24,8 @@ def test_all_exceptions_exported():
 
 def test_all_functions_exported():
     assert callable(xa11y.app)
-    assert callable(xa11y.all_apps)
+    assert callable(xa11y.apps)
     assert callable(xa11y.locator)
-    assert callable(xa11y.list_apps)
     assert callable(xa11y.check_permissions)
 
 
@@ -38,7 +36,7 @@ def test_all_list():
     assert isinstance(xa11y.__all__, list)
     assert "Node" in xa11y.__all__
     assert "app" in xa11y.__all__
-    assert "all_apps" in xa11y.__all__
+    assert "apps" in xa11y.__all__
     assert "locator" in xa11y.__all__
     assert "XA11yError" in xa11y.__all__
 
@@ -56,7 +54,3 @@ def test_locator_is_type():
 
 def test_rect_is_type():
     assert isinstance(xa11y.Rect, type)
-
-
-def test_app_info_is_type():
-    assert isinstance(xa11y.AppInfo, type)

--- a/xa11y-python/tests/test_provider.py
+++ b/xa11y-python/tests/test_provider.py
@@ -1,6 +1,4 @@
-"""Tests for module-level functions: app(), all_apps(), list_apps(), check_permissions()."""
-
-from xa11y._native import _make_test_apps
+"""Tests for module-level functions: app(), apps(), check_permissions()."""
 
 # ── app() (via _make_test_tree mock) ────────────────────────────────────────
 
@@ -11,29 +9,3 @@ def test_app_root_has_name(tree):
 
 def test_app_root_has_children(tree):
     assert len(tree.children) > 0
-
-
-# ── list_apps() ─────────────────────────────────────────────────────────────
-
-
-def test_list_apps():
-    apps = _make_test_apps()
-    assert len(apps) == 2
-    assert apps[0].name == "TestApp"
-    assert apps[0].pid == 1234
-    assert apps[0].bundle_id == "com.test.app"
-    assert apps[1].name == "OtherApp"
-    assert apps[1].pid == 5678
-    assert apps[1].bundle_id is None
-
-
-def test_app_info_repr():
-    apps = _make_test_apps()
-    r = repr(apps[0])
-    assert "TestApp" in r
-    assert "1234" in r
-    assert "com.test.app" in r
-
-    r2 = repr(apps[1])
-    assert "OtherApp" in r2
-    assert "bundle_id" not in r2

--- a/xa11y-python/tests/test_typing.py
+++ b/xa11y-python/tests/test_typing.py
@@ -9,7 +9,6 @@ def test_stub_types_are_accessible():
     assert xa11y.Node is not None
     assert xa11y.Locator is not None
     assert xa11y.Rect is not None
-    assert xa11y.AppInfo is not None
 
 
 def test_py_typed_marker_exists():

--- a/xa11y-windows/src/stub.rs
+++ b/xa11y-windows/src/stub.rs
@@ -1,8 +1,8 @@
 //! Stub backend for non-Windows platforms (allows compilation on all targets).
 
 use xa11y_core::{
-    Action, ActionData, AppInfo, AppTarget, Error, NodeData, PermissionStatus, Provider,
-    QueryOptions, Result, Tree,
+    Action, ActionData, AppTarget, Error, NodeData, PermissionStatus, Provider, QueryOptions,
+    Result, Tree,
 };
 
 #[derive(Default)]
@@ -21,7 +21,7 @@ impl Provider for WindowsProvider {
     fn get_app_tree(&self, _: &AppTarget, _: &QueryOptions) -> Result<Tree> {
         unreachable!()
     }
-    fn get_all_apps(&self, _: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self, _: &QueryOptions) -> Result<Tree> {
         unreachable!()
     }
     fn perform_action(
@@ -34,9 +34,6 @@ impl Provider for WindowsProvider {
         unreachable!()
     }
     fn check_permissions(&self) -> Result<PermissionStatus> {
-        unreachable!()
-    }
-    fn list_apps(&self) -> Result<Vec<AppInfo>> {
         unreachable!()
     }
 }

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -11,7 +11,7 @@ use windows::Win32::System::Threading::*;
 use windows::Win32::UI::Accessibility::*;
 
 use xa11y_core::{
-    Action, ActionData, AppInfo, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
+    Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
     EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, QueryOptions,
     RawPlatformData, Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
@@ -589,7 +589,7 @@ impl Provider for WindowsProvider {
         Ok(Tree::new(app_name, Some(pid), screen_size, nodes))
     }
 
-    fn get_all_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree> {
         let screen_size = Self::detect_screen_size();
         let mut nodes = Vec::new();
         let mut elements = Vec::new();
@@ -1025,18 +1025,6 @@ impl Provider for WindowsProvider {
     fn check_permissions(&self) -> Result<PermissionStatus> {
         Ok(PermissionStatus::Granted)
     }
-
-    fn list_apps(&self) -> Result<Vec<AppInfo>> {
-        let apps = self.list_gui_apps();
-        Ok(apps
-            .into_iter()
-            .map(|(pid, name)| AppInfo {
-                name,
-                pid,
-                bundle_id: None,
-            })
-            .collect())
-    }
 }
 
 // ── Helper Functions ─────────────────────────────────────────────────────────
@@ -1324,18 +1312,14 @@ impl EventProvider for WindowsProvider {
     fn subscribe(&self, target: &AppTarget, filter: EventFilter) -> Result<Subscription> {
         let (tx, rx) = std::sync::mpsc::channel();
 
-        let app_info = match target {
+        let (app_name, app_pid) = match target {
             AppTarget::ByName(name) => {
                 let apps = self.list_gui_apps();
                 let found = apps
                     .iter()
                     .find(|(_, n)| n.to_lowercase().contains(&name.to_lowercase()));
                 match found {
-                    Some((pid, name)) => AppInfo {
-                        name: name.clone(),
-                        pid: *pid,
-                        bundle_id: None,
-                    },
+                    Some((pid, name)) => (name.clone(), *pid),
                     None => {
                         return Err(Error::AppNotFound {
                             target: name.clone(),
@@ -1343,11 +1327,7 @@ impl EventProvider for WindowsProvider {
                     }
                 }
             }
-            AppTarget::ByPid(pid) => AppInfo {
-                name: String::new(),
-                pid: *pid,
-                bundle_id: None,
-            },
+            AppTarget::ByPid(pid) => (String::new(), *pid),
             AppTarget::ByWindow(_) => {
                 return Err(Error::Platform {
                     code: -1,
@@ -1386,7 +1366,8 @@ impl EventProvider for WindowsProvider {
                         if filter.kinds.is_empty() || filter.kinds.contains(&kind) {
                             let _ = tx.send(Event {
                                 kind,
-                                app: app_info.clone(),
+                                app_name: app_name.clone(),
+                                app_pid,
                                 target: tree.iter().find(|n| n.states.focused).cloned(),
                                 state_flag: None,
                                 state_value: None,
@@ -1405,7 +1386,8 @@ impl EventProvider for WindowsProvider {
                     if filter.kinds.is_empty() || filter.kinds.contains(&kind) {
                         let _ = tx.send(Event {
                             kind,
-                            app: app_info.clone(),
+                            app_name: app_name.clone(),
+                            app_pid,
                             target: None,
                             state_flag: None,
                             state_value: None,

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -42,9 +42,9 @@
 use std::sync::{Arc, OnceLock};
 
 // Re-export public types. Tree is exported because Provider trait methods reference it,
-// but end users should interact with Node (returned by app/all_apps), not Tree directly.
+// but end users should interact with Node (returned by app/apps), not Tree directly.
 pub use xa11y_core::{
-    Action, ActionData, AppInfo, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
+    Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
     EventKind, EventProvider, EventReceiver, Locator, Node, NodeData, PermissionStatus, Provider,
     QueryOptions, RawPlatformData, Rect, Result, Role, ScrollDirection, StateFlag, StateSet,
     Subscription, TextChangeData, TextChangeType, Toggled, Tree, WindowHandle,
@@ -79,8 +79,8 @@ impl Provider for StaticProviderRef {
     fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<xa11y_core::Tree> {
         self.0.get_app_tree(target, opts)
     }
-    fn get_all_apps(&self, opts: &QueryOptions) -> Result<xa11y_core::Tree> {
-        self.0.get_all_apps(opts)
+    fn get_apps(&self, opts: &QueryOptions) -> Result<xa11y_core::Tree> {
+        self.0.get_apps(opts)
     }
     fn perform_action(
         &self,
@@ -94,14 +94,11 @@ impl Provider for StaticProviderRef {
     fn check_permissions(&self) -> Result<PermissionStatus> {
         self.0.check_permissions()
     }
-    fn list_apps(&self) -> Result<Vec<AppInfo>> {
-        self.0.list_apps()
-    }
 }
 
 /// Get the global provider as an `Arc<dyn Provider>`.
 ///
-/// Returns a handle to the same singleton used by `app()`, `all_apps()`, etc.
+/// Returns a handle to the same singleton used by `app()`, `apps()`, etc.
 /// Useful when you need to pass a provider to objects that store it (e.g. `Locator`).
 pub fn provider() -> Result<Arc<dyn Provider>> {
     Ok(Arc::new(StaticProviderRef(get_provider_ref()?)))
@@ -123,8 +120,8 @@ pub fn app(target: &AppTarget, opts: &QueryOptions) -> Result<Node> {
 /// Snapshot all running applications (shallow).
 ///
 /// Returns the root [`Node`] of a merged tree containing all apps.
-pub fn all_apps(opts: &QueryOptions) -> Result<Node> {
-    let tree = get_provider_ref()?.get_all_apps(opts)?;
+pub fn apps(opts: &QueryOptions) -> Result<Node> {
+    let tree = get_provider_ref()?.get_apps(opts)?;
     let tree = Arc::new(tree);
     Ok(Node::new(tree, 0))
 }
@@ -145,11 +142,6 @@ pub fn perform_action(node: &Node, action: Action, data: Option<ActionData>) -> 
 /// Check if accessibility permissions are granted.
 pub fn check_permissions() -> Result<PermissionStatus> {
     get_provider_ref()?.check_permissions()
-}
-
-/// List running applications with their PIDs.
-pub fn list_apps() -> Result<Vec<AppInfo>> {
-    get_provider_ref()?.list_apps()
 }
 
 /// Create a Locator targeting a specific application.

--- a/xa11y/tests/INTEG_COVERAGE.md
+++ b/xa11y/tests/INTEG_COVERAGE.md
@@ -10,10 +10,9 @@ Last updated: 2026-03-19
 | Method | Status | Tests |
 |--------|--------|-------|
 | `get_app_tree` | Covered | All tree/selector/query tests |
-| `get_all_apps` | Covered | `get_all_apps_returns_nonempty` |
+| `get_apps` | Covered | `apps_returns_nonempty` |
 | `perform_action` | Covered | Multiple action tests (Press, Focus, SetValue, Increment, Decrement, Expand, Collapse) |
 | `check_permissions` | Covered | `check_permissions_granted` |
-| `list_apps` | Covered | `list_apps_includes_test_app`, `list_apps_has_valid_pids` |
 
 ## AppTarget Variants
 

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -16,7 +16,7 @@ mod tests {
     use xa11y::*;
 
     // ════════════════════════════════════════════════════════════════
-    // Provider Operations (6 tests)
+    // Provider Operations (4 tests)
     // ════════════════════════════════════════════════════════════════
 
     #[test]
@@ -32,38 +32,15 @@ mod tests {
 
     #[test]
     #[ignore]
-    fn list_apps_includes_test_app() {
-        let apps = xa11y::list_apps().unwrap();
-        assert!(
-            apps.iter().any(|a| a.name.contains("xa11y")),
-            "Test app not in app list: {:?}",
-            apps.iter().map(|a| &a.name).collect::<Vec<_>>()
-        );
-    }
-
-    #[test]
-    #[ignore]
-    fn list_apps_has_valid_pids() {
-        let apps = xa11y::list_apps().unwrap();
-        let test_app = apps.iter().find(|a| a.name.contains("xa11y"));
-        assert!(test_app.is_some());
-        assert!(
-            test_app.unwrap().pid > 0,
-            "Test app should have a valid PID"
-        );
-    }
-
-    #[test]
-    #[ignore]
-    fn get_all_apps_returns_nonempty() {
+    fn apps_returns_nonempty() {
         // Limit depth/elements to avoid traversing every app on the system
-        let root = xa11y::all_apps(&QueryOptions {
+        let root = xa11y::apps(&QueryOptions {
             max_depth: Some(2),
             max_elements: Some(200),
             ..QueryOptions::default()
         })
         .unwrap();
-        assert!(!root.tree().is_empty(), "get_all_apps should return nodes");
+        assert!(!root.tree().is_empty(), "apps should return nodes");
         assert_eq!(root.tree().app_name, "Desktop");
         assert!(
             root.tree().pid.is_none(),
@@ -76,7 +53,7 @@ mod tests {
             .any(|n| n.name.as_deref().is_some_and(|name| name.contains("xa11y")));
         assert!(
             has_test_app,
-            "get_all_apps should include the test app. Apps: {:?}",
+            "apps should include the test app. Apps: {:?}",
             root.subtree()
                 .iter()
                 .filter(|n| n.parent_index.is_none_or(|p| p == 0))
@@ -88,9 +65,19 @@ mod tests {
     #[test]
     #[ignore]
     fn app_target_by_pid() {
-        let apps = xa11y::list_apps().unwrap();
-        let test_app = apps.iter().find(|a| a.name.contains("xa11y")).unwrap();
-        let pid = test_app.pid;
+        // Find test app PID from the apps tree
+        let root = xa11y::apps(&QueryOptions {
+            max_depth: Some(1),
+            max_elements: Some(200),
+            ..QueryOptions::default()
+        })
+        .unwrap();
+        let subtree = root.subtree();
+        let test_app = subtree
+            .iter()
+            .find(|n| n.name.as_deref().is_some_and(|name| name.contains("xa11y")))
+            .expect("Test app not found in apps tree");
+        let pid = test_app.pid.expect("Test app should have a PID");
         assert!(pid > 0);
         let root = xa11y::app(&AppTarget::ByPid(pid), &QueryOptions::default()).unwrap();
         assert!(!root.tree().is_empty());

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -854,8 +854,6 @@ fn platform_provider_operations_return_errors() {
         &QueryOptions::default(),
     );
     assert!(result.is_err());
-
-    let _result = provider.list_apps();
 }
 
 // ── Selector edge cases ──
@@ -927,7 +925,7 @@ impl Provider for MockProvider {
         Ok(self.tree.clone())
     }
 
-    fn get_all_apps(&self, _opts: &QueryOptions) -> xa11y::Result<Tree> {
+    fn get_apps(&self, _opts: &QueryOptions) -> xa11y::Result<Tree> {
         Ok(self.tree.clone())
     }
 
@@ -944,10 +942,6 @@ impl Provider for MockProvider {
 
     fn check_permissions(&self) -> xa11y::Result<PermissionStatus> {
         Ok(PermissionStatus::Granted)
-    }
-
-    fn list_apps(&self) -> xa11y::Result<Vec<AppInfo>> {
-        Ok(vec![])
     }
 }
 


### PR DESCRIPTION
The apps() function (formerly all_apps()) returns a full tree with all
app information, making the separate list_apps() -> Vec<AppInfo> redundant.

- Remove AppInfo struct from xa11y-core and all re-exports
- Remove list_apps() from Provider trait and all implementations
- Rename get_all_apps() -> get_apps() in Provider trait
- Rename all_apps() -> apps() in public Rust and Python APIs
- Inline app_name/app_pid fields directly into Event struct
- Update all platform providers, stubs, tests, fuzz targets, and docs

https://claude.ai/code/session_01EuPKe7MmUHCgAzCUaJpW5U