### PR TITLE
Remove synthetic_empty hack from wait API

### DIFF
--- a/xa11y-core/src/event_provider.rs
+++ b/xa11y-core/src/event_provider.rs
@@ -28,7 +28,7 @@ pub trait EventProvider: Provider {
         selector: &str,
         state: ElementState,
         timeout: Duration,
-    ) -> Result<NodeData>;
+    ) -> Result<Option<NodeData>>;
 }
 
 /// A live event subscription. Drop to unsubscribe.

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -360,46 +360,54 @@ impl Locator {
     /// Wait until the element is visible, polling with fresh snapshots.
     pub fn wait_visible(&self, timeout: Duration) -> Result<Node> {
         self.wait_for_state(ElementState::Visible, timeout)
+            .map(|opt| opt.expect("visible wait must return a node"))
     }
 
     /// Wait until the element exists in the tree.
     pub fn wait_attached(&self, timeout: Duration) -> Result<Node> {
         self.wait_for_state(ElementState::Attached, timeout)
+            .map(|opt| opt.expect("attached wait must return a node"))
     }
 
     /// Wait until the element is removed from the tree.
-    pub fn wait_detached(&self, timeout: Duration) -> Result<Node> {
+    pub fn wait_detached(&self, timeout: Duration) -> Result<()> {
         self.wait_for_state(ElementState::Detached, timeout)
+            .map(|_| ())
     }
 
     /// Wait until the element is enabled.
     pub fn wait_enabled(&self, timeout: Duration) -> Result<Node> {
         self.wait_for_state(ElementState::Enabled, timeout)
+            .map(|opt| opt.expect("enabled wait must return a node"))
     }
 
     /// Wait until the element is disabled (exists but not enabled).
     pub fn wait_disabled(&self, timeout: Duration) -> Result<Node> {
         self.wait_for_state(ElementState::Disabled, timeout)
+            .map(|opt| opt.expect("disabled wait must return a node"))
     }
 
     /// Wait until the element is hidden or removed.
-    pub fn wait_hidden(&self, timeout: Duration) -> Result<Node> {
+    pub fn wait_hidden(&self, timeout: Duration) -> Result<()> {
         self.wait_for_state(ElementState::Hidden, timeout)
+            .map(|_| ())
     }
 
     /// Wait until the element has keyboard focus.
     pub fn wait_focused(&self, timeout: Duration) -> Result<Node> {
         self.wait_for_state(ElementState::Focused, timeout)
+            .map(|opt| opt.expect("focused wait must return a node"))
     }
 
     /// Wait until the element does not have keyboard focus.
     pub fn wait_unfocused(&self, timeout: Duration) -> Result<Node> {
         self.wait_for_state(ElementState::Unfocused, timeout)
+            .map(|opt| opt.expect("unfocused wait must return a node"))
     }
 
     /// Wait for an [`ElementState`] condition to be met.
-    pub fn wait_for_state(&self, state: ElementState, timeout: Duration) -> Result<Node> {
-        self.poll_until(|node| state.is_met(node), state.is_absence_state(), timeout)
+    pub fn wait_for_state(&self, state: ElementState, timeout: Duration) -> Result<Option<Node>> {
+        self.poll_until(|node| state.is_met(node), timeout)
     }
 
     /// Wait until an arbitrary predicate is satisfied, polling with fresh
@@ -411,17 +419,16 @@ impl Locator {
         &self,
         predicate: impl Fn(Option<&NodeData>) -> bool,
         timeout: Duration,
-    ) -> Result<Node> {
-        self.poll_until(&predicate, false, timeout)
+    ) -> Result<Option<Node>> {
+        self.poll_until(&predicate, timeout)
     }
 
     /// Core polling loop shared by `wait_for_state` and `wait_until`.
     fn poll_until(
         &self,
         predicate: impl Fn(Option<&NodeData>) -> bool,
-        allow_absent: bool,
         timeout: Duration,
-    ) -> Result<Node> {
+    ) -> Result<Option<Node>> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -438,14 +445,7 @@ impl Locator {
             let node_ref = matched_index.and_then(|i| tree.get_data(i));
 
             if predicate(node_ref) {
-                return if allow_absent {
-                    Ok(matched_index
-                        .map(|i| Node::new(Arc::new(tree), i))
-                        .unwrap_or_else(Node::synthetic_empty))
-                } else {
-                    let i = matched_index.expect("predicate requires node to exist");
-                    Ok(Node::new(Arc::new(tree), i))
-                };
+                return Ok(matched_index.map(|i| Node::new(Arc::new(tree), i)));
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y-core/src/node.rs
+++ b/xa11y-core/src/node.rs
@@ -84,31 +84,6 @@ pub struct NodeData {
     pub parent_index: Option<NodeIndex>,
 }
 
-impl NodeData {
-    /// Create a synthetic empty node, used as a placeholder when a wait
-    /// condition is satisfied by the *absence* of a node (e.g. Detached/Hidden).
-    pub fn synthetic_empty() -> Self {
-        Self {
-            role: Role::Unknown,
-            name: None,
-            value: None,
-            description: None,
-            bounds: None,
-            actions: vec![],
-            states: StateSet::default(),
-            numeric_value: None,
-            min_value: None,
-            max_value: None,
-            stable_id: None,
-            pid: None,
-            raw: RawPlatformData::Synthetic,
-            index: 0,
-            children_indices: vec![],
-            parent_index: None,
-        }
-    }
-}
-
 /// A node in an accessibility tree snapshot, with navigation.
 ///
 /// `Node` dereferences to [`NodeData`], so all properties (`role`, `name`,
@@ -215,18 +190,6 @@ impl Node {
             .into_iter()
             .map(|idx| Node::new(Arc::clone(&self.snapshot), idx))
             .collect())
-    }
-
-    /// Get a synthetic empty Node (no snapshot navigation).
-    /// Used as a placeholder when a wait condition is satisfied by absence.
-    pub fn synthetic_empty() -> Self {
-        let tree = Tree::new(
-            String::new(),
-            None,
-            (0, 0),
-            vec![NodeData::synthetic_empty()],
-        );
-        Node::new(Arc::new(tree), 0)
     }
 }
 

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1208,7 +1208,7 @@ impl EventProvider for LinuxProvider {
         selector: &str,
         state: ElementState,
         timeout: Duration,
-    ) -> Result<NodeData> {
+    ) -> Result<Option<NodeData>> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -1223,7 +1223,7 @@ impl EventProvider for LinuxProvider {
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
             if state.is_met(node) {
-                return Ok(node.cloned().unwrap_or_else(NodeData::synthetic_empty));
+                return Ok(node.cloned());
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1555,7 +1555,7 @@ impl EventProvider for MacOSProvider {
         selector: &str,
         state: ElementState,
         timeout: Duration,
-    ) -> Result<NodeData> {
+    ) -> Result<Option<NodeData>> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -1570,7 +1570,7 @@ impl EventProvider for MacOSProvider {
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
             if state.is_met(node) {
-                return Ok(node.cloned().unwrap_or_else(NodeData::synthetic_empty));
+                return Ok(node.cloned());
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -1434,7 +1434,7 @@ impl EventProvider for WindowsProvider {
         selector: &str,
         state: ElementState,
         timeout: Duration,
-    ) -> Result<NodeData> {
+    ) -> Result<Option<NodeData>> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -1449,7 +1449,7 @@ impl EventProvider for WindowsProvider {
             let node = matches.as_ref().and_then(|m| m.first().copied());
 
             if state.is_met(node) {
-                return Ok(node.cloned().unwrap_or_else(NodeData::synthetic_empty));
+                return Ok(node.cloned());
             }
 
             std::thread::sleep(poll_interval);

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -1634,7 +1634,7 @@ mod tests {
             "wait_for attached should succeed: {:?}",
             result.err()
         );
-        let node = result.unwrap();
+        let node = result.unwrap().expect("attached node should exist");
         assert_eq!(node.role, Role::Button);
     }
 }


### PR DESCRIPTION
Absence-based waits (wait_detached, wait_hidden) now return Result<()>
instead of manufacturing a fake Node. Presence-based waits keep returning
Result<Node>. The internal poll_until returns Result<Option<Node>>,
and EventProvider::wait_for returns Result<Option<NodeData>>.

https://claude.ai/code/session_019tiaMqXXwMFURNXygVCt5M