### PR TITLE
feat: panic on unknown role mappings in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT"
 repository = "https://github.com/xa11y/xa11y"
 
 [workspace.dependencies]
-xa11y-core = { path = "xa11y-core", version = "0.5.2" }
+xa11y-core = { path = "xa11y-core", version = "0.5.2", default-features = false }
 xa11y-macos = { path = "xa11y-macos", version = "0.5.2" }
 xa11y-windows = { path = "xa11y-windows", version = "0.5.2" }
 xa11y-linux = { path = "xa11y-linux", version = "0.5.2" }

--- a/scripts/run_integ_tests.sh
+++ b/scripts/run_integ_tests.sh
@@ -94,7 +94,7 @@ dbus-send --session --print-reply --dest=org.a11y.Bus /org/a11y/bus \
 
 # 3. Build everything
 echo "Building workspace..."
-cargo build --workspace 2>&1
+cargo build --workspace --features xa11y/strict-roles 2>&1
 
 # Support BUILD_ONLY mode (for pre-warming the build cache)
 if [ "${BUILD_ONLY:-}" = "1" ]; then
@@ -117,9 +117,9 @@ echo "Running integration tests..."
 TEST_FILTER="${TEST_FILTER:-}"
 set +e
 if [ -n "$TEST_FILTER" ]; then
-    cargo test -p xa11y --test integ_test -- --ignored --test-threads=1 $TEST_FILTER 2>&1
+    cargo test -p xa11y --features strict-roles --test integ_test -- --ignored --test-threads=1 $TEST_FILTER 2>&1
 else
-    cargo test -p xa11y --test integ_test -- --ignored --test-threads=1 2>&1
+    cargo test -p xa11y --features strict-roles --test integ_test -- --ignored --test-threads=1 2>&1
 fi
 TEST_EXIT=$?
 set -e

--- a/scripts/run_integ_tests_macos.sh
+++ b/scripts/run_integ_tests_macos.sh
@@ -23,7 +23,7 @@ echo "=== xa11y macOS integration test harness ==="
 
 # 1. Build everything
 echo "Building workspace..."
-cargo build --workspace 2>&1
+cargo build --workspace --features xa11y/strict-roles 2>&1
 
 # 2. Launch the test application (run binary directly, not via cargo run,
 #    because cargo run changes the process owner name in CGWindowListCopyWindowInfo)
@@ -38,7 +38,7 @@ sleep 2
 # 3. Run integration tests
 echo "Running integration tests..."
 set +e
-cargo test -p xa11y --test integ_test -- --ignored --test-threads=1 2>&1
+cargo test -p xa11y --features strict-roles --test integ_test -- --ignored --test-threads=1 2>&1
 TEST_EXIT=$?
 
 # 4. Run macOS provider AX call count regression tests

--- a/xa11y-core/Cargo.toml
+++ b/xa11y-core/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 description = "Core types, traits, and selector engine for xa11y cross-platform accessibility"
 
+[features]
+strict-roles = []
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -18,7 +18,7 @@ pub use event::{ElementState, Event, EventType, StateFlag, TextChangeData, TextC
 pub use event_provider::{CancelHandle, EventReceiver, Subscription, SubscriptionIter};
 pub use locator::Locator;
 pub use provider::Provider;
-pub use role::Role;
+pub use role::{unknown_role, Role};
 pub use selector::Selector;
 
 /// Maximum tree traversal depth for providers. Prevents stack overflow from

--- a/xa11y-core/src/role.rs
+++ b/xa11y-core/src/role.rs
@@ -150,6 +150,17 @@ impl Role {
     }
 }
 
+/// Returns `Role::Unknown` normally, but panics with a descriptive message when
+/// the `strict-roles` feature is enabled. Platform backends call this in their
+/// catch-all mapping arms so that integration tests surface unmapped roles.
+#[inline]
+pub fn unknown_role(context: &str) -> Role {
+    if cfg!(feature = "strict-roles") {
+        panic!("strict-roles: unmapped platform role — {context}");
+    }
+    Role::Unknown
+}
+
 impl std::fmt::Display for Role {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_snake_case())

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1604,7 +1604,7 @@ fn map_atspi_role(role_name: &str) -> Role {
         "tooltip" | "tool tip" => Role::Tooltip,
         "status bar" | "statusbar" => Role::Status,
         "landmark" | "navigation" => Role::Navigation,
-        _ => Role::Unknown,
+        _ => xa11y_core::unknown_role(role_name),
     }
 }
 
@@ -1673,7 +1673,7 @@ fn map_atspi_role_number(role: u32) -> Role {
         101 => Role::Alert,      // Notification
         116 => Role::StaticText, // Static
         129 => Role::Button,     // PushButtonMenu
-        _ => Role::Unknown,
+        _ => xa11y_core::unknown_role(&format!("AT-SPI role number {role}")),
     }
 }
 

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -867,7 +867,7 @@ fn map_ax_role(role: &str, subrole: Option<&str>) -> Role {
         "AXStatusBar" => Role::Status,
         "AXColorWell" | "AXValueIndicator" | "AXGrid" | "AXRuler" | "AXGrowArea" | "AXMatte"
         | "AXDockItem" | "AXBrowser" => Role::Unknown,
-        _ => Role::Unknown,
+        _ => xa11y_core::unknown_role(role),
     }
 }
 

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -1266,7 +1266,7 @@ fn map_uia_control_type(control_type: UIA_CONTROLTYPE_ID) -> Role {
         UIA_ToolTipControlTypeId => Role::Tooltip,
         UIA_CalendarControlTypeId => Role::Group,
         UIA_CustomControlTypeId => Role::Unknown,
-        _ => Role::Unknown,
+        _ => xa11y_core::unknown_role(&format!("UIA control type {}", control_type.0)),
     }
 }
 

--- a/xa11y/Cargo.toml
+++ b/xa11y/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 
 [features]
 testing = []
+strict-roles = ["xa11y-core/strict-roles"]
 
 [dependencies]
 xa11y-core = { workspace = true }


### PR DESCRIPTION
## Summary

- Adds a `strict-roles` Cargo feature flag to `xa11y-core` with an `unknown_role()` helper that panics when enabled, instead of silently returning `Role::Unknown`
- Wires the catch-all `_ =>` arms in all three platform backends (AT-SPI, AX, UIA) to call `unknown_role()` with a descriptive context message
- Enables `strict-roles` in integration test scripts (`run_integ_tests.sh`, `run_integ_tests_macos.sh`) so CI catches unmapped roles
- Regular unit tests and production builds are completely unaffected — the feature is only activated during integration test runs

## Test plan

- [x] `cargo xtask fmt --check` passes
- [x] `cargo xtask lint` passes
- [x] `cargo xtask test` passes (unit tests, no strict-roles)
- [x] `cargo test -p xa11y --features strict-roles --no-run` compiles
- [ ] CI integration tests pass on Linux
- [ ] CI integration tests pass on macOS

https://claude.ai/code/session_013WwzbJGNUwgasTBW69WJQs