### PR TITLE
fix(linux): return ActionNotSupported for unsupported scroll actions

### DIFF
--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1468,17 +1468,21 @@ impl Provider for LinuxProvider {
                 .do_atspi_action_by_name(&target, "scroll down")
                 .is_err()
             {
-                // Fall back to Component.ScrollTo (single call, not repeatable)
-                let proxy =
-                    self.make_proxy(&target.bus_name, &target.path, "org.a11y.atspi.Component")?;
-                // BOTTOM_EDGE = 3
-                proxy
-                    .call_method("ScrollTo", &(3u32,))
-                    .map_err(|e| Error::Platform {
-                        code: -1,
-                        message: format!("ScrollTo failed: {}", e),
-                    })?;
-                return Ok(());
+                // Fall back to Component.ScrollTo (single call, not repeatable).
+                // If both fail, return ActionNotSupported for clearer error handling.
+                // Fixes GitHub issue #99.
+                if let Ok(proxy) =
+                    self.make_proxy(&target.bus_name, &target.path, "org.a11y.atspi.Component")
+                {
+                    // BOTTOM_EDGE = 3
+                    if proxy.call_method("ScrollTo", &(3u32,)).is_ok() {
+                        return Ok(());
+                    }
+                }
+                return Err(Error::ActionNotSupported {
+                    action: "scroll_down".to_string(),
+                    role: element.role,
+                });
             }
         }
         Ok(())
@@ -1489,17 +1493,21 @@ impl Provider for LinuxProvider {
         let count = (amount.abs() as u32).max(1);
         for _ in 0..count {
             if self.do_atspi_action_by_name(&target, "scroll up").is_err() {
-                // Fall back to Component.ScrollTo (single call, not repeatable)
-                let proxy =
-                    self.make_proxy(&target.bus_name, &target.path, "org.a11y.atspi.Component")?;
-                // TOP_EDGE = 2
-                proxy
-                    .call_method("ScrollTo", &(2u32,))
-                    .map_err(|e| Error::Platform {
-                        code: -1,
-                        message: format!("ScrollTo failed: {}", e),
-                    })?;
-                return Ok(());
+                // Fall back to Component.ScrollTo (single call, not repeatable).
+                // If both fail, return ActionNotSupported for clearer error handling.
+                // Fixes GitHub issue #99.
+                if let Ok(proxy) =
+                    self.make_proxy(&target.bus_name, &target.path, "org.a11y.atspi.Component")
+                {
+                    // TOP_EDGE = 2
+                    if proxy.call_method("ScrollTo", &(2u32,)).is_ok() {
+                        return Ok(());
+                    }
+                }
+                return Err(Error::ActionNotSupported {
+                    action: "scroll_up".to_string(),
+                    role: element.role,
+                });
             }
         }
         Ok(())
@@ -1513,17 +1521,21 @@ impl Provider for LinuxProvider {
                 .do_atspi_action_by_name(&target, "scroll right")
                 .is_err()
             {
-                // Fall back to Component.ScrollTo (single call, not repeatable)
-                let proxy =
-                    self.make_proxy(&target.bus_name, &target.path, "org.a11y.atspi.Component")?;
-                // RIGHT_EDGE = 5
-                proxy
-                    .call_method("ScrollTo", &(5u32,))
-                    .map_err(|e| Error::Platform {
-                        code: -1,
-                        message: format!("ScrollTo failed: {}", e),
-                    })?;
-                return Ok(());
+                // Fall back to Component.ScrollTo (single call, not repeatable).
+                // If both fail, return ActionNotSupported for clearer error handling.
+                // Fixes GitHub issue #99.
+                if let Ok(proxy) =
+                    self.make_proxy(&target.bus_name, &target.path, "org.a11y.atspi.Component")
+                {
+                    // RIGHT_EDGE = 5
+                    if proxy.call_method("ScrollTo", &(5u32,)).is_ok() {
+                        return Ok(());
+                    }
+                }
+                return Err(Error::ActionNotSupported {
+                    action: "scroll_right".to_string(),
+                    role: element.role,
+                });
             }
         }
         Ok(())
@@ -1537,17 +1549,21 @@ impl Provider for LinuxProvider {
                 .do_atspi_action_by_name(&target, "scroll left")
                 .is_err()
             {
-                // Fall back to Component.ScrollTo (single call, not repeatable)
-                let proxy =
-                    self.make_proxy(&target.bus_name, &target.path, "org.a11y.atspi.Component")?;
-                // LEFT_EDGE = 4
-                proxy
-                    .call_method("ScrollTo", &(4u32,))
-                    .map_err(|e| Error::Platform {
-                        code: -1,
-                        message: format!("ScrollTo failed: {}", e),
-                    })?;
-                return Ok(());
+                // Fall back to Component.ScrollTo (single call, not repeatable).
+                // If both fail, return ActionNotSupported for clearer error handling.
+                // Fixes GitHub issue #99.
+                if let Ok(proxy) =
+                    self.make_proxy(&target.bus_name, &target.path, "org.a11y.atspi.Component")
+                {
+                    // LEFT_EDGE = 4
+                    if proxy.call_method("ScrollTo", &(4u32,)).is_ok() {
+                        return Ok(());
+                    }
+                }
+                return Err(Error::ActionNotSupported {
+                    action: "scroll_left".to_string(),
+                    role: element.role,
+                });
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

When scroll_* actions fail on both the AT-SPI Action interface and Component.ScrollTo fallback, return `ActionNotSupported` instead of `Platform` error. This provides clearer error messages and better aligns with the library's error handling conventions.

## Problem

Previously, when scroll actions failed:
1. AT-SPI Action interface lookup fails (no "scroll down" action)
2. Component.ScrollTo fallback fails with `DBus.Error.NotSupported`
3. User sees confusing `Platform` error with raw DBus message

## Solution

- Changed scroll methods to return `ActionNotSupported` when both mechanisms fail
- Error now clearly indicates which action is not supported on which role
- Example: `ActionNotSupportedError: scroll_down not supported on button`

## Test plan

- [x] Rust unit tests pass
- [x] Manual verification: scroll methods now return consistent error type

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)