### PR TITLE
fix(macos): improve AX role mapping — ScrollThumb, Browser, Column, MenuButton

### DIFF
--- a/tests/cocoa/test_widgets.py
+++ b/tests/cocoa/test_widgets.py
@@ -208,3 +208,29 @@ def test_list_has_items(cocoa_app: xa11y.Element) -> None:
     # NSTableView (used for list views) is exposed as AXTable, not AXList
     lst = find(cocoa_app, 'table[name="Items"]')
     assert len(lst.children()) >= 1
+
+
+# ── Scroll bar ────────────────────────────────────────────────────────────────
+
+
+def test_scroll_bar_found(cocoa_app: xa11y.Element) -> None:
+    # The main window uses NSScrollView — a scroll_bar should be present.
+    scrollbars = cocoa_app.locator("scroll_bar").elements()
+    assert len(scrollbars) >= 1, "Expected at least one scroll_bar"
+
+
+def test_scroll_thumb_role(cocoa_app: xa11y.Element) -> None:
+    # macOS exposes AXValueIndicator (scroll thumb) as a child of scroll_bar.
+    # It must map to scroll_thumb, not unknown.
+    scrollbars = cocoa_app.locator("scroll_bar").elements()
+    assert scrollbars, "No scroll_bar found — cannot test scroll_thumb"
+    thumbs = [
+        child
+        for sb in scrollbars
+        for child in sb.children()
+        if child.role == "scroll_thumb"
+    ]
+    assert thumbs, (
+        "No scroll_thumb found inside scroll_bar children. "
+        "AXValueIndicator may be mapping to unknown instead of scroll_thumb."
+    )

--- a/tests/qt/test_03_a11y_tree.py
+++ b/tests/qt/test_03_a11y_tree.py
@@ -245,7 +245,7 @@ def test_tree_roles_are_all_valid(qt_app):
         "radio_button", "text_field", "text_area", "static_text",
         "combo_box", "list", "list_item", "menu", "menu_item",
         "menu_bar", "tab", "tab_group", "table", "table_row",
-        "table_cell", "toolbar", "scroll_bar", "slider", "image",
+        "table_cell", "toolbar", "scroll_bar", "scroll_thumb", "slider", "image",
         "link", "group", "dialog", "alert", "progress_bar",
         "tree_item", "web_area", "heading", "separator", "split_group",
         "switch", "spin_button", "tooltip", "status", "navigation",

--- a/xa11y-core/src/role.rs
+++ b/xa11y-core/src/role.rs
@@ -54,6 +54,8 @@ pub enum Role {
     Status,
     /// Navigation landmark
     Navigation,
+    /// Scroll thumb — the draggable indicator inside a scroll bar
+    ScrollThumb,
 }
 
 impl Role {
@@ -100,6 +102,7 @@ impl Role {
             "tooltip" => Some(Role::Tooltip),
             "status" => Some(Role::Status),
             "navigation" => Some(Role::Navigation),
+            "scroll_thumb" => Some(Role::ScrollThumb),
             _ => None,
         }
     }
@@ -146,6 +149,7 @@ impl Role {
             Role::Tooltip => "tooltip",
             Role::Status => "status",
             Role::Navigation => "navigation",
+            Role::ScrollThumb => "scroll_thumb",
         }
     }
 }
