### PR TITLE
fix: Qt accessibility issues — flatten tree, dedupe stable_id, description mapping, post-action delay

### DIFF
--- a/scripts/run_integ_tests.sh
+++ b/scripts/run_integ_tests.sh
@@ -42,9 +42,14 @@ done
 echo "Starting Xvfb on $XVFB_DISPLAY..."
 Xvfb "$XVFB_DISPLAY" -screen 0 1280x1024x24 -ac &
 CLEANUP_PIDS+=($!)
-sleep 1
 
 export DISPLAY="$XVFB_DISPLAY"
+
+# Poll until X is ready (up to 5s)
+for i in $(seq 1 50); do
+    if xdpyinfo -display "$DISPLAY" &>/dev/null 2>&1; then break; fi
+    sleep 0.1
+done
 echo "DISPLAY=$DISPLAY"
 
 # 2. Start AT-SPI2 bus launcher and registryd
@@ -66,8 +71,6 @@ else
     echo "WARNING: at-spi-bus-launcher not found, AT-SPI2 may not work"
 fi
 
-sleep 1
-
 # Start the registry daemon
 if command -v /usr/libexec/at-spi2-registryd &>/dev/null; then
     /usr/libexec/at-spi2-registryd &
@@ -79,7 +82,12 @@ else
     echo "WARNING: at-spi2-registryd not found"
 fi
 
-sleep 1
+# Poll until AT-SPI bus is reachable (up to 5s)
+for i in $(seq 1 50); do
+    if dbus-send --session --print-reply --dest=org.a11y.Bus /org/a11y/bus \
+        org.freedesktop.DBus.Peer.Ping &>/dev/null 2>&1; then break; fi
+    sleep 0.1
+done
 
 # 2b. Enable accessibility on the AT-SPI bus (required for apps to register)
 echo "Enabling AT-SPI accessibility..."
@@ -92,9 +100,9 @@ dbus-send --session --print-reply --dest=org.a11y.Bus /org/a11y/bus \
     string:org.a11y.Status string:ScreenReaderEnabled variant:boolean:true \
     2>/dev/null || true
 
-# 3. Build everything
-echo "Building workspace..."
-cargo build --workspace 2>&1
+# 3. Build the test app (tests are compiled by cargo test below)
+echo "Building test app..."
+cargo build -p xa11y-test-app 2>&1
 
 # Support BUILD_ONLY mode (for pre-warming the build cache)
 if [ "${BUILD_ONLY:-}" = "1" ]; then
@@ -108,9 +116,14 @@ echo "Launching xa11y-test-app..."
 ./target/debug/xa11y-test-app --headless &
 CLEANUP_PIDS+=($!)
 
-# Wait for the app to start and register with AT-SPI
+# Wait for the app to register with AT-SPI (poll up to 10s)
 echo "Waiting for test app to register with AT-SPI..."
-sleep 3
+for i in $(seq 1 100); do
+    if dbus-send --session --print-reply --dest=org.a11y.atspi.Registry \
+        /org/a11y/atspi/accessible/root org.a11y.atspi.Accessible.GetChildren \
+        &>/dev/null 2>&1; then break; fi
+    sleep 0.1
+done
 
 # 5. Run integration tests
 echo "Running integration tests..."

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1083,7 +1083,12 @@ impl Provider for LinuxProvider {
                     })?;
                 Ok(())
             }
-        }
+        }?;
+
+        // Brief pause so the app can process the action and update its AT-SPI tree
+        // before the caller re-reads state.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        Ok(())
     }
 
     fn check_permissions(&self) -> Result<PermissionStatus> {

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -733,7 +733,7 @@ impl MacOSProvider {
                     let count = seen.entry(id.clone()).or_insert(0);
                     *count += 1;
                     if *count > 1 {
-                        elem.stable_id = Some(format!("{}#{}", id, count - 1));
+                        elem.stable_id = Some(format!("{}#{}", id, *count - 1));
                     }
                 }
             }

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -723,6 +723,22 @@ impl MacOSProvider {
             });
         }
 
+        // Deduplicate stable_ids — Qt QListWidget children can share the same
+        // AXIdentifier, which breaks cross-snapshot correlation. Append a
+        // disambiguation suffix to duplicates.
+        {
+            let mut seen: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+            for elem in &mut elements {
+                if let Some(ref id) = elem.stable_id {
+                    let count = seen.entry(id.clone()).or_insert(0);
+                    *count += 1;
+                    if *count > 1 {
+                        elem.stable_id = Some(format!("{}#{}", id, count - 1));
+                    }
+                }
+            }
+        }
+
         // Cache AX element handles for action dispatch
         *self.cached_elements.lock().unwrap() = ax_elements;
 
