### PR TITLE
fix: wait for WebView content before running Tauri tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,6 +27,7 @@ def launch_test_app(
     app_names: list[str],
     env_overrides: dict[str, str] | None = None,
     startup_timeout: int = STARTUP_TIMEOUT,
+    content_ready_selector: str | None = None,
 ) -> Generator[xa11y.Element, None, None]:
     """Launch a test app and yield its xa11y Element handle.
 
@@ -35,6 +36,9 @@ def launch_test_app(
         app_names: Names to search for via accessibility API (tried in order).
         env_overrides: Extra environment variables to set for the subprocess.
         startup_timeout: Seconds to wait for the app to appear.
+        content_ready_selector: If set, keep polling until this selector matches
+            within the app element (useful for WebView apps where UI content
+            loads asynchronously after the app window appears).
 
     Yields:
         The xa11y Element for the app's root application node.
@@ -96,6 +100,22 @@ def launch_test_app(
             f"Available apps: {app_list}\n"
             f"stdout: {out}\nstderr: {err}"
         )
+
+    if content_ready_selector is not None:
+        content_deadline = time.monotonic() + startup_timeout
+        while time.monotonic() < content_deadline:
+            try:
+                app.locator(content_ready_selector).element()
+                break
+            except (xa11y.SelectorNotMatchedError, xa11y.PlatformError):
+                time.sleep(0.5)
+        else:
+            proc.terminate()
+            proc.wait(timeout=5)
+            pytest.fail(
+                f"Content not ready: selector {content_ready_selector!r} "
+                f"not found after {startup_timeout}s."
+            )
 
     yield app
 

--- a/tests/tauri/conftest.py
+++ b/tests/tauri/conftest.py
@@ -40,4 +40,5 @@ def tauri_app():
     yield from launch_test_app(
         command=[BINARY],
         app_names=APP_NAMES,
+        content_ready_selector='button[name="OK"]',
     )


### PR DESCRIPTION
## Summary
- Tauri `test_ok_button_exists` was flaky on Linux CI — the WebView HTML content loads asynchronously after the app window appears in the accessibility tree
- Added `content_ready_selector` parameter to `launch_test_app()` that polls until a specific element is found before yielding
- Tauri conftest now waits for `button[name="OK"]` to appear before tests begin

## Test plan
- [ ] Linux CI Tauri integration tests pass consistently
- [ ] Other test suites (Qt, GTK, Cocoa) unaffected (they don't use the new parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)