### PR TITLE
fix: commit generated READMEs and remove sync-readmes from CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,9 +129,6 @@ jobs:
           .venv-qt-test/Scripts/pip.exe install maturin pytest pytest-timeout
           .venv-qt-test/Scripts/pip.exe install -r xa11y-qt-test-app/requirements.txt
 
-      - name: Generate READMEs
-        run: cargo xtask sync-readmes
-
       - name: Build & install xa11y Python bindings
         shell: bash
         working-directory: xa11y-python
@@ -168,6 +165,9 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+      - name: Check READMEs are in sync
+        run: cargo xtask sync-readmes --check
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets
@@ -260,9 +260,6 @@ jobs:
       - name: Ruff format
         working-directory: xa11y-python
         run: ../.venv/bin/ruff format --check python/ tests/
-
-      - name: Generate READMEs
-        run: cargo xtask sync-readmes
 
       - name: Build & install
         working-directory: xa11y-python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,9 +40,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Generate READMEs for package validation
-        run: cargo xtask sync-readmes
-
       - name: Bump version
         run: cargo release ${{ inputs.level }} --execute --no-confirm
 
@@ -66,9 +63,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Generate crates.io README
-        run: cargo xtask sync-readmes
 
       - name: Publish xa11y-core
         run: cargo publish -p xa11y-core
@@ -120,9 +114,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Generate PyPI README
-        run: cargo xtask sync-readmes
-
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
@@ -159,9 +150,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Generate PyPI README
-        run: cargo xtask sync-readmes
-
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
@@ -187,9 +175,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Generate PyPI README
-        run: cargo xtask sync-readmes
-
       - uses: PyO3/maturin-action@v1
         with:
           target: x86_64
@@ -210,9 +195,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-
-      - name: Generate PyPI README
-        run: cargo xtask sync-readmes
 
       - uses: PyO3/maturin-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,5 @@
 **/corpus
 **/artifacts
 .venv*/
-
-# Generated READMEs for crates.io and PyPI (built from root README.md)
-xa11y/README.md
-xa11y-python/README.md
 __pycache__/
 *.pyc