@@ -795,8 +811,11 @@ impl MacOSProvider {
         let subrole_str = ax_string(element.as_ptr(), "AXSubrole");
         let role = map_ax_role(&role_str, subrole_str.as_deref());
 
-        let name = ax_string(element.as_ptr(), "AXTitle")
-            .or_else(|| ax_string(element.as_ptr(), "AXDescription"))
+        let ax_title = ax_string(element.as_ptr(), "AXTitle");
+        let ax_description = ax_string(element.as_ptr(), "AXDescription");
+        let name = ax_title
+            .clone()
+            .or_else(|| ax_description.clone())
             .or_else(|| {
                 // For static text, the "value" IS the name
                 if role == Role::StaticText {
@@ -806,7 +825,17 @@ impl MacOSProvider {
                 }
             });
 
-        let description = ax_string(element.as_ptr(), "AXHelp");
+        // Qt's setAccessibleDescription maps to AXHelp, not AXDescription.
+        // Try AXHelp first; fall back to AXDescription only when it wasn't
+        // already consumed as the name.
+        let description = ax_string(element.as_ptr(), "AXHelp").or_else(|| {
+            if ax_title.is_some() {
+                // AXDescription wasn't used for the name — safe to use as description
+                ax_description
+            } else {
+                None
+            }
+        });
 
         // Value depends on role
         let value = match role {
@@ -928,11 +957,29 @@ impl MacOSProvider {
                     }
                 }
             }
-            // Skip nested AXApplication children — prevents infinite recursion from
-            // Qt/PySide6 apps that list themselves as their own child.
+            // Flatten nested application children — application nodes should only
+            // appear at the top level. Qt/PySide6 apps erroneously list themselves
+            // as their own child; we skip the duplicate but adopt its real children.
             {
                 let child_role = ax_string(child.as_ptr(), "AXRole").unwrap_or_default();
                 if child_role == "AXApplication" {
+                    let grandchildren = ax_children(child.as_ptr());
+                    for gc in &grandchildren {
+                        let gc_role = ax_string(gc.as_ptr(), "AXRole").unwrap_or_default();
+                        if gc_role == "AXApplication" {
+                            continue;
+                        }
+                        let gc_idx = elements.len() as u32;
+                        child_ids.push(gc_idx);
+                        self.traverse(
+                            gc,
+                            elements,
+                            ax_elements,
+                            Some(element_idx),
+                            depth + 1,
+                            screen_size,
+                        );
+                    }
                     continue;
                 }
             }
@@ -1264,7 +1311,12 @@ impl Provider for MacOSProvider {
                 }
                 Ok(())
             }
