### PR TITLE
Add JavaScript API documentation generation to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: docs/site/package-lock.json
+          cache-dependency-path: |
+            docs/site/package-lock.json
+            xa11y-js/package-lock.json
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -38,6 +40,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
+            xa11y-js/target
           key: docs-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: docs-cargo-
 
@@ -48,6 +51,27 @@ jobs:
 
       - name: Install Sphinx
         run: pip install sphinx sphinx-rtd-theme sphinx-autoapi
+
+      # The JS API doc generator reads xa11y-js/native.d.ts, which is
+      # produced by napi-rs from the Rust source. Build + patch it here
+      # so the generator has a fresh source of truth to read from.
+      - name: Install xa11y-js dev dependencies
+        working-directory: xa11y-js
+        run: npm ci
+
+      - name: Build xa11y-js native binding (for type stubs)
+        working-directory: xa11y-js
+        run: npx napi build --platform --js native.js --dts native.d.ts
+
+      - name: Patch native.d.ts
+        working-directory: xa11y-js
+        run: node scripts/patch-native-dts.mjs
+
+      - name: Generate Python API docs
+        run: python docs/generate_python_api.py
+
+      - name: Generate JavaScript API docs
+        run: python docs/generate_js_api.py
 
       - name: Install npm dependencies
         working-directory: docs/site


### PR DESCRIPTION
## Summary
This PR enhances the documentation build workflow to generate JavaScript API documentation alongside the existing Python API docs. It adds build steps for the xa11y-js package to ensure fresh type definitions are available for the documentation generator.

## Key Changes
- Extended npm cache configuration to include `xa11y-js/package-lock.json` for dependency caching
- Added Rust build cache for `xa11y-js/target` directory to speed up subsequent builds
- Added build steps to compile xa11y-js native bindings and generate fresh TypeScript type definitions (`native.d.ts`)
- Integrated a patching step for the generated type definitions via `scripts/patch-native-dts.mjs`
- Added Python script execution to generate both Python and JavaScript API documentation

## Implementation Details
The workflow now:
1. Installs xa11y-js dev dependencies
2. Builds the native binding using napi-rs to generate `native.d.ts`
3. Patches the generated type definitions for documentation purposes
4. Generates both Python and JavaScript API documentation from the fresh type definitions

This ensures the documentation always reflects the current state of the native bindings and provides a single source of truth for API documentation generation.

https://claude.ai/code/session_01DfgVVKjLsHz7xfmMQBhxWr