### PR TITLE
Remove ScrollDirection from public API, prefer separate scroll functions

### DIFF
--- a/xa11y-fuzz/src/bin/provider_fuzz.rs
+++ b/xa11y-fuzz/src/bin/provider_fuzz.rs
@@ -16,6 +16,7 @@ mod provider_fuzz {
     use rand::prelude::*;
     use std::time::{SystemTime, UNIX_EPOCH};
     use xa11y::*;
+    use xa11y_core::ScrollDirection;
 
     // ── CLI ──────────────────────────────────────────────────────────────────
 

--- a/xa11y-python/Cargo.lock
+++ b/xa11y-python/Cargo.lock
@@ -1263,6 +1263,7 @@ version = "0.2.1"
 dependencies = [
  "pyo3",
  "xa11y",
+ "xa11y-core",
 ]
 
 [[package]]

--- a/xa11y-python/Cargo.toml
+++ b/xa11y-python/Cargo.toml
@@ -11,4 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 xa11y = { path = "../xa11y" }
+xa11y-core = { path = "../xa11y-core" }
 pyo3 = { version = "0.23", features = ["abi3-py39"] }

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -237,11 +237,14 @@ class Locator:
         """Type text into the matched element."""
     def select_text(self, start: int, end: int) -> None:
         """Select a text range by character offsets."""
-    def scroll(self, direction: str, amount: float = 1.0) -> None:
-        """Scroll the matched element.
-
-        *direction*: ``"up"``, ``"down"``, ``"left"``, or ``"right"``.
-        """
+    def scroll_up(self, amount: float = 1.0) -> None:
+        """Scroll the matched element upward."""
+    def scroll_down(self, amount: float = 1.0) -> None:
+        """Scroll the matched element downward."""
+    def scroll_left(self, amount: float = 1.0) -> None:
+        """Scroll the matched element leftward."""
+    def scroll_right(self, amount: float = 1.0) -> None:
+        """Scroll the matched element rightward."""
     def wait_visible(self, timeout: float = 5.0) -> None:
         """Wait until the element is visible (default 5s timeout)."""
     def wait_attached(self, timeout: float = 5.0) -> None:

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -79,18 +79,6 @@ fn action_to_str(a: &xa11y::Action) -> &'static str {
     }
 }
 
-fn parse_scroll_direction(s: &str) -> PyResult<xa11y::ScrollDirection> {
-    match s {
-        "up" => Ok(xa11y::ScrollDirection::Up),
-        "down" => Ok(xa11y::ScrollDirection::Down),
-        "left" => Ok(xa11y::ScrollDirection::Left),
-        "right" => Ok(xa11y::ScrollDirection::Right),
-        _ => Err(PyValueError::new_err(format!(
-            "Unknown scroll direction: {s} (expected up/down/left/right)"
-        ))),
-    }
-}
-
 fn resolve_app_target(name: Option<&str>, pid: Option<u32>) -> PyResult<xa11y::AppTarget> {
     match (name, pid) {
         (Some(n), _) => Ok(xa11y::AppTarget::ByName(n.to_string())),
@@ -616,13 +604,45 @@ impl Locator {
         )
     }
 
-    #[pyo3(signature = (direction, amount=1.0))]
-    fn scroll(&self, direction: &str, amount: f64) -> PyResult<()> {
-        let dir = parse_scroll_direction(direction)?;
+    #[pyo3(signature = (amount=1.0))]
+    fn scroll_up(&self, amount: f64) -> PyResult<()> {
         self.perform_action(
             xa11y::Action::Scroll,
             Some(xa11y::ActionData::ScrollAmount {
-                direction: dir,
+                direction: xa11y_core::ScrollDirection::Up,
+                amount,
+            }),
+        )
+    }
+
+    #[pyo3(signature = (amount=1.0))]
+    fn scroll_down(&self, amount: f64) -> PyResult<()> {
+        self.perform_action(
+            xa11y::Action::Scroll,
+            Some(xa11y::ActionData::ScrollAmount {
+                direction: xa11y_core::ScrollDirection::Down,
+                amount,
+            }),
+        )
+    }
+
+    #[pyo3(signature = (amount=1.0))]
+    fn scroll_left(&self, amount: f64) -> PyResult<()> {
+        self.perform_action(
+            xa11y::Action::Scroll,
+            Some(xa11y::ActionData::ScrollAmount {
+                direction: xa11y_core::ScrollDirection::Left,
+                amount,
+            }),
+        )
+    }
+
+    #[pyo3(signature = (amount=1.0))]
+    fn scroll_right(&self, amount: f64) -> PyResult<()> {
+        self.perform_action(
+            xa11y::Action::Scroll,
+            Some(xa11y::ActionData::ScrollAmount {
+                direction: xa11y_core::ScrollDirection::Right,
                 amount,
             }),
         )

--- a/xa11y-python/tests/test_locator.py
+++ b/xa11y-python/tests/test_locator.py
@@ -233,17 +233,20 @@ def test_locator_select_text(tree):
     tree.locator("text_field").select_text(0, 3)
 
 
-def test_locator_scroll(tree):
-    tree.locator("list").scroll("down")
+def test_locator_scroll_down(tree):
+    tree.locator("list").scroll_down()
 
 
-def test_locator_scroll_with_amount(tree):
-    tree.locator("list").scroll("up", 5.0)
+def test_locator_scroll_up_with_amount(tree):
+    tree.locator("list").scroll_up(5.0)
 
 
-def test_locator_scroll_invalid_direction(tree):
-    with pytest.raises(ValueError, match="scroll direction"):
-        tree.locator("list").scroll("sideways")
+def test_locator_scroll_left(tree):
+    tree.locator("list").scroll_left()
+
+
+def test_locator_scroll_right(tree):
+    tree.locator("list").scroll_right(2.0)
 
 
 # ── Wait operations ──────────────────────────────────────────────────────────

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -45,8 +45,8 @@ use std::sync::{Arc, OnceLock};
 pub use xa11y_core::{
     Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
     EventKind, EventProvider, EventReceiver, Locator, Node, NodeData, PermissionStatus, Provider,
-    RawPlatformData, Rect, Result, Role, ScrollDirection, StateFlag, StateSet, Subscription,
-    TextChangeData, TextChangeType, Toggled, Tree, WindowHandle,
+    RawPlatformData, Rect, Result, Role, StateFlag, StateSet, Subscription, TextChangeData,
+    TextChangeType, Toggled, Tree, WindowHandle,
 };
 
 // ── Internal singleton ──────────────────────────────────────────────────────

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -14,6 +14,7 @@ mod integ;
 mod tests {
     use super::integ as h;
     use xa11y::*;
+    use xa11y_core::ScrollDirection;
 
     // ════════════════════════════════════════════════════════════════
     // Provider Operations (4 tests)

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -5,6 +5,7 @@
 //! or running applications are needed.
 
 use xa11y::*;
+use xa11y_core::ScrollDirection;
 
 /// Helper to build a sample accessibility tree for testing.
 fn sample_tree() -> Tree {


### PR DESCRIPTION
The Rust Locator already exposed scroll_up/down/left/right — this makes
those the canonical API and stops re-exporting ScrollDirection from the
umbrella crate. Python bindings now mirror this with scroll_up(),
scroll_down(), scroll_left(), scroll_right() instead of scroll(direction).

https://claude.ai/code/session_01QdrRAyDcqjYKqMxWdUTWj8