-        }
+        }?;
+
+        // Brief pause so the app can process the action and update its AX tree
+        // before the caller re-reads state.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        Ok(())
     }
 
     fn check_permissions(&self) -> Result<PermissionStatus> {
@@ -1330,7 +1382,8 @@ unsafe extern "C" fn ax_observer_callback(
             role,
             name: ax_string(element, "AXTitle"),
             value: ax_value_string(element),
-            description: ax_string(element, "AXDescription"),
+            description: ax_string(element, "AXHelp")
+                .or_else(|| ax_string(element, "AXDescription")),
             bounds: None,
             actions: vec![],
             states: StateSet::default(),

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -4,11 +4,11 @@ use xa11y::*;
 
 /// Get the test app tree, retrying briefly for registration.
 pub fn app_tree() -> Element {
-    for attempt in 0..3 {
+    for attempt in 0..6 {
         match App::from_name(xa11y::provider().unwrap(), "xa11y") {
             Ok(app) => return app.elements().expect("Failed to snapshot app tree"),
-            Err(_) if attempt < 2 => {
-                std::thread::sleep(std::time::Duration::from_millis(200));
+            Err(_) if attempt < 5 => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
             }
             Err(e) => panic!("Could not find test app after retries: {}", e),
         }
@@ -64,10 +64,10 @@ pub fn act(element: &Element, action: Action) -> Element {
     act_with(element, action, None)
 }
 
-/// Perform an action with data on an element, wait, then re-read the tree.
+/// Perform an action with data on an element, then re-read the tree.
+/// The provider already pauses briefly after each action for state to settle.
 pub fn act_with(element: &Element, action: Action, data: Option<ActionData>) -> Element {
     try_act_with(element, action, data)
         .unwrap_or_else(|e| panic!("Action {:?} failed: {}", action, e));
-    std::thread::sleep(std::time::Duration::from_millis(100));
     app_tree()
 }

--- a/xa11y/tests/integ_test.rs
+++ b/xa11y/tests/integ_test.rs
@@ -598,7 +598,6 @@ mod tests {
         // Focus action may succeed or fail depending on AT-SPI adapter support
         let result = h::try_act(&submit, Action::Focus);
         if result.is_ok() {
-            std::thread::sleep(std::time::Duration::from_millis(100));
             let root2 = h::app_tree();
             let submit2 = h::named(&root2, "Submit");
             // Some adapters may not reflect focused state change
@@ -952,7 +951,6 @@ mod tests {
             Some(ActionData::Value("Jane Smith".to_string())),
         ) {
             Ok(()) => {
-                std::thread::sleep(std::time::Duration::from_millis(300));
                 let root2 = h::app_tree();
                 // Value may or may not be reflected via AT-SPI depending on adapter
                 let updated = root2
@@ -980,7 +978,6 @@ mod tests {
             Some(ActionData::NumericValue(75.0)),
         );
         assert!(result.is_ok(), "SetValue numeric: {:?}", result.err());
-        std::thread::sleep(std::time::Duration::from_millis(300));
         let root2 = h::app_tree();
         let s2 = h::query(&root2, "slider").unwrap();
         if !s2.is_empty() {
@@ -1013,7 +1010,6 @@ mod tests {
             let initial: f64 = spin.value.as_deref().unwrap_or("0").parse().unwrap_or(0.0);
             let result = h::try_act(&spin, Action::Increment);
             if result.is_ok() {
-                std::thread::sleep(std::time::Duration::from_millis(300));
                 let root2 = h::app_tree();
                 if let Some(s2) = h::query(&root2, "slider").unwrap().first() {
                     if let Some(v) = &s2.value {
@@ -1047,7 +1043,6 @@ mod tests {
             let before: f64 = spin.value.as_deref().unwrap_or("0").parse().unwrap_or(0.0);
             let result = h::try_act(&spin, Action::Decrement);
             if result.is_ok() {
-                std::thread::sleep(std::time::Duration::from_millis(300));
                 let root2 = h::app_tree();
                 if let Some(s2) = h::query(&root2, "slider").unwrap().first() {
                     if let Some(v) = &s2.value {
@@ -1087,7 +1082,6 @@ mod tests {
         if let Some(node) = expander {
             // Expand
             if let Ok(()) = h::try_act(&node, Action::Expand) {
-                std::thread::sleep(std::time::Duration::from_millis(300));
                 let root2 = h::app_tree();
                 let n2 = h::query(&root2, r#"[name*="Expander"]"#)
                     .unwrap()
@@ -1103,7 +1097,6 @@ mod tests {
                     if n.states.expanded == Some(true) {
                         // Collapse
                         if let Ok(()) = h::try_act(&n, Action::Collapse) {
-                            std::thread::sleep(std::time::Duration::from_millis(300));
                             let root3 = h::app_tree();
                             let n3 = h::query(&root3, r#"[name*="Expander"]"#)
                                 .unwrap()

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -261,11 +261,7 @@ fn tree_get_by_index() {
 #[test]
 fn tree_get_nonexistent() {
     let root = sample_tree();
-    assert!(root
-        .subtree()
-        .into_iter()
-        .find(|e| e.index == 999)
-        .is_none());
+    assert!(!root.subtree().into_iter().any(|e| e.index == 999));
 }
 
 #[test]


### PR DESCRIPTION
- macOS: adopt grandchildren of duplicate AXApplication nodes instead of
  just skipping them, matching the Linux provider's flatten strategy
- macOS: deduplicate stable_ids when multiple elements share the same
  AXIdentifier (e.g. QListWidget children)
- macOS: fall back to AXDescription for the description field when AXHelp
  is absent and AXDescription wasn't consumed as the element name
- macOS: use AXHelp (then AXDescription) in event handler description
- macOS + Linux: add 50ms post-action delay so the app can update its
  accessibility tree before the caller re-reads state
- Fix pre-existing clippy search_is_some lint in unit_test.rs

https://claude.ai/code/session_01YPi7fsnnvqujPVqXXy47ao