### PR TITLE
Fix formatting from ScrollDirection removal

### DIFF
--- a/xa11y-core/src/action.rs
+++ b/xa11y-core/src/action.rs
@@ -144,4 +144,3 @@ impl std::fmt::Display for ActionData {
         }
     }
 }
-

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -919,9 +919,17 @@ impl Provider for LinuxProvider {
                             "org.a11y.atspi.Component",
                         )?;
                         let scroll_type: u32 = if is_vertical {
-                            if amount >= 0.0 { 3 } else { 2 } // BOTTOM_EDGE / TOP_EDGE
+                            if amount >= 0.0 {
+                                3
+                            } else {
+                                2
+                            } // BOTTOM_EDGE / TOP_EDGE
                         } else {
-                            if amount >= 0.0 { 5 } else { 4 } // RIGHT_EDGE / LEFT_EDGE
+                            if amount >= 0.0 {
+                                5
+                            } else {
+                                4
+                            } // RIGHT_EDGE / LEFT_EDGE
                         };
                         proxy
                             .call_method("ScrollTo", &(scroll_type,))

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -45,8 +45,8 @@ use std::sync::{Arc, OnceLock};
 pub use xa11y_core::{
     Action, ActionData, AppTarget, CancelHandle, ElementState, Error, Event, EventFilter,
     EventKind, EventReceiver, Locator, Node, NodeData, PermissionStatus, RawPlatformData, Rect,
-    Result, Role, StateFlag, StateSet, Subscription, TextChangeData,
-    TextChangeType, Toggled, Tree, WindowHandle,
+    Result, Role, StateFlag, StateSet, Subscription, TextChangeData, TextChangeType, Toggled, Tree,
+    WindowHandle,
 };
 
 // Provider traits are implementation details used by platform backends and Python bindings,


### PR DESCRIPTION
## Summary
- Applies `cargo fmt` fixes missed in the ScrollDirection removal commit

## Test plan
- [ ] CI lint/format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)