@@ -164,5 +168,75 @@ pub fn unknown_role(context: &str) -> Role {
 impl std::fmt::Display for Role {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_snake_case())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scroll_thumb_roundtrips() {
+        assert_eq!(Role::ScrollThumb.to_snake_case(), "scroll_thumb");
+        assert_eq!(
+            Role::from_snake_case("scroll_thumb"),
+            Some(Role::ScrollThumb)
+        );
+        assert_eq!(format!("{}", Role::ScrollThumb), "scroll_thumb");
+    }
+
+    #[test]
+    fn all_roles_roundtrip() {
+        // Every role must parse back from its own snake_case representation.
+        let roles = [
+            Role::Unknown,
+            Role::Window,
+            Role::Application,
+            Role::Button,
+            Role::CheckBox,
+            Role::RadioButton,
+            Role::TextField,
+            Role::TextArea,
+            Role::StaticText,
+            Role::ComboBox,
+            Role::List,
+            Role::ListItem,
+            Role::Menu,
+            Role::MenuItem,
+            Role::MenuBar,
+            Role::Tab,
+            Role::TabGroup,
+            Role::Table,
+            Role::TableRow,
+            Role::TableCell,
+            Role::Toolbar,
+            Role::ScrollBar,
+            Role::ScrollThumb,
+            Role::Slider,
+            Role::Image,
+            Role::Link,
+            Role::Group,
+            Role::Dialog,
+            Role::Alert,
+            Role::ProgressBar,
+            Role::TreeItem,
+            Role::WebArea,
+            Role::Heading,
+            Role::Separator,
+            Role::SplitGroup,
+            Role::Switch,
+            Role::SpinButton,
+            Role::Tooltip,
+            Role::Status,
+            Role::Navigation,
+        ];
+        for role in roles {
+            let s = role.to_snake_case();
+            assert_eq!(
+                Role::from_snake_case(s),
+                Some(role),
+                "roundtrip failed for {s}"
+            );
+        }
     }
 }

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -839,7 +839,11 @@ fn map_ax_role(role: &str, subrole: Option<&str>) -> Role {
         "AXTextField" | "AXSecureTextField" => Role::TextField,
         "AXTextArea" => Role::TextArea,
         "AXStaticText" => Role::StaticText,
-        "AXComboBox" | "AXPopUpButton" | "AXMenuButton" => Role::ComboBox,
+        "AXComboBox" | "AXPopUpButton" => Role::ComboBox,
+        "AXMenuButton" => match subrole {
+            Some("AXSegment") => Role::Button,
+            _ => Role::ComboBox,
+        },
         "AXList" => Role::List,
         "AXTable" => Role::Table,
         "AXOutline" => Role::List,
@@ -854,7 +858,9 @@ fn map_ax_role(role: &str, subrole: Option<&str>) -> Role {
         "AXSlider" => Role::Slider,
         "AXImage" => Role::Image,
         "AXLink" => Role::Link,
-        "AXGroup" | "AXScrollArea" | "AXLayoutArea" | "AXRadioGroup" => Role::Group,
+        "AXGroup" | "AXScrollArea" | "AXLayoutArea" | "AXRadioGroup" | "AXBrowser" | "AXColumn" => {
+            Role::Group
+        }
         "AXDialog" => Role::Dialog,
         "AXProgressIndicator" | "AXBusyIndicator" | "AXLevelIndicator" => Role::ProgressBar,
         "AXDisclosureTriangle" => Role::TreeItem,
@@ -865,8 +871,10 @@ fn map_ax_role(role: &str, subrole: Option<&str>) -> Role {
         "AXIncrementor" => Role::SpinButton,
         "AXToolTip" => Role::Tooltip,
         "AXStatusBar" => Role::Status,
-        "AXColorWell" | "AXValueIndicator" | "AXGrid" | "AXRuler" | "AXGrowArea" | "AXMatte"
-        | "AXDockItem" | "AXBrowser" => Role::Unknown,
+        "AXValueIndicator" => Role::ScrollThumb,
+        "AXColorWell" | "AXGrid" | "AXRuler" | "AXGrowArea" | "AXMatte" | "AXDockItem" => {
+            Role::Unknown
+        }
         _ => xa11y_core::unknown_role(role),
     }
 }
@@ -2254,10 +2262,16 @@ mod tests {
         assert_eq!(map_ax_role("AXWebArea", None), Role::WebArea);
         assert_eq!(map_ax_role("AXIncrementor", None), Role::SpinButton);
         assert_eq!(map_ax_role("AXColorWell", None), Role::Unknown);
-        assert_eq!(map_ax_role("AXValueIndicator", None), Role::Unknown);
         assert_eq!(map_ax_role("TotallyUnknownRole", None), Role::Unknown);
         // PySide6/Qt exposes QComboBox as AXMenuButton on macOS
         assert_eq!(map_ax_role("AXMenuButton", None), Role::ComboBox);
+        // AXBrowser (Finder column view) and AXColumn (table columns) map to Group
+        assert_eq!(map_ax_role("AXBrowser", None), Role::Group);
+        assert_eq!(map_ax_role("AXColumn", None), Role::Group);
+        // AXValueIndicator is the scroll thumb inside a scroll bar
+        assert_eq!(map_ax_role("AXValueIndicator", None), Role::ScrollThumb);
+        // AXMenuButton with AXSegment subrole is a segmented control button
+        assert_eq!(map_ax_role("AXMenuButton", Some("AXSegment")), Role::Button);
     }
 
     #[test]

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -1261,7 +1261,7 @@ fn map_uia_control_type(control_type: UIA_CONTROLTYPE_ID) -> Role {
         UIA_SpinnerControlTypeId => Role::SpinButton,
         UIA_SplitButtonControlTypeId => Role::Button,
         UIA_StatusBarControlTypeId => Role::Status,
-        UIA_ThumbControlTypeId => Role::Unknown,
+        UIA_ThumbControlTypeId => Role::ScrollThumb,
         UIA_TitleBarControlTypeId => Role::Group,
         UIA_ToolTipControlTypeId => Role::Tooltip,
         UIA_CalendarControlTypeId => Role::Group,
@@ -1409,6 +1409,10 @@ mod tests {
         assert_eq!(map_uia_control_type(UIA_ImageControlTypeId), Role::Image);
         assert_eq!(map_uia_control_type(UIA_HyperlinkControlTypeId), Role::Link);
         assert_eq!(map_uia_control_type(UIA_GroupControlTypeId), Role::Group);
+        assert_eq!(
+            map_uia_control_type(UIA_ThumbControlTypeId),
+            Role::ScrollThumb
+        );
         assert_eq!(
             map_uia_control_type(UIA_CONTROLTYPE_ID(99999)),
             Role::Unknown

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -400,6 +400,7 @@ fn role_snake_case_roundtrip() {
         Role::TableRow,
         Role::TableCell,
         Role::ScrollBar,
+        Role::ScrollThumb,
         Role::ProgressBar,
         Role::TreeItem,
         Role::WebArea,


### PR DESCRIPTION
## Summary

- Add `Role::ScrollThumb` (`scroll_thumb`) mapped from `AXValueIndicator` (macOS) and `UIA_ThumbControlTypeId` (Windows) — scroll thumbs no longer show as `unknown`
- `AXBrowser` → `Role::Group` (Finder column view was `unknown`)
- `AXColumn` → `Role::Group` (table columns in Safari/System Settings were `unknown`)
- `AXMenuButton` + `AXSegment` subrole → `Role::Button` (Back/Forward segmented controls in System Settings were `combo_box`)

Gaps found by exploring real apps (Finder, Safari, System Settings, Chrome, Messages, Ghostty, Calculator) with the xa11y CLI.

## Test plan

- [ ] Unit tests: `cargo xtask test` — `scroll_thumb_roundtrips`, `all_roles_roundtrip`, updated macOS/Windows mapping assertions
- [ ] Cocoa integration tests: `cargo xtask test-cocoa` — `test_scroll_bar_found`, `test_scroll_thumb_role`
- [ ] `cargo xtask fmt --check` and `cargo xtask lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)