### PR TITLE
Simplify EventFilter to only accept a selector string

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -886,7 +886,7 @@ pub trait EventProvider: Provider {
     /// Returns the first matching event or a timeout error.
     ///
     /// Playwright mapping: `page.waitForEvent('popup')` becomes
-    ///   `provider.wait_for_event(target, EventFilter::kinds(&[EventKind::WindowOpened]), timeout)?`
+    ///   `provider.wait_for_event(target, EventFilter::all(), timeout)?`
     fn wait_for_event(
         &self,
         target: &AppTarget,
@@ -951,30 +951,17 @@ Filters are applied at subscription time so backends can minimize overhead by on
 ```rust
 /// Filter to narrow which events are delivered.
 pub struct EventFilter {
-    /// Which event kinds to subscribe to. Empty = all events.
-    pub kinds: Vec<EventKind>,
-
     /// Only deliver events from elements matching this selector.
     /// None = all elements in the target app.
     pub selector: Option<String>,
-
-    /// For StateChanged events: only these state flags.
-    /// Empty = all state changes.
-    pub state_flags: Vec<StateFlag>,
 }
 
 impl EventFilter {
-    /// Subscribe to all events from the target.
+    /// Subscribe to all events from the target (no selector filter).
     pub fn all() -> Self;
-
-    /// Subscribe to specific event kinds.
-    pub fn kinds(kinds: &[EventKind]) -> Self;
 
     /// Subscribe to events on elements matching a selector.
     pub fn selector(selector: &str) -> Self;
-
-    /// Combine kind filter with selector filter.
-    pub fn new(kinds: &[EventKind], selector: Option<&str>) -> Self;
 }
 ```
 
@@ -1071,10 +1058,10 @@ The event system is designed so a Playwright-compatible desktop adapter can map 
 
 | Playwright API | xa11y equivalent |
 |---|---|
-| `page.on('close', fn)` | `subscribe(app, EventFilter::kinds(&[WindowClosed]))` |
-| `page.on('popup', fn)` | `subscribe(app, EventFilter::kinds(&[WindowOpened]))` |
-| `page.on('dialog', fn)` | `subscribe(app, EventFilter::kinds(&[Alert]))` |
-| `page.waitForEvent('popup')` | `wait_for_event(app, EventFilter::kinds(&[WindowOpened]), timeout)` |
+| `page.on('close', fn)` | `subscribe(app, EventFilter::all())` |
+| `page.on('popup', fn)` | `subscribe(app, EventFilter::all())` |
+| `page.on('dialog', fn)` | `subscribe(app, EventFilter::all())` |
+| `page.waitForEvent('popup')` | `wait_for_event(app, EventFilter::all(), timeout)` |
 | `locator.waitFor({state: 'visible'})` | `wait_for(app, selector, ElementState::Visible, timeout)` |
 | `locator.waitFor({state: 'detached'})` | `wait_for(app, selector, ElementState::Detached, timeout)` |
 | `locator.waitFor({state: 'hidden'})` | `wait_for(app, selector, ElementState::Hidden, timeout)` |

--- a/xa11y-core/src/event.rs
+++ b/xa11y-core/src/event.rs
@@ -104,42 +104,21 @@ pub enum StateFlag {
 /// Filter to narrow which events are delivered.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EventFilter {
-    /// Which event kinds to subscribe to. Empty = all events.
-    pub kinds: Vec<EventKind>,
     /// Only deliver events from elements matching this selector.
+    /// None = all elements in the target app.
     pub selector: Option<String>,
-    /// For StateChanged events: only these state flags.
-    pub state_flags: Vec<StateFlag>,
 }
 
 impl EventFilter {
-    /// Subscribe to all events from the target.
+    /// Subscribe to all events from the target (no selector filter).
     pub fn all() -> Self {
         Self::default()
-    }
-
-    /// Subscribe to specific event kinds.
-    pub fn kinds(kinds: &[EventKind]) -> Self {
-        Self {
-            kinds: kinds.to_vec(),
-            ..Default::default()
-        }
     }
 
     /// Subscribe to events on elements matching a selector.
     pub fn selector(selector: &str) -> Self {
         Self {
             selector: Some(selector.to_string()),
-            ..Default::default()
-        }
-    }
-
-    /// Combine kind filter with selector filter.
-    pub fn new(kinds: &[EventKind], selector: Option<&str>) -> Self {
-        Self {
-            kinds: kinds.to_vec(),
-            selector: selector.map(|s| s.to_string()),
-            ..Default::default()
         }
     }
 }

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1088,7 +1088,7 @@ impl Provider for LinuxProvider {
 // ── EventProvider ────────────────────────────────────────────────────────────
 
 impl EventProvider for LinuxProvider {
-    fn subscribe(&self, target: &AppTarget, filter: EventFilter) -> Result<Subscription> {
+    fn subscribe(&self, target: &AppTarget, _filter: EventFilter) -> Result<Subscription> {
         let (tx, rx) = std::sync::mpsc::channel();
 
         let (app_name, app_pid) = match target {
@@ -1137,18 +1137,16 @@ impl EventProvider for LinuxProvider {
                 if focused_name != prev_focused {
                     if prev_focused.is_some() {
                         let kind = EventKind::FocusChanged;
-                        if filter.kinds.is_empty() || filter.kinds.contains(&kind) {
-                            let _ = tx.send(Event {
-                                kind,
-                                app_name: app_name.clone(),
-                                app_pid,
-                                target: tree.iter().find(|n| n.states.focused).cloned(),
-                                state_flag: None,
-                                state_value: None,
-                                text_change: None,
-                                timestamp: std::time::Instant::now(),
-                            });
-                        }
+                        let _ = tx.send(Event {
+                            kind,
+                            app_name: app_name.clone(),
+                            app_pid,
+                            target: tree.iter().find(|n| n.states.focused).cloned(),
+                            state_flag: None,
+                            state_value: None,
+                            text_change: None,
+                            timestamp: std::time::Instant::now(),
+                        });
                     }
                     prev_focused = focused_name;
                 }
@@ -1157,18 +1155,16 @@ impl EventProvider for LinuxProvider {
                 let node_count = tree.len();
                 if node_count != prev_node_count && prev_node_count > 0 {
                     let kind = EventKind::StructureChanged;
-                    if filter.kinds.is_empty() || filter.kinds.contains(&kind) {
-                        let _ = tx.send(Event {
-                            kind,
-                            app_name: app_name.clone(),
-                            app_pid,
-                            target: None,
-                            state_flag: None,
-                            state_value: None,
-                            text_change: None,
-                            timestamp: std::time::Instant::now(),
-                        });
-                    }
+                    let _ = tx.send(Event {
+                        kind,
+                        app_name: app_name.clone(),
+                        app_pid,
+                        target: None,
+                        state_flag: None,
+                        state_value: None,
+                        text_change: None,
+                        timestamp: std::time::Instant::now(),
+                    });
                 }
                 prev_node_count = node_count;
             }

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1323,7 +1323,6 @@ impl Provider for MacOSProvider {
 /// Context passed to AXObserver callback via refcon pointer.
 struct ObserverContext {
     sender: std::sync::mpsc::Sender<Event>,
-    filter: EventFilter,
     app_name: String,
     app_pid: u32,
 }
@@ -1355,10 +1354,6 @@ unsafe extern "C" fn ax_observer_callback(
         "AXTitleChanged" => EventKind::NameChanged,
         _ => return,
     };
-
-    if !ctx.filter.kinds.is_empty() && !ctx.filter.kinds.contains(&kind) {
-        return;
-    }
 
     // Build minimal target node from the AX element
     let target = if !element.is_null() {
@@ -1401,7 +1396,7 @@ unsafe extern "C" fn ax_observer_callback(
 }
 
 impl EventProvider for MacOSProvider {
-    fn subscribe(&self, target: &AppTarget, filter: EventFilter) -> Result<Subscription> {
+    fn subscribe(&self, target: &AppTarget, _filter: EventFilter) -> Result<Subscription> {
         let (pid, app_name) = match target {
             AppTarget::ByName(name) => {
                 let apps = Self::list_gui_apps();
@@ -1430,7 +1425,6 @@ impl EventProvider for MacOSProvider {
 
         let ctx = Box::new(ObserverContext {
             sender: tx,
-            filter,
             app_name,
             app_pid: pid as u32,
         });

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -1309,7 +1309,7 @@ fn map_uia_control_type(control_type: UIA_CONTROLTYPE_ID) -> Role {
 // ── EventProvider (polling-based) ─────────────────────────────────────────────
 
 impl EventProvider for WindowsProvider {
-    fn subscribe(&self, target: &AppTarget, filter: EventFilter) -> Result<Subscription> {
+    fn subscribe(&self, target: &AppTarget, _filter: EventFilter) -> Result<Subscription> {
         let (tx, rx) = std::sync::mpsc::channel();
 
         let (app_name, app_pid) = match target {
@@ -1362,19 +1362,16 @@ impl EventProvider for WindowsProvider {
                     .and_then(|n| n.name.clone());
                 if focused_name != prev_focused {
                     if prev_focused.is_some() {
-                        let kind = EventKind::FocusChanged;
-                        if filter.kinds.is_empty() || filter.kinds.contains(&kind) {
-                            let _ = tx.send(Event {
-                                kind,
-                                app_name: app_name.clone(),
-                                app_pid,
-                                target: tree.iter().find(|n| n.states.focused).cloned(),
-                                state_flag: None,
-                                state_value: None,
-                                text_change: None,
-                                timestamp: std::time::Instant::now(),
-                            });
-                        }
+                        let _ = tx.send(Event {
+                            kind: EventKind::FocusChanged,
+                            app_name: app_name.clone(),
+                            app_pid,
+                            target: tree.iter().find(|n| n.states.focused).cloned(),
+                            state_flag: None,
+                            state_value: None,
+                            text_change: None,
+                            timestamp: std::time::Instant::now(),
+                        });
                     }
                     prev_focused = focused_name;
                 }
@@ -1382,19 +1379,16 @@ impl EventProvider for WindowsProvider {
                 // Detect structure changes
                 let node_count = tree.len();
                 if node_count != prev_node_count && prev_node_count > 0 {
-                    let kind = EventKind::StructureChanged;
-                    if filter.kinds.is_empty() || filter.kinds.contains(&kind) {
-                        let _ = tx.send(Event {
-                            kind,
-                            app_name: app_name.clone(),
-                            app_pid,
-                            target: None,
-                            state_flag: None,
-                            state_value: None,
-                            text_change: None,
-                            timestamp: std::time::Instant::now(),
-                        });
-                    }
+                    let _ = tx.send(Event {
+                        kind: EventKind::StructureChanged,
+                        app_name: app_name.clone(),
+                        app_pid,
+                        target: None,
+                        state_flag: None,
+                        state_value: None,
+                        text_change: None,
+                        timestamp: std::time::Instant::now(),
+                    });
                 }
                 prev_node_count = node_count;
             }

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -1573,10 +1573,7 @@ mod tests {
         let root = h::app_tree();
 
         let sub = ep
-            .subscribe(
-                &AppTarget::ByName("xa11y".to_string()),
-                EventFilter::kinds(&[EventKind::FocusChanged]),
-            )
+            .subscribe(&AppTarget::ByName("xa11y".to_string()), EventFilter::all())
             .unwrap();
 
         // Trigger a focus change
@@ -1606,7 +1603,7 @@ mod tests {
         // Wait for an event with a very short timeout — should timeout
         let result = ep.wait_for_event(
             &AppTarget::ByName("xa11y".to_string()),
-            EventFilter::kinds(&[EventKind::Alert]),
+            EventFilter::all(),
             Duration::from_millis(100),
         );
         assert!(

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -753,28 +753,13 @@ fn raw_platform_data_serialization() {
 #[test]
 fn event_filter_all() {
     let filter = EventFilter::all();
-    assert!(filter.kinds.is_empty());
     assert!(filter.selector.is_none());
-    assert!(filter.state_flags.is_empty());
-}
-
-#[test]
-fn event_filter_kinds() {
-    let filter = EventFilter::kinds(&[EventKind::FocusChanged, EventKind::ValueChanged]);
-    assert_eq!(filter.kinds.len(), 2);
 }
 
 #[test]
 fn event_filter_selector() {
     let filter = EventFilter::selector("button[name=\"Submit\"]");
     assert_eq!(filter.selector.as_deref(), Some("button[name=\"Submit\"]"));
-}
-
-#[test]
-fn event_filter_combined() {
-    let filter = EventFilter::new(&[EventKind::StateChanged], Some("check_box"));
-    assert_eq!(filter.kinds.len(), 1);
-    assert_eq!(filter.selector.as_deref(), Some("check_box"));
 }
 
 // ── QueryOptions ──


### PR DESCRIPTION
Remove `kinds` and `state_flags` fields from EventFilter, leaving only
the `selector` field. Remove associated constructors (`kinds`, `new`) and
kind-based filtering logic from all platform providers (Linux, macOS,
Windows). Update tests and design docs accordingly.

https://claude.ai/code/session_01L4bCeNG3eT4HWLTUpaFevx