### PR TITLE
Remove QueryOptions from public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,16 @@ Cross-platform accessibility library for reading and interacting with accessibil
 use xa11y::*;
 
 fn main() -> Result<()> {
-    let provider = create_provider()?;
-
     // Get the accessibility tree for an app
-    let tree = provider.get_app_tree(
-        &AppTarget::ByName("Safari".to_string()),
-        &QueryOptions::default(),
-    )?;
+    let root = app(&AppTarget::ByName("Safari".to_string()))?;
 
     // Find elements with CSS-like selectors
-    let buttons = tree.query("button[name='Submit']")?;
+    let buttons = root.query("button[name='Submit']")?;
     println!("Found {} buttons", buttons.len());
 
     // Interact with elements
-    let submit = Locator::new(&*provider, AppTarget::ByName("Safari".to_string()), "button[name='Submit']");
-    submit.press()?;
+    let loc = locator(AppTarget::ByName("Safari".to_string()), "button[name='Submit']")?;
+    loc.press()?;
 
     Ok(())
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -400,10 +400,10 @@ integer       := [1-9][0-9]*
 pub trait Provider: Send + Sync {
     /// Snapshot a specific application's accessibility tree.
     /// Platform handles are cached internally for action dispatch.
-    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree>;
+    fn get_app_tree(&self, target: &AppTarget) -> Result<Tree>;
 
     /// Snapshot all running applications (shallow).
-    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree>;
+    fn get_apps(&self) -> Result<Tree>;
 
     /// Perform an action on an element from a specific snapshot.
     ///
@@ -441,14 +441,6 @@ pub enum AppTarget {
     ByWindow(WindowHandle),
 }
 
-pub struct QueryOptions {
-    /// Maximum tree depth to traverse. `None` = unlimited.
-    pub max_depth: Option<u32>,
-    /// Maximum number of elements to collect. `None` = unlimited.
-    pub max_elements: Option<u32>,
-    pub visible_only: bool,
-    pub roles: Option<Vec<Role>>,   // filter to specific roles
-}
 // Note: RawPlatformData is always populated on nodes. Platform handles are
 // always cached internally for action dispatch.
 
@@ -542,7 +534,7 @@ xa11y/
 │   ├── node.rs          # Node, StateSet, Rect
 │   ├── tree.rs          # Tree snapshot
 │   ├── selector.rs      # CSS-like query parser + matcher
-│   ├── provider.rs      # Provider trait, QueryOptions, AppTarget
+│   ├── provider.rs      # Provider trait, AppTarget
 │   └── lib.rs
 │
 ├── xa11y-macos/         # macOS backend (AXUIElement via FFI)

--- a/docs/site/src/content/docs/api/rust.mdx
+++ b/docs/site/src/content/docs/api/rust.mdx
@@ -12,13 +12,9 @@ cargo add xa11y
 ```rust
 use xa11y::*;
 
-let provider = create_provider()?;
-let tree = provider.get_app_tree(
-    &AppTarget::ByName("Safari".to_string()),
-    &QueryOptions::default(),
-)?;
+let root = app(&AppTarget::ByName("Safari".to_string()))?;
 
-for node in tree.query("button")? {
+for node in root.query("button")? {
     println!("{:?}", node.name);
 }
 ```

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -75,16 +75,11 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     use xa11y::*;
 
     fn main() -> Result<()> {
-        let provider = create_provider()?;
-
         // Get the accessibility tree for an app by name
-        let tree = provider.get_app_tree(
-            &AppTarget::ByName("Safari".to_string()),
-            &QueryOptions::default(),
-        )?;
+        let root = app(&AppTarget::ByName("Safari".to_string()))?;
 
-        println!("Root: {:?}", tree.root().role);
-        println!("Children: {}", tree.children(tree.root()).len());
+        println!("Root: {:?}", root.role);
+        println!("Children: {}", root.children().len());
 
         Ok(())
     }
@@ -112,22 +107,18 @@ xa11y supports CSS-like selectors to find elements in the tree.
     ```rust
     use xa11y::*;
 
-    let provider = create_provider()?;
-    let tree = provider.get_app_tree(
-        &AppTarget::ByName("Safari".to_string()),
-        &QueryOptions::default(),
-    )?;
+    let root = app(&AppTarget::ByName("Safari".to_string()))?;
 
     // Find all buttons
-    let buttons = tree.query("button")?;
+    let buttons = root.query("button")?;
 
     // Find a button by name
-    let submit = tree.query("button[name='Submit']")?;
+    let submit = root.query("button[name='Submit']")?;
     let first = &submit[0];
     println!("Found: {}", first.name.as_deref().unwrap_or("unnamed"));
 
     // Find text fields
-    let fields = tree.query("textfield")?;
+    let fields = root.query("textfield")?;
     ```
   </TabItem>
   <TabItem label="Python">
@@ -194,10 +185,7 @@ xa11y supports CSS-like selectors to find elements in the tree.
     ```rust
     use xa11y::*;
 
-    let root = apps(&QueryOptions {
-        max_depth: Some(1),
-        ..QueryOptions::default()
-    })?;
+    let root = apps()?;
 
     for child in root.children() {
         println!("{} (pid: {:?})", child.name.as_deref().unwrap_or("?"), child.pid());
@@ -208,7 +196,7 @@ xa11y supports CSS-like selectors to find elements in the tree.
     ```python
     import xa11y
 
-    root = xa11y.apps(max_depth=1)
+    root = xa11y.apps()
     for child in root.children:
         print(f"{child.name} (pid: {child.pid})")
     ```

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -18,6 +18,6 @@ pub use event::{
 pub use event_provider::{CancelHandle, EventProvider, EventReceiver, Subscription};
 pub use locator::Locator;
 pub use node::{Node, NodeData, RawPlatformData, Rect, StateSet, Toggled};
-pub use provider::{AppTarget, PermissionStatus, Provider, QueryOptions, WindowHandle};
+pub use provider::{AppTarget, PermissionStatus, Provider, WindowHandle};
 pub use role::Role;
 pub use tree::Tree;

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -5,7 +5,7 @@ use crate::action::{Action, ActionData, ScrollDirection};
 use crate::error::{Error, Result};
 use crate::event::ElementState;
 use crate::node::{Node, NodeData, Rect, StateSet};
-use crate::provider::{AppTarget, Provider, QueryOptions};
+use crate::provider::{AppTarget, Provider};
 use crate::role::Role;
 use crate::tree::Tree;
 
@@ -34,7 +34,6 @@ pub struct Locator {
     provider: Arc<dyn Provider>,
     target: AppTarget,
     selector: String,
-    opts: QueryOptions,
     /// Which match to select (0-based). `None` means first match.
     nth: Option<usize>,
 }
@@ -48,29 +47,12 @@ struct Resolved {
 }
 
 impl Locator {
-    /// Create a new Locator with default query options.
+    /// Create a new Locator.
     pub fn new(provider: Arc<dyn Provider>, target: AppTarget, selector: &str) -> Self {
         Self {
             provider,
             target,
             selector: selector.to_string(),
-            opts: QueryOptions::default(),
-            nth: None,
-        }
-    }
-
-    /// Create a new Locator with custom query options.
-    pub fn with_opts(
-        provider: Arc<dyn Provider>,
-        target: AppTarget,
-        selector: &str,
-        opts: QueryOptions,
-    ) -> Self {
-        Self {
-            provider,
-            target,
-            selector: selector.to_string(),
-            opts,
             nth: None,
         }
     }
@@ -114,7 +96,7 @@ impl Locator {
 
     /// Snapshot the tree and resolve the selector to a single node.
     fn resolve(&self) -> Result<Resolved> {
-        let tree = self.provider.get_app_tree(&self.target, &self.opts)?;
+        let tree = self.provider.get_app_tree(&self.target)?;
         let matches = tree.query(&self.selector)?;
         let idx = self.nth.unwrap_or(0);
         let node = matches.get(idx).ok_or_else(|| Error::SelectorNotMatched {
@@ -198,7 +180,7 @@ impl Locator {
 
     /// Count matching elements in the current tree.
     pub fn count(&self) -> Result<usize> {
-        let tree = self.provider.get_app_tree(&self.target, &self.opts)?;
+        let tree = self.provider.get_app_tree(&self.target)?;
         let matches = tree.query(&self.selector)?;
         Ok(matches.len())
     }
@@ -431,7 +413,7 @@ impl Locator {
                 return Err(Error::Timeout { elapsed });
             }
 
-            let tree = self.provider.get_app_tree(&self.target, &self.opts)?;
+            let tree = self.provider.get_app_tree(&self.target)?;
             let matches = tree.query(&self.selector).ok();
             let idx = self.nth.unwrap_or(0);
             let matched_index = matches.as_ref().and_then(|m| m.get(idx).map(|n| n.index));

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -3,16 +3,15 @@ use serde::{Deserialize, Serialize};
 use crate::action::{Action, ActionData};
 use crate::error::Result;
 use crate::node::NodeData;
-use crate::role::Role;
 use crate::tree::Tree;
 
 /// Platform backend trait for accessibility tree access.
 pub trait Provider: Send + Sync {
     /// Snapshot a specific application's accessibility tree.
-    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree>;
+    fn get_app_tree(&self, target: &AppTarget) -> Result<Tree>;
 
     /// Snapshot all running applications (shallow).
-    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree>;
+    fn get_apps(&self) -> Result<Tree>;
 
     /// Perform an action on an element from a specific snapshot.
     ///
@@ -51,19 +50,6 @@ pub enum WindowHandle {
     Windows(usize),
     /// Linux X11 window ID
     X11(u64),
-}
-
-/// Options controlling tree traversal and content.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct QueryOptions {
-    /// Maximum tree depth to traverse. `None` = unlimited.
-    pub max_depth: Option<u32>,
-    /// Maximum number of elements to collect. `None` = unlimited.
-    pub max_elements: Option<u32>,
-    /// Only include visible elements.
-    pub visible_only: bool,
-    /// Filter to specific roles. Empty = no filter.
-    pub roles: Vec<Role>,
 }
 
 /// Result of a permission check.

--- a/xa11y-fuzz/src/bin/provider_fuzz.rs
+++ b/xa11y-fuzz/src/bin/provider_fuzz.rs
@@ -230,46 +230,6 @@ mod provider_fuzz {
         }
     }
 
-    // ── QueryOptions Generation ──────────────────────────────────────────────
-
-    fn random_query_options(rng: &mut StdRng) -> QueryOptions {
-        let max_depth = match rng.random_range(0u8..10) {
-            0..=3 => None,
-            4 => Some(0),
-            5 => Some(1),
-            6..=7 => Some(rng.random_range(2..6)),
-            _ => Some(rng.random_range(10..100)),
-        };
-
-        let max_elements = match rng.random_range(0u8..10) {
-            0..=5 => None,
-            6 => Some(1),
-            7 => Some(rng.random_range(2..10)),
-            8 => Some(rng.random_range(10..50)),
-            _ => Some(rng.random_range(50..500)),
-        };
-
-        let visible_only = rng.random_bool(0.3);
-
-        let roles = if rng.random_bool(0.2) {
-            let count = rng.random_range(1..=5);
-            let mut r = Vec::with_capacity(count);
-            for _ in 0..count {
-                r.push(ALL_ROLES[rng.random_range(0..ALL_ROLES.len())]);
-            }
-            r
-        } else {
-            Vec::new()
-        };
-
-        QueryOptions {
-            max_depth,
-            max_elements,
-            visible_only,
-            roles,
-        }
-    }
-
     // ── ActionData Generation ────────────────────────────────────────────────
 
     fn random_action_data(
@@ -352,10 +312,10 @@ mod provider_fuzz {
 
         fn ensure_tree(&mut self) {
             if self.tree.is_none() {
-                match self.provider.get_app_tree(
-                    &AppTarget::ByName("xa11y".to_string()),
-                    &QueryOptions::default(),
-                ) {
+                match self
+                    .provider
+                    .get_app_tree(&AppTarget::ByName("xa11y".to_string()))
+                {
                     Ok(tree) => self.tree = Some(tree),
                     Err(e) => self.log(&format!("ensure_tree failed: {}", e)),
                 }
@@ -366,11 +326,10 @@ mod provider_fuzz {
     // ── Operations ───────────────────────────────────────────────────────────
 
     fn op_get_tree_by_name(state: &mut FuzzState) {
-        let opts = random_query_options(&mut state.rng);
-        state.log(&format!("get_app_tree(ByName, {:?})", opts));
+        state.log("get_app_tree(ByName)");
         match state
             .provider
-            .get_app_tree(&AppTarget::ByName("xa11y".to_string()), &opts)
+            .get_app_tree(&AppTarget::ByName("xa11y".to_string()))
         {
             Ok(tree) => {
                 inspect_tree(&tree, &mut state.rng);
@@ -384,14 +343,10 @@ mod provider_fuzz {
     }
 
     fn op_get_tree_by_pid(state: &mut FuzzState) {
-        let opts = random_query_options(&mut state.rng);
-        state.log(&format!(
-            "get_app_tree(ByPid({}), {:?})",
-            state.test_app_pid, opts
-        ));
+        state.log(&format!("get_app_tree(ByPid({}))", state.test_app_pid));
         match state
             .provider
-            .get_app_tree(&AppTarget::ByPid(state.test_app_pid), &opts)
+            .get_app_tree(&AppTarget::ByPid(state.test_app_pid))
         {
             Ok(tree) => {
                 inspect_tree(&tree, &mut state.rng);
@@ -406,19 +361,16 @@ mod provider_fuzz {
 
     fn op_get_tree_by_name_not_found(state: &mut FuzzState) {
         state.log("get_app_tree(ByName(\"nonexistent_app_XYZ\"))");
-        let result = state.provider.get_app_tree(
-            &AppTarget::ByName("nonexistent_app_XYZ_999".to_string()),
-            &QueryOptions::default(),
-        );
+        let result = state
+            .provider
+            .get_app_tree(&AppTarget::ByName("nonexistent_app_XYZ_999".to_string()));
         assert!(result.is_err(), "Expected AppNotFound for bogus app name");
         state.errors += 1;
     }
 
     fn op_get_tree_by_pid_not_found(state: &mut FuzzState) {
         state.log("get_app_tree(ByPid(99999))");
-        let result = state
-            .provider
-            .get_app_tree(&AppTarget::ByPid(99999), &QueryOptions::default());
+        let result = state.provider.get_app_tree(&AppTarget::ByPid(99999));
         match result {
             Ok(tree) => inspect_tree(&tree, &mut state.rng),
             Err(_) => state.errors += 1,
@@ -427,20 +379,16 @@ mod provider_fuzz {
 
     fn op_get_tree_by_window(state: &mut FuzzState) {
         state.log("get_app_tree(ByWindow) -> expected error");
-        let result = state.provider.get_app_tree(
-            &AppTarget::ByWindow(WindowHandle::MacOS(0)),
-            &QueryOptions::default(),
-        );
+        let result = state
+            .provider
+            .get_app_tree(&AppTarget::ByWindow(WindowHandle::MacOS(0)));
         assert!(result.is_err(), "Expected ByWindow to fail on macOS");
         state.errors += 1;
     }
 
     fn op_get_apps(state: &mut FuzzState) {
-        let mut opts = random_query_options(&mut state.rng);
-        opts.max_depth = Some(opts.max_depth.map_or(3, |d| d.min(3)));
-        opts.max_elements = Some(opts.max_elements.map_or(100, |n| n.min(100)));
-        state.log(&format!("get_apps({:?})", opts));
-        match state.provider.get_apps(&opts) {
+        state.log("get_apps()");
+        match state.provider.get_apps() {
             Ok(tree) => {
                 state.log(&format!("  -> {} nodes", tree.len()));
                 let _ = tree.root_data();
@@ -725,11 +673,7 @@ mod provider_fuzz {
 
         let mut test_app_pid = 0u32;
         for attempt in 0..10 {
-            if let Ok(tree) = provider.get_apps(&QueryOptions {
-                max_depth: Some(1),
-                max_elements: Some(200),
-                ..QueryOptions::default()
-            }) {
+            if let Ok(tree) = provider.get_apps() {
                 if let Some(app) = tree
                     .iter()
                     .find(|n| n.name.as_deref().is_some_and(|name| name.contains("xa11y")))

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use xa11y_core::{
     Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
-    EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, QueryOptions,
-    Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
+    EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, Rect, Result,
+    Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
 use zbus::blocking::{Connection, Proxy};
 
@@ -306,24 +306,12 @@ impl LinuxProvider {
     fn traverse(
         &self,
         aref: &AccessibleRef,
-        opts: &QueryOptions,
         nodes: &mut Vec<NodeData>,
         refs: &mut Vec<AccessibleRef>,
         parent_idx: Option<u32>,
         depth: u32,
         screen_size: (u32, u32),
     ) {
-        if let Some(max_depth) = opts.max_depth {
-            if depth > max_depth {
-                return;
-            }
-        }
-        if let Some(max_elements) = opts.max_elements {
-            if nodes.len() >= max_elements as usize {
-                return;
-            }
-        }
-
         let role_name = self.get_role_name(aref).unwrap_or_default();
         let role_num = self.get_role_number(aref).unwrap_or(0);
         let role = if !role_name.is_empty() {
@@ -331,47 +319,6 @@ impl LinuxProvider {
         } else {
             map_atspi_role_number(role_num)
         };
-
-        // Don't apply role/visibility filters to the root node (depth 0)
-        // so the tree always has at least the application node.
-        let is_root = depth == 0;
-
-        // For role filtering, skip adding this node but still traverse children
-        // so descendant nodes matching the filter can be found.
-        let skip_for_role = if !is_root {
-            !opts.roles.is_empty() && !opts.roles.contains(&role)
-        } else {
-            false
-        };
-
-        // If role-filtered, skip this node but still traverse children
-        // so that descendant nodes matching the filter can be found.
-        if skip_for_role {
-            let children = self.get_children(aref).unwrap_or_default();
-            for child_ref in &children {
-                if let Some(max_elements) = opts.max_elements {
-                    if nodes.len() >= max_elements as usize {
-                        break;
-                    }
-                }
-                if child_ref.path == "/org/a11y/atspi/null"
-                    || child_ref.bus_name.is_empty()
-                    || child_ref.path.is_empty()
-                {
-                    continue;
-                }
-                self.traverse(
-                    child_ref,
-                    opts,
-                    nodes,
-                    refs,
-                    parent_idx,
-                    depth + 1,
-                    screen_size,
-                );
-            }
-            return;
-        }
 
         let mut name = self.get_name(aref).ok().filter(|s| !s.is_empty());
         let description = self.get_description(aref).ok().filter(|s| !s.is_empty());
@@ -387,10 +334,6 @@ impl LinuxProvider {
         let bounds = self.get_extents(aref);
         let states = self.parse_states(aref, role);
         let actions = self.get_actions(aref);
-
-        if !is_root && opts.visible_only && !states.visible {
-            return;
-        }
 
         let raw = {
             let raw_role = if role_name.is_empty() {
@@ -448,11 +391,6 @@ impl LinuxProvider {
         let mut child_ids = Vec::new();
 
         for child_ref in &children {
-            if let Some(max_elements) = opts.max_elements {
-                if nodes.len() >= max_elements as usize {
-                    break;
-                }
-            }
             // Skip invalid refs
             if child_ref.path == "/org/a11y/atspi/null"
                 || child_ref.bus_name.is_empty()
@@ -464,7 +402,6 @@ impl LinuxProvider {
             child_ids.push(child_idx);
             self.traverse(
                 child_ref,
-                opts,
                 nodes,
                 refs,
                 Some(node_idx),
@@ -707,7 +644,7 @@ impl LinuxProvider {
 }
 
 impl Provider for LinuxProvider {
-    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree> {
+    fn get_app_tree(&self, target: &AppTarget) -> Result<Tree> {
         let app_ref = match target {
             AppTarget::ByName(name) => self.find_app_by_name(name)?,
             AppTarget::ByPid(pid) => self.find_app_by_pid(*pid)?,
@@ -724,7 +661,7 @@ impl Provider for LinuxProvider {
         let mut nodes = Vec::new();
         let mut refs = Vec::new();
 
-        self.traverse(&app_ref, opts, &mut nodes, &mut refs, None, 0, screen_size);
+        self.traverse(&app_ref, &mut nodes, &mut refs, None, 0, screen_size);
 
         if nodes.is_empty() {
             return Err(Error::AppNotFound {
@@ -740,7 +677,7 @@ impl Provider for LinuxProvider {
         Ok(Tree::new(app_name, pid, screen_size, nodes))
     }
 
-    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self) -> Result<Tree> {
         let screen_size = Self::detect_screen_size();
         let mut nodes = Vec::new();
 
@@ -791,7 +728,7 @@ impl Provider for LinuxProvider {
             }
             let child_idx = nodes.len() as u32;
             root_children.push(child_idx);
-            self.traverse(child, opts, &mut nodes, &mut refs, Some(0), 1, screen_size);
+            self.traverse(child, &mut nodes, &mut refs, Some(0), 1, screen_size);
         }
 
         nodes[0].children_indices = root_children;
@@ -1123,8 +1060,7 @@ impl EventProvider for LinuxProvider {
             while !stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                 std::thread::sleep(Duration::from_millis(100));
 
-                let tree = match poll_provider.get_app_tree(&target_clone, &QueryOptions::default())
-                {
+                let tree = match poll_provider.get_app_tree(&target_clone) {
                     Ok(t) => t,
                     Err(_) => continue,
                 };
@@ -1218,7 +1154,7 @@ impl EventProvider for LinuxProvider {
                 return Err(Error::Timeout { elapsed });
             }
 
-            let tree = self.get_app_tree(target, &QueryOptions::default())?;
+            let tree = self.get_app_tree(target)?;
             let matches = tree.query(selector).ok();
             let node = matches.as_ref().and_then(|m| m.first().copied());
 

--- a/xa11y-linux/src/stub.rs
+++ b/xa11y-linux/src/stub.rs
@@ -1,8 +1,7 @@
 //! Stub backend for non-Linux platforms (allows compilation on all targets).
 
 use xa11y_core::{
-    Action, ActionData, AppTarget, Error, NodeData, PermissionStatus, Provider, QueryOptions,
-    Result, Tree,
+    Action, ActionData, AppTarget, Error, NodeData, PermissionStatus, Provider, Result, Tree,
 };
 
 #[derive(Default)]
@@ -15,14 +14,14 @@ impl LinuxProvider {
 }
 
 impl Provider for LinuxProvider {
-    fn get_app_tree(&self, _target: &AppTarget, _opts: &QueryOptions) -> Result<Tree> {
+    fn get_app_tree(&self, _target: &AppTarget) -> Result<Tree> {
         Err(Error::Platform {
             code: -1,
             message: "Linux backend not available on this platform".to_string(),
         })
     }
 
-    fn get_apps(&self, _opts: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self) -> Result<Tree> {
         Err(Error::Platform {
             code: -1,
             message: "Linux backend not available on this platform".to_string(),

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -856,11 +856,6 @@ impl MacOSProvider {
         let mut child_ids = Vec::new();
 
         for child in &children {
-            if let Some(max_elements) = opts.max_elements {
-                if nodes.len() >= max_elements as usize {
-                    break;
-                }
-            }
             // Skip macOS system chrome (menu bar, window buttons, title bar text).
             // These are added by macOS, not by the app's accesskit tree.
             if role == Role::Application {

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -11,8 +11,8 @@ use core_foundation::string::CFString;
 
 use xa11y_core::{
     Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
-    EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, QueryOptions,
-    RawPlatformData, Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
+    EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, RawPlatformData,
+    Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
 
 // ── FFI Declarations ──────────────────────────────────────────────────────────
@@ -731,7 +731,6 @@ impl MacOSProvider {
     fn traverse(
         &self,
         element: &AXElement,
-        opts: &QueryOptions,
         nodes: &mut Vec<NodeData>,
         elements: &mut Vec<AXElement>,
         parent_idx: Option<u32>,
@@ -751,46 +750,9 @@ impl MacOSProvider {
             return;
         }
 
-        if let Some(max_depth) = opts.max_depth {
-            if depth > max_depth {
-                return;
-            }
-        }
-        if let Some(max_elements) = opts.max_elements {
-            if nodes.len() >= max_elements as usize {
-                return;
-            }
-        }
-
         let role_str = ax_string(element.as_ptr(), "AXRole").unwrap_or_default();
         let subrole_str = ax_string(element.as_ptr(), "AXSubrole");
         let role = map_ax_role(&role_str, subrole_str.as_deref());
-
-        let role_filtered = !opts.roles.is_empty() && !opts.roles.contains(&role);
-
-        // If role is filtered out, skip this node but still recurse into children.
-        // Still increment depth to respect the hard limit.
-        if role_filtered {
-            let children = ax_children(element.as_ptr());
-            for child in &children {
-                if let Some(max_elements) = opts.max_elements {
-                    if nodes.len() >= max_elements as usize {
-                        break;
-                    }
-                }
-                self.traverse(
-                    child,
-                    opts,
-                    nodes,
-                    elements,
-                    parent_idx,
-                    depth + 1,
-                    screen_size,
-                    visited,
-                );
-            }
-            return;
-        }
 
         let name = ax_string(element.as_ptr(), "AXTitle")
             .or_else(|| ax_string(element.as_ptr(), "AXDescription"))
@@ -812,25 +774,6 @@ impl MacOSProvider {
         };
 
         let states = parse_states(element.as_ptr(), role);
-
-        if opts.visible_only && !states.visible {
-            // Skip invisible node but still recurse children (they may be visible).
-            // Still increment depth to respect the hard limit.
-            let children = ax_children(element.as_ptr());
-            for child in &children {
-                self.traverse(
-                    child,
-                    opts,
-                    nodes,
-                    elements,
-                    parent_idx,
-                    depth + 1,
-                    screen_size,
-                    visited,
-                );
-            }
-            return;
-        }
 
         // Bounds
         let bounds = match (ax_position(element.as_ptr()), ax_size(element.as_ptr())) {
@@ -954,7 +897,6 @@ impl MacOSProvider {
             child_ids.push(child_idx);
             self.traverse(
                 child,
-                opts,
                 nodes,
                 elements,
                 Some(node_idx),
@@ -969,7 +911,7 @@ impl MacOSProvider {
 }
 
 impl Provider for MacOSProvider {
-    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree> {
+    fn get_app_tree(&self, target: &AppTarget) -> Result<Tree> {
         let (app_element, pid, app_name) = match target {
             AppTarget::ByName(name) => self.find_app_by_name(name)?,
             AppTarget::ByPid(pid) => {
@@ -991,7 +933,6 @@ impl Provider for MacOSProvider {
         let mut visited = HashSet::new();
         self.traverse(
             &app_element,
-            opts,
             &mut nodes,
             &mut elements,
             None,
@@ -1012,7 +953,7 @@ impl Provider for MacOSProvider {
         Ok(Tree::new(app_name, Some(pid as u32), screen_size, nodes))
     }
 
-    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self) -> Result<Tree> {
         let screen_size = Self::detect_screen_size();
         let mut nodes = Vec::new();
         let mut elements = Vec::new();
@@ -1056,7 +997,6 @@ impl Provider for MacOSProvider {
             root_children.push(child_idx);
             self.traverse(
                 &app_element,
-                opts,
                 &mut nodes,
                 &mut elements,
                 Some(0),
@@ -1565,7 +1505,7 @@ impl EventProvider for MacOSProvider {
                 return Err(Error::Timeout { elapsed });
             }
 
-            let tree = self.get_app_tree(target, &QueryOptions::default())?;
+            let tree = self.get_app_tree(target)?;
             let matches = tree.query(selector).ok();
             let node = matches.as_ref().and_then(|m| m.first().copied());
 

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -25,10 +25,10 @@ mod stub {
     }
 
     impl Provider for MacOSProvider {
-        fn get_app_tree(&self, _: &AppTarget, _: &QueryOptions) -> Result<Tree> {
+        fn get_app_tree(&self, _: &AppTarget) -> Result<Tree> {
             unreachable!()
         }
-        fn get_apps(&self, _: &QueryOptions) -> Result<Tree> {
+        fn get_apps(&self) -> Result<Tree> {
             unreachable!()
         }
         fn perform_action(

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -91,24 +91,6 @@ fn parse_scroll_direction(s: &str) -> PyResult<xa11y::ScrollDirection> {
     }
 }
 
-fn build_query_options(
-    max_depth: Option<u32>,
-    max_elements: Option<u32>,
-    visible_only: bool,
-    roles: Option<Vec<String>>,
-) -> xa11y::QueryOptions {
-    xa11y::QueryOptions {
-        max_depth,
-        max_elements,
-        visible_only,
-        roles: roles
-            .unwrap_or_default()
-            .iter()
-            .filter_map(|s| xa11y::Role::from_snake_case(s))
-            .collect(),
-    }
-}
-
 fn resolve_app_target(name: Option<&str>, pid: Option<u32>) -> PyResult<xa11y::AppTarget> {
     match (name, pid) {
         (Some(n), _) => Ok(xa11y::AppTarget::ByName(n.to_string())),
@@ -319,26 +301,17 @@ impl Node {
     }
 
     /// Create a Locator for lazy element resolution from this snapshot's app.
-    #[pyo3(signature = (selector, *, max_depth=None, max_elements=None, visible_only=false, roles=None))]
-    fn locator(
-        &self,
-        selector: &str,
-        max_depth: Option<u32>,
-        max_elements: Option<u32>,
-        visible_only: bool,
-        roles: Option<Vec<String>>,
-    ) -> PyResult<Locator> {
+    #[pyo3(signature = (selector))]
+    fn locator(&self, selector: &str) -> PyResult<Locator> {
         let ctx = self._ctx.as_ref().ok_or_else(|| {
             PyValueError::new_err(
                 "locator() requires a snapshot context (node from app(), not locator.get())",
             )
         })?;
-        let opts = build_query_options(max_depth, max_elements, visible_only, roles);
         Ok(Locator {
             provider: ctx.provider.clone(),
             target: ctx.target.clone(),
             selector: selector.to_string(),
-            opts,
             nth: None,
         })
     }
@@ -433,7 +406,6 @@ struct Locator {
     target: xa11y::AppTarget,
     #[pyo3(get)]
     selector: String,
-    opts: xa11y::QueryOptions,
     nth: Option<usize>,
 }
 
@@ -552,7 +524,7 @@ impl Locator {
     fn count(&self) -> PyResult<usize> {
         let tree = self
             .provider
-            .get_app_tree(&self.target, &self.opts)
+            .get_app_tree(&self.target)
             .map_err(to_py_err)?;
         let matches = tree.query(&self.selector).map_err(to_py_err)?;
         Ok(matches.len())
@@ -732,7 +704,7 @@ impl Locator {
     fn resolve(&self) -> PyResult<(xa11y::Tree, u32)> {
         let tree = self
             .provider
-            .get_app_tree(&self.target, &self.opts)
+            .get_app_tree(&self.target)
             .map_err(to_py_err)?;
         let matches = tree.query(&self.selector).map_err(to_py_err)?;
         let idx = self.nth.unwrap_or(0);
@@ -776,7 +748,7 @@ impl Locator {
             }
 
             let node: Option<xa11y::NodeData> = (|| {
-                let tree = self.provider.get_app_tree(&self.target, &self.opts).ok()?;
+                let tree = self.provider.get_app_tree(&self.target).ok()?;
                 let matches = tree.query(&self.selector).ok()?;
                 let idx = self.nth.unwrap_or(0);
                 matches.get(idx).copied().cloned()
@@ -809,7 +781,7 @@ impl Locator {
                 return Err(to_py_err(xa11y::Error::Timeout { elapsed }));
             }
 
-            let tree_result = self.provider.get_app_tree(&self.target, &self.opts);
+            let tree_result = self.provider.get_app_tree(&self.target);
             let states = tree_result.ok().and_then(|tree| {
                 tree.query(&self.selector).ok().and_then(|matches| {
                     let idx = self.nth.unwrap_or(0);
@@ -843,64 +815,37 @@ impl Locator {
 
 /// Snapshot an app's accessibility tree and return the root Node.
 #[pyfunction]
-#[pyo3(signature = (name=None, *, pid=None, max_depth=None, max_elements=None, visible_only=false, roles=None))]
-fn app(
-    py: Python<'_>,
-    name: Option<&str>,
-    pid: Option<u32>,
-    max_depth: Option<u32>,
-    max_elements: Option<u32>,
-    visible_only: bool,
-    roles: Option<Vec<String>>,
-) -> PyResult<Py<Node>> {
+#[pyo3(signature = (name=None, *, pid=None))]
+fn app(py: Python<'_>, name: Option<&str>, pid: Option<u32>) -> PyResult<Py<Node>> {
     let provider = get_provider()?;
     let target = resolve_app_target(name, pid)?;
-    let opts = build_query_options(max_depth, max_elements, visible_only, roles);
     let p = provider.clone();
     let rust_tree = py
-        .allow_threads(|| p.get_app_tree(&target, &opts))
+        .allow_threads(|| p.get_app_tree(&target))
         .map_err(to_py_err)?;
     convert_to_root_node(py, rust_tree, provider, target)
 }
 
 /// Snapshot all running apps and return the root Node.
 #[pyfunction]
-#[pyo3(signature = (*, max_depth=None, max_elements=None, visible_only=false, roles=None))]
-fn apps(
-    py: Python<'_>,
-    max_depth: Option<u32>,
-    max_elements: Option<u32>,
-    visible_only: bool,
-    roles: Option<Vec<String>>,
-) -> PyResult<Py<Node>> {
+fn apps(py: Python<'_>) -> PyResult<Py<Node>> {
     let provider = get_provider()?;
-    let opts = build_query_options(max_depth, max_elements, visible_only, roles);
     let p = provider.clone();
-    let rust_tree = py.allow_threads(|| p.get_apps(&opts)).map_err(to_py_err)?;
+    let rust_tree = py.allow_threads(|| p.get_apps()).map_err(to_py_err)?;
     let target = xa11y::AppTarget::ByName(String::new());
     convert_to_root_node(py, rust_tree, provider, target)
 }
 
 /// Create a Locator for lazy element resolution.
 #[pyfunction]
-#[pyo3(signature = (name=None, *, pid=None, selector, max_depth=None, max_elements=None, visible_only=false, roles=None))]
-fn locator(
-    name: Option<&str>,
-    pid: Option<u32>,
-    selector: &str,
-    max_depth: Option<u32>,
-    max_elements: Option<u32>,
-    visible_only: bool,
-    roles: Option<Vec<String>>,
-) -> PyResult<Locator> {
+#[pyo3(signature = (name=None, *, pid=None, selector))]
+fn locator(name: Option<&str>, pid: Option<u32>, selector: &str) -> PyResult<Locator> {
     let provider = get_provider()?;
     let target = resolve_app_target(name, pid)?;
-    let opts = build_query_options(max_depth, max_elements, visible_only, roles);
     Ok(Locator {
         provider,
         target,
         selector: selector.to_string(),
-        opts,
         nth: None,
     })
 }
@@ -970,15 +915,11 @@ struct MockProvider {
 }
 
 impl xa11y::Provider for MockProvider {
-    fn get_app_tree(
-        &self,
-        _target: &xa11y::AppTarget,
-        _opts: &xa11y::QueryOptions,
-    ) -> xa11y::Result<xa11y::Tree> {
+    fn get_app_tree(&self, _target: &xa11y::AppTarget) -> xa11y::Result<xa11y::Tree> {
         Ok(self.tree.clone())
     }
 
-    fn get_apps(&self, _opts: &xa11y::QueryOptions) -> xa11y::Result<xa11y::Tree> {
+    fn get_apps(&self) -> xa11y::Result<xa11y::Tree> {
         Ok(self.tree.clone())
     }
 

--- a/xa11y-windows/src/stub.rs
+++ b/xa11y-windows/src/stub.rs
@@ -1,8 +1,7 @@
 //! Stub backend for non-Windows platforms (allows compilation on all targets).
 
 use xa11y_core::{
-    Action, ActionData, AppTarget, Error, NodeData, PermissionStatus, Provider, QueryOptions,
-    Result, Tree,
+    Action, ActionData, AppTarget, Error, NodeData, PermissionStatus, Provider, Result, Tree,
 };
 
 #[derive(Default)]
@@ -18,10 +17,10 @@ impl WindowsProvider {
 }
 
 impl Provider for WindowsProvider {
-    fn get_app_tree(&self, _: &AppTarget, _: &QueryOptions) -> Result<Tree> {
+    fn get_app_tree(&self, _: &AppTarget) -> Result<Tree> {
         unreachable!()
     }
-    fn get_apps(&self, _: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self) -> Result<Tree> {
         unreachable!()
     }
     fn perform_action(

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -12,8 +12,8 @@ use windows::Win32::UI::Accessibility::*;
 
 use xa11y_core::{
     Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
-    EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, QueryOptions,
-    RawPlatformData, Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
+    EventKind, EventProvider, EventReceiver, NodeData, PermissionStatus, Provider, RawPlatformData,
+    Rect, Result, Role, ScrollDirection, StateSet, Subscription, Toggled, Tree,
 };
 
 /// Initialize COM for UIA. Called once per WindowsProvider creation.
@@ -235,7 +235,6 @@ impl WindowsProvider {
     fn traverse(
         &self,
         element: &IUIAutomationElement,
-        opts: &QueryOptions,
         nodes: &mut Vec<NodeData>,
         elements: &mut Vec<IUIAutomationElement>,
         parent_idx: Option<u32>,
@@ -250,17 +249,6 @@ impl WindowsProvider {
         // Depth limit is sufficient for cycle protection on UIA trees.
         // (COM pointer identity is unreliable for cycle detection because
         // UIA creates proxy objects with different addresses for the same element.)
-
-        if let Some(max_depth) = opts.max_depth {
-            if depth > max_depth {
-                return;
-            }
-        }
-        if let Some(max_elements) = opts.max_elements {
-            if nodes.len() >= max_elements as usize {
-                return;
-            }
-        }
 
         let control_type = unsafe { element.CurrentControlType() }.unwrap_or(UIA_CONTROLTYPE_ID(0));
         let mut role = map_uia_control_type(control_type);
@@ -285,26 +273,6 @@ impl WindowsProvider {
                     }
                 }
             }
-        }
-
-        // Role filter: skip node but still traverse children
-        let role_filtered = if depth > 0 {
-            !opts.roles.is_empty() && !opts.roles.contains(&role)
-        } else {
-            false
-        };
-
-        if role_filtered {
-            self.traverse_children(
-                element,
-                opts,
-                nodes,
-                elements,
-                parent_idx,
-                depth,
-                screen_size,
-            );
-            return;
         }
 
         let name = unsafe { element.CurrentName() }
@@ -342,19 +310,6 @@ impl WindowsProvider {
             });
 
         let states = parse_states(element, role);
-
-        if depth > 0 && opts.visible_only && !states.visible {
-            self.traverse_children(
-                element,
-                opts,
-                nodes,
-                elements,
-                parent_idx,
-                depth,
-                screen_size,
-            );
-            return;
-        }
 
         // Bounds
         let bounds = unsafe { element.CurrentBoundingRectangle() }
@@ -451,17 +406,11 @@ impl WindowsProvider {
                 let count = unsafe { children.Length() }.unwrap_or(0);
                 if count > 0 {
                     for i in 0..count {
-                        if let Some(max_elements) = opts.max_elements {
-                            if nodes.len() >= max_elements as usize {
-                                break;
-                            }
-                        }
                         if let Ok(child_el) = unsafe { children.GetElement(i) } {
                             let child_idx = nodes.len() as u32;
                             child_ids.push(child_idx);
                             self.traverse(
                                 &child_el,
-                                opts,
                                 nodes,
                                 elements,
                                 Some(node_idx),
@@ -486,16 +435,10 @@ impl WindowsProvider {
             if let Ok(walker) = unsafe { self.automation.RawViewWalker() } {
                 let mut child = unsafe { walker.GetFirstChildElement(element) }.ok();
                 while let Some(ref child_el) = child {
-                    if let Some(max_elements) = opts.max_elements {
-                        if nodes.len() >= max_elements as usize {
-                            break;
-                        }
-                    }
                     let child_idx = nodes.len() as u32;
                     child_ids.push(child_idx);
                     self.traverse(
                         child_el,
-                        opts,
                         nodes,
                         elements,
                         Some(node_idx),
@@ -509,47 +452,10 @@ impl WindowsProvider {
 
         nodes[node_idx as usize].children_indices = child_ids;
     }
-
-    /// Traverse children only (used when current node is filtered out).
-    #[allow(clippy::too_many_arguments)]
-    fn traverse_children(
-        &self,
-        element: &IUIAutomationElement,
-        opts: &QueryOptions,
-        nodes: &mut Vec<NodeData>,
-        elements: &mut Vec<IUIAutomationElement>,
-        parent_idx: Option<u32>,
-        depth: u32,
-        screen_size: (u32, u32),
-    ) {
-        let walker = match unsafe { self.automation.RawViewWalker() } {
-            Ok(w) => w,
-            Err(_) => return,
-        };
-
-        let mut child = unsafe { walker.GetFirstChildElement(element) }.ok();
-        while let Some(ref child_el) = child {
-            if let Some(max_elements) = opts.max_elements {
-                if nodes.len() >= max_elements as usize {
-                    break;
-                }
-            }
-            self.traverse(
-                child_el,
-                opts,
-                nodes,
-                elements,
-                parent_idx,
-                depth + 1,
-                screen_size,
-            );
-            child = unsafe { walker.GetNextSiblingElement(child_el) }.ok();
-        }
-    }
 }
 
 impl Provider for WindowsProvider {
-    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<Tree> {
+    fn get_app_tree(&self, target: &AppTarget) -> Result<Tree> {
         let (app_element, pid, app_name) = match target {
             AppTarget::ByName(name) => self.find_app_by_name(name)?,
             AppTarget::ByPid(pid) => {
@@ -570,7 +476,6 @@ impl Provider for WindowsProvider {
 
         self.traverse(
             &app_element,
-            opts,
             &mut nodes,
             &mut elements,
             None,
@@ -589,7 +494,7 @@ impl Provider for WindowsProvider {
         Ok(Tree::new(app_name, Some(pid), screen_size, nodes))
     }
 
-    fn get_apps(&self, opts: &QueryOptions) -> Result<Tree> {
+    fn get_apps(&self) -> Result<Tree> {
         let screen_size = Self::detect_screen_size();
         let mut nodes = Vec::new();
         let mut elements = Vec::new();
@@ -661,15 +566,7 @@ impl Provider for WindowsProvider {
                 }
                 let child_idx = nodes.len() as u32;
                 root_children.push(child_idx);
-                self.traverse(
-                    &el,
-                    opts,
-                    &mut nodes,
-                    &mut elements,
-                    Some(0),
-                    1,
-                    screen_size,
-                );
+                self.traverse(&el, &mut nodes, &mut elements, Some(0), 1, screen_size);
             }
         }
 
@@ -1349,8 +1246,7 @@ impl EventProvider for WindowsProvider {
             while !stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                 std::thread::sleep(Duration::from_millis(100));
 
-                let tree = match poll_provider.get_app_tree(&target_clone, &QueryOptions::default())
-                {
+                let tree = match poll_provider.get_app_tree(&target_clone) {
                     Ok(t) => t,
                     Err(_) => continue,
                 };
@@ -1444,7 +1340,7 @@ impl EventProvider for WindowsProvider {
                 return Err(Error::Timeout { elapsed });
             }
 
-            let tree = self.get_app_tree(target, &QueryOptions::default())?;
+            let tree = self.get_app_tree(target)?;
             let matches = tree.query(selector).ok();
             let node = matches.as_ref().and_then(|m| m.first().copied());
 

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -14,7 +14,6 @@
 //!     PermissionStatus::Granted => {
 //!         let root = app(
 //!             &AppTarget::ByName("Safari".to_string()),
-//!             &QueryOptions::default(),
 //!         ).expect("Failed to get app");
 //!
 //!         // Snapshot navigation — no refetch
@@ -46,8 +45,8 @@ use std::sync::{Arc, OnceLock};
 pub use xa11y_core::{
     Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
     EventKind, EventProvider, EventReceiver, Locator, Node, NodeData, PermissionStatus, Provider,
-    QueryOptions, RawPlatformData, Rect, Result, Role, ScrollDirection, StateFlag, StateSet,
-    Subscription, TextChangeData, TextChangeType, Toggled, Tree, WindowHandle,
+    RawPlatformData, Rect, Result, Role, ScrollDirection, StateFlag, StateSet, Subscription,
+    TextChangeData, TextChangeType, Toggled, Tree, WindowHandle,
 };
 
 // ── Internal singleton ──────────────────────────────────────────────────────
@@ -76,11 +75,11 @@ fn get_provider_ref() -> Result<&'static dyn Provider> {
 struct StaticProviderRef(&'static dyn Provider);
 
 impl Provider for StaticProviderRef {
-    fn get_app_tree(&self, target: &AppTarget, opts: &QueryOptions) -> Result<xa11y_core::Tree> {
-        self.0.get_app_tree(target, opts)
+    fn get_app_tree(&self, target: &AppTarget) -> Result<xa11y_core::Tree> {
+        self.0.get_app_tree(target)
     }
-    fn get_apps(&self, opts: &QueryOptions) -> Result<xa11y_core::Tree> {
-        self.0.get_apps(opts)
+    fn get_apps(&self) -> Result<xa11y_core::Tree> {
+        self.0.get_apps()
     }
     fn perform_action(
         &self,
@@ -111,8 +110,8 @@ pub fn provider() -> Result<Arc<dyn Provider>> {
 /// Returns the root [`Node`], which you can navigate via
 /// `parent()`, `children()`, and `query()` — all using the snapshot
 /// (no platform refetch).
-pub fn app(target: &AppTarget, opts: &QueryOptions) -> Result<Node> {
-    let tree = get_provider_ref()?.get_app_tree(target, opts)?;
+pub fn app(target: &AppTarget) -> Result<Node> {
+    let tree = get_provider_ref()?.get_app_tree(target)?;
     let tree = Arc::new(tree);
     Ok(Node::new(tree, 0))
 }
@@ -120,8 +119,8 @@ pub fn app(target: &AppTarget, opts: &QueryOptions) -> Result<Node> {
 /// Snapshot all running applications (shallow).
 ///
 /// Returns the root [`Node`] of a merged tree containing all apps.
-pub fn apps(opts: &QueryOptions) -> Result<Node> {
-    let tree = get_provider_ref()?.get_apps(opts)?;
+pub fn apps() -> Result<Node> {
+    let tree = get_provider_ref()?.get_apps()?;
     let tree = Arc::new(tree);
     Ok(Node::new(tree, 0))
 }
@@ -150,11 +149,6 @@ pub fn check_permissions() -> Result<PermissionStatus> {
 /// making them immune to staleness.
 pub fn locator(target: AppTarget, selector: &str) -> Result<Locator> {
     Ok(Locator::new(provider()?, target, selector))
-}
-
-/// Create a Locator with custom query options.
-pub fn locator_with_opts(target: AppTarget, selector: &str, opts: QueryOptions) -> Result<Locator> {
-    Ok(Locator::with_opts(provider()?, target, selector, opts))
 }
 
 // ── Platform provider construction (internal) ───────────────────────────────

--- a/xa11y/tests/INTEG_COVERAGE.md
+++ b/xa11y/tests/INTEG_COVERAGE.md
@@ -73,15 +73,6 @@ Last updated: 2026-03-19
 | `required` | Not coverable | No standard widget sets this |
 | `busy` | Not coverable | No standard widget sets this |
 
-## QueryOptions Fields
-
-| Field | Status | Tests |
-|-------|--------|-------|
-| `max_depth` | Covered | `opts_max_depth` |
-| `max_elements` | Covered | `opts_max_elements` |
-| `visible_only` | Covered | `opts_visible_only` |
-| `roles` | Covered | `opts_roles_filter` |
-
 ## Action Variants
 
 | Action | Status | Tests |
@@ -164,7 +155,6 @@ Covered via test app nodes: `Application`, `Window`, `Button`, `CheckBox`, `Radi
 - All EventProvider trait methods covered
 - All Node navigation and Tree internal methods covered
 - All Node fields covered
-- All QueryOptions fields covered
 - 13/15 Action variants covered (all except Toggle, ShowMenu)
 - All selector features covered except description attribute
 - 14 role-specific tests covering 30+ Role variants

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -2,15 +2,10 @@
 
 use xa11y::*;
 
-/// Get the test app tree with default options, retrying briefly for registration.
+/// Get the test app tree, retrying briefly for registration.
 pub fn app_tree() -> Node {
-    app_tree_with(&QueryOptions::default())
-}
-
-/// Get the test app tree with custom QueryOptions, retrying for registration.
-pub fn app_tree_with(opts: &QueryOptions) -> Node {
     for attempt in 0..3 {
-        match xa11y::app(&AppTarget::ByName("xa11y".to_string()), opts) {
+        match xa11y::app(&AppTarget::ByName("xa11y".to_string())) {
             Ok(root) => return root,
             Err(_) if attempt < 2 => {
                 std::thread::sleep(std::time::Duration::from_millis(200));

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -33,20 +33,13 @@ mod tests {
     #[test]
     #[ignore]
     fn apps_returns_nonempty() {
-        // Limit depth/elements to avoid traversing every app on the system
-        let root = xa11y::apps(&QueryOptions {
-            max_depth: Some(2),
-            max_elements: Some(200),
-            ..QueryOptions::default()
-        })
-        .unwrap();
+        let root = xa11y::apps().unwrap();
         assert!(!root.tree().is_empty(), "apps should return nodes");
         assert_eq!(root.tree().app_name, "Desktop");
         assert!(
             root.tree().pid.is_none(),
             "Multi-app tree should have no PID"
         );
-        // With limited traversal, test app should still appear at depth 1-2
         let has_test_app = root
             .subtree()
             .iter()
@@ -66,12 +59,7 @@ mod tests {
     #[ignore]
     fn app_target_by_pid() {
         // Find test app PID from the apps tree
-        let root = xa11y::apps(&QueryOptions {
-            max_depth: Some(1),
-            max_elements: Some(200),
-            ..QueryOptions::default()
-        })
-        .unwrap();
+        let root = xa11y::apps().unwrap();
         let subtree = root.subtree();
         let test_app = subtree
             .iter()
@@ -79,7 +67,7 @@ mod tests {
             .expect("Test app not found in apps tree");
         let pid = test_app.pid.expect("Test app should have a PID");
         assert!(pid > 0);
-        let root = xa11y::app(&AppTarget::ByPid(pid), &QueryOptions::default()).unwrap();
+        let root = xa11y::app(&AppTarget::ByPid(pid)).unwrap();
         assert!(!root.tree().is_empty());
         assert_eq!(root.tree().pid, Some(pid));
     }
@@ -871,40 +859,6 @@ mod tests {
         assert!(results[0].name.as_deref().unwrap().contains("Sub"));
     }
 
-    // ════════════════════════════════════════════════════════════════
-    // QueryOptions (5 tests)
-    // ════════════════════════════════════════════════════════════════
-
-    #[test]
-    #[ignore]
-    fn opts_max_depth() {
-        let shallow = h::app_tree_with(&QueryOptions {
-            max_depth: Some(1),
-            ..QueryOptions::default()
-        });
-        let deep = h::app_tree();
-        assert!(
-            shallow.tree().len() < deep.tree().len(),
-            "Shallow ({}) should be smaller than deep ({})",
-            shallow.tree().len(),
-            deep.tree().len()
-        );
-    }
-
-    #[test]
-    #[ignore]
-    fn opts_max_elements() {
-        let limited = h::app_tree_with(&QueryOptions {
-            max_elements: Some(5),
-            ..QueryOptions::default()
-        });
-        assert!(
-            limited.tree().len() <= 5,
-            "Got {} elements",
-            limited.tree().len()
-        );
-    }
-
     #[test]
     #[ignore]
     fn raw_data_always_present() {
@@ -923,45 +877,6 @@ mod tests {
             }
             _ => panic!("Expected macOS raw data"),
         }
-    }
-
-    #[test]
-    #[ignore]
-    fn opts_visible_only() {
-        let root = h::app_tree_with(&QueryOptions {
-            visible_only: true,
-            ..QueryOptions::default()
-        });
-        // The root node is always included even if not visible,
-        // so skip it when checking visibility.
-        for node in root.subtree() {
-            if node.parent_index.is_none() {
-                continue;
-            }
-            assert!(
-                node.states.visible,
-                "Node {:?} should be visible",
-                node.name
-            );
-        }
-        assert!(root.tree().len() > 1);
-    }
-
-    #[test]
-    #[ignore]
-    fn opts_roles_filter() {
-        let root = h::app_tree_with(&QueryOptions {
-            roles: vec![Role::Button],
-            ..QueryOptions::default()
-        });
-        // The root node is always included to anchor the tree.
-        for node in root.subtree() {
-            if node.parent_index.is_none() {
-                continue;
-            }
-            assert_eq!(node.role, Role::Button);
-        }
-        assert!(root.tree().len() >= 2);
     }
 
     // ════════════════════════════════════════════════════════════════
@@ -1385,10 +1300,7 @@ mod tests {
     #[test]
     #[ignore]
     fn error_app_not_found() {
-        let result = xa11y::app(
-            &AppTarget::ByName("nonexistent_app_12345".to_string()),
-            &QueryOptions::default(),
-        );
+        let result = xa11y::app(&AppTarget::ByName("nonexistent_app_12345".to_string()));
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::AppNotFound { .. }));
     }

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -58,14 +58,9 @@ mod tests {
     #[test]
     #[ignore]
     fn app_target_by_pid() {
-        // Find test app PID from the apps tree
-        let root = xa11y::apps().unwrap();
-        let subtree = root.subtree();
-        let test_app = subtree
-            .iter()
-            .find(|n| n.name.as_deref().is_some_and(|name| name.contains("xa11y")))
-            .expect("Test app not found in apps tree");
-        let pid = test_app.pid.expect("Test app should have a PID");
+        // Get the test app's PID via ByName, then verify ByPid works
+        let by_name = h::app_tree();
+        let pid = by_name.tree().pid.expect("app tree should have a PID");
         assert!(pid > 0);
         let root = xa11y::app(&AppTarget::ByPid(pid)).unwrap();
         assert!(!root.tree().is_empty());

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -777,17 +777,6 @@ fn event_filter_combined() {
     assert_eq!(filter.selector.as_deref(), Some("check_box"));
 }
 
-// ── QueryOptions ──
-
-#[test]
-fn query_options_default() {
-    let opts = QueryOptions::default();
-    assert!(opts.max_depth.is_none());
-    assert!(opts.max_elements.is_none());
-    assert!(!opts.visible_only);
-    assert!(opts.roles.is_empty());
-}
-
 // ── Provider trait / AppTarget ──
 
 #[test]
@@ -849,10 +838,7 @@ fn platform_provider_operations_return_errors() {
         Err(_) => return,
     };
 
-    let result = provider.get_app_tree(
-        &AppTarget::ByName("NonexistentApp12345".to_string()),
-        &QueryOptions::default(),
-    );
+    let result = provider.get_app_tree(&AppTarget::ByName("NonexistentApp12345".to_string()));
     assert!(result.is_err());
 }
 
@@ -921,11 +907,11 @@ impl MockProvider {
 }
 
 impl Provider for MockProvider {
-    fn get_app_tree(&self, _target: &AppTarget, _opts: &QueryOptions) -> xa11y::Result<Tree> {
+    fn get_app_tree(&self, _target: &AppTarget) -> xa11y::Result<Tree> {
         Ok(self.tree.clone())
     }
 
-    fn get_apps(&self, _opts: &QueryOptions) -> xa11y::Result<Tree> {
+    fn get_apps(&self) -> xa11y::Result<Tree> {
         Ok(self.tree.clone())
     }
 


### PR DESCRIPTION
app() and apps() now return all elements always — callers can use
query() to filter. This removes max_depth, max_elements, visible_only,
and roles filtering from the Provider trait and all platform backends.

https://claude.ai/code/session_01VV7vjqYXNY4Tm66TSdL3a9