--- a/xa11y-python/README.md
+++ b/xa11y-python/README.md
@@ -1,0 +1,95 @@
+# xa11y
+
+[![Crates.io](https://img.shields.io/crates/v/xa11y)](https://crates.io/crates/xa11y)
+[![PyPI](https://img.shields.io/pypi/v/xa11y)](https://pypi.org/project/xa11y/)
+[![CI](https://github.com/xa11y/xa11y/actions/workflows/ci.yml/badge.svg)](https://github.com/xa11y/xa11y/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
+
+Cross-platform accessibility library for reading and interacting with accessibility trees. One API for macOS, Windows, and Linux.
+
+**Use cases:** UI testing, AI agent tooling, assistive technology, desktop automation.
+
+**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
+
+## Quick Example
+
+```python
+import xa11y
+
+safari = xa11y.app("Safari")
+
+# Find elements with CSS-like selectors
+for button in safari.locator("button").elements():
+    print(button.name)
+
+# Interact with elements via locator (re-resolves every call)
+safari.locator("button[name='Submit']").press()
+
+safari.locator("textfield[name^='Search']").set_value("hello world")
+```
+
+## Installation
+
+```bash
+pip install xa11y
+```
+
+Requires Python 3.9+. Pre-built wheels available for Linux, macOS, and Windows.
+
+> **macOS:** Grant accessibility permissions to your terminal in **System Settings > Privacy & Security > Accessibility**.
+>
+> **Linux:** AT-SPI2 must be running (default on GNOME/most DEs). No special permissions needed.
+>
+> **Windows:** No special permissions needed.
+
+## Selector Syntax
+
+Query accessibility trees with CSS-like selectors:
+
+| Pattern | Meaning |
+| --- | --- |
+| `button` | Elements with role Button |
+| `button[name='OK']` | Button named exactly "OK" |
+| `textfield[name^='Search']` | Text field whose name starts with "Search" |
+| `textfield[name*='email']` | Text field whose name contains "email" |
+| `group > button` | Buttons that are direct children of a group |
+| `window button` | Buttons anywhere inside a window |
+| `button:nth(2)` | The 2nd button match |
+
+## Supported Actions
+
+| Action | Description |
+| --- | --- |
+| `press` | Click / activate |
+| `focus` / `blur` | Move or remove keyboard focus |
+| `toggle` | Toggle a checkbox or switch |
+| `expand` / `collapse` | Expand or collapse a disclosure |
+| `select` | Select an item |
+| `set_value` | Set a text field's value |
+| `type_text` | Type text into an element |
+| `increment` / `decrement` | Adjust a slider or stepper |
+| `scroll` | Scroll in a direction |
+| `show_menu` | Open a context menu |
+
+## Platform Support
+
+| Platform | Backend |
+| --- | --- |
+| macOS | AXUIElement |
+| Linux | AT-SPI2 (D-Bus) |
+| Windows | UI Automation |
+
+## Contributing
+
+```bash
+git clone https://github.com/xa11y/xa11y && cd xa11y
+cargo build --workspace
+cargo xtask check   # fmt, lint, test, python bindings
+```
+
+See the [development docs](https://xa11y.dev/guides/overview/) for architecture and setup.
+
+## License
+
+MIT. All dependencies are permissively licensed (MIT, Apache-2.0, BSD, or similar), enforced via `cargo-deny`.

--- a/xa11y/README.md
+++ b/xa11y/README.md
@@ -1,0 +1,96 @@
+# xa11y
+
+[![Crates.io](https://img.shields.io/crates/v/xa11y)](https://crates.io/crates/xa11y)
+[![PyPI](https://img.shields.io/pypi/v/xa11y)](https://pypi.org/project/xa11y/)
+[![CI](https://github.com/xa11y/xa11y/actions/workflows/ci.yml/badge.svg)](https://github.com/xa11y/xa11y/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
+
+Cross-platform accessibility library for reading and interacting with accessibility trees. One API for macOS, Windows, and Linux.
+
+**Use cases:** UI testing, AI agent tooling, assistive technology, desktop automation.
+
+**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
+
+## Quick Example
+
+```rust
+use xa11y::*;
+
+fn main() -> Result<()> {
+    let safari = App::from_name(provider()?, "Safari")?;
+
+    // Snapshot the tree and find elements with CSS-like selectors
+    let buttons = safari.locator("button[name='Submit']").elements()?;
+    println!("Found {} buttons", buttons.len());
+
+    // Interact with elements via locator (re-resolves every call)
+    safari.locator("button[name='Submit']").press()?;
+
+    Ok(())
+}
+```
+
+## Installation
+
+```toml
+[dependencies]
+xa11y = "0.2"
+```
+
+> **macOS:** Grant accessibility permissions to your terminal in **System Settings > Privacy & Security > Accessibility**.
+>
+> **Linux:** AT-SPI2 must be running (default on GNOME/most DEs). No special permissions needed.
+>
+> **Windows:** No special permissions needed.
+
+## Selector Syntax
+
+Query accessibility trees with CSS-like selectors:
+
+| Pattern | Meaning |
+| --- | --- |
+| `button` | Elements with role Button |
+| `button[name='OK']` | Button named exactly "OK" |
+| `textfield[name^='Search']` | Text field whose name starts with "Search" |
+| `textfield[name*='email']` | Text field whose name contains "email" |
+| `group > button` | Buttons that are direct children of a group |
+| `window button` | Buttons anywhere inside a window |
+| `button:nth(2)` | The 2nd button match |
+
+## Supported Actions
+
+| Action | Description |
+| --- | --- |
+| `press` | Click / activate |
+| `focus` / `blur` | Move or remove keyboard focus |
+| `toggle` | Toggle a checkbox or switch |
+| `expand` / `collapse` | Expand or collapse a disclosure |
+| `select` | Select an item |
+| `set_value` | Set a text field's value |
+| `type_text` | Type text into an element |
+| `increment` / `decrement` | Adjust a slider or stepper |
+| `scroll` | Scroll in a direction |
+| `show_menu` | Open a context menu |
+
+## Platform Support
+
+| Platform | Backend |
+| --- | --- |
+| macOS | AXUIElement |
+| Linux | AT-SPI2 (D-Bus) |
+| Windows | UI Automation |
+
+## Contributing
+
+```bash
+git clone https://github.com/xa11y/xa11y && cd xa11y
+cargo build --workspace
+cargo xtask check   # fmt, lint, test, python bindings
+```
+
+See the [development docs](https://xa11y.dev/guides/overview/) for architecture and setup.
+
+## License
+
+MIT. All dependencies are permissively licensed (MIT, Apache-2.0, BSD, or similar), enforced via `cargo-deny`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,7 +19,7 @@ COMMANDS:
     docs                Build documentation
     coverage            Generate code coverage report
     fuzz [ARGS..]       Run provider fuzzer (pass-through args)
-    sync-readmes        Generate crates.io/PyPI READMEs from root README.md
+    sync-readmes [--check]  Generate crates.io/PyPI READMEs from root README.md
     check               Run ALL pre-PR checks (fmt, lint, test, test-python, docs)
     help                Show this help
 ";
@@ -40,7 +40,7 @@ fn main() -> ExitCode {
         "docs" => do_docs(),
         "coverage" => do_coverage(),
         "fuzz" => do_fuzz(rest),
-        "sync-readmes" => do_sync_readmes(),
+        "sync-readmes" => do_sync_readmes(rest),
         "check" => do_check(),
         "help" | "--help" | "-h" => {
             print!("{HELP}");
@@ -239,8 +239,13 @@ fn do_fuzz(args: &[String]) -> bool {
     run("bash", &cmd_args)
 }
 
-fn do_sync_readmes() -> bool {
-    heading("Sync READMEs");
+fn do_sync_readmes(args: &[String]) -> bool {
+    let check = args.iter().any(|a| a == "--check");
+    heading(if check {
+        "Check READMEs are in sync"
+    } else {
+        "Sync READMEs"
+    });
     let root = project_root();
     let source = match fs::read_to_string(root.join("README.md")) {
         Ok(s) => s,
@@ -258,10 +263,18 @@ fn do_sync_readmes() -> bool {
     let mut ok = true;
     for &(keep, dest) in targets {
         let remove = if keep == "rust" { "python" } else { "rust" };
-        let text = strip_lang_blocks(&source, keep, remove);
-
+        let expected = strip_lang_blocks(&source, keep, remove);
         let path = root.join(dest);
-        if let Err(e) = fs::write(&path, &text) {
+
+        if check {
+            let actual = fs::read_to_string(&path).unwrap_or_default();
+            if actual != expected {
+                eprintln!("{dest} is out of date. Run `cargo xtask sync-readmes` to fix.");
+                ok = false;
+            } else {
+                eprintln!("{dest} is up to date.");
+            }
+        } else if let Err(e) = fs::write(&path, &expected) {
             eprintln!("Failed to write {dest}: {e}");
             ok = false;
         } else {
@@ -308,6 +321,12 @@ fn strip_lang_blocks(source: &str, keep: &str, remove: &str) -> String {
 
 fn do_check() -> bool {
     let mut ok = true;
+
+    heading("PRE-PR CHECK: sync-readmes");
+    if !do_sync_readmes(&["--check".to_string()]) {
+        eprintln!("!! READMEs out of date. Run `cargo xtask sync-readmes` to fix.");
+        ok = false;
+    }
 
     heading("PRE-PR CHECK: format");
     if !do_fmt(&["--check".to_string()]) {


### PR DESCRIPTION
Generated READMEs (xa11y/README.md, xa11y-python/README.md) were
gitignored, forcing every CI job that needed them to run
`cargo xtask sync-readmes` first (8 times across ci.yml and publish.yml).

Now the generated files are committed to git and a single --check in the
lint job catches drift. The xtask command gains a --check flag (like fmt)
and do_check includes it in pre-PR validation.

https://claude.ai/code/session_01BsRB2ebVyhiQrTxgsJb7AA