### PR TITLE
docs(linux): document --force-renderer-accessibility for Electron apps

### DIFF
--- a/docs/site/src/content/docs/guides/platform-details.mdx
+++ b/docs/site/src/content/docs/guides/platform-details.mdx
@@ -127,3 +127,40 @@ The tri-state checked value (`Off` / `On` / `Mixed`) is derived differently:
 - **macOS:** Parses the `AXValue` attribute — `"0"` = Off, `"1"` = On, `"2"` = Mixed.
 - **Linux:** Uses AT-SPI state bits — `Checked` (0x10) and `Mixed` (0x2000).
 - **Windows:** Reads `TogglePattern.CurrentToggleState` — 0 = Off, 1 = On, 2 = Indeterminate.
+
+### Linux Electron and Chromium apps
+
+On Linux, Electron and Chromium-based apps ship with their AT-SPI2 bridge disabled by default for performance. xa11y will connect to the app but its tree will contain only the top-level window — `App.by_name("…").locator("button").count()` returns 0 even though buttons are visible on screen.
+
+To expose the full tree, launch the app with `--force-renderer-accessibility`:
+
+```bash
+# VS Code
+code --force-renderer-accessibility
+
+# Cursor
+cursor --force-renderer-accessibility
+
+# Google Chrome / Chromium
+google-chrome --force-renderer-accessibility
+```
+
+Representative node counts on Ubuntu 24.04 + GNOME 46 (Wayland):
+
+| App       | Without flag | With flag |
+| --------- | ------------:| ---------:|
+| VS Code   | 1            | 140       |
+| Cursor    | 1            | 116       |
+| Chrome    | 1            | 210       |
+
+Native GTK apps (Nautilus, gnome-terminal, GNOME Calculator, gnome-text-editor) don't need the flag — their AT-SPI2 bridge is enabled by default.
+
+Firefox exposes its tree when launched with `MOZ_ACCESSIBILITY_ATK2=1` set in the environment.
+
+To diagnose whether a target app has AT-SPI2 enabled at all:
+
+```bash
+busctl --user tree org.a11y.atspi.Registry | grep -i "<app-name>"
+```
+
+If the app's subtree is missing, the problem is the app's accessibility configuration, not xa11y.

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -32,7 +32,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 After changing permissions, restart your terminal for them to take effect. `App::by_name()` (Rust) or `xa11y.App.by_name()` (Python) will return a `PermissionDenied` error with setup instructions if either permission is missing.
 
-**Linux** — Ensure AT-SPI2 is running (default on GNOME and most desktop environments). No special permissions needed.
+**Linux** — Ensure AT-SPI2 is running (default on GNOME and most desktop environments). No special permissions needed. Electron and Chromium-based apps (VS Code, Cursor, Chrome) require an additional launch flag to expose their accessibility tree — see [Platform Details](/guides/platform-details/#linux-electron-and-chromium-apps).
 
 **Windows** — No special permissions needed.
 


### PR DESCRIPTION
## Summary
- Add a Platform Caveats subsection documenting that Electron/Chromium apps on Linux need `--force-renderer-accessibility` to expose their AT-SPI2 tree.
- Add a one-line pointer from the Linux setup note in the Quick Start to the new section.

## Why
Without the flag, `App.by_name("code")` succeeds but `locator("button").count()` returns 0 because the app only exposes a single top-level window node to AT-SPI2. This was confusing while running Linux canary tests against VS Code, Cursor, and Chrome — the fix is a one-line launch arg, but that fact lives only in Chromium's source tree today, not in xa11y docs.

Representative node counts (Ubuntu 24.04 + GNOME 46, Wayland):

| App | Without flag | With flag |
| --- | ---: | ---: |
| VS Code | 1 | 140 |
| Cursor | 1 | 116 |
| Chrome | 1 | 210 |

Also includes the Firefox `MOZ_ACCESSIBILITY_ATK2=1` env var (same class of issue) and a `busctl tree org.a11y.atspi.Registry` diagnostic for users to check whether a target app is even registering with AT-SPI2.

## Test plan
- [x] `npm run build` in `docs/site/` succeeds (7 pages built, no warnings).
- [x] Generated anchor `#linux-electron-and-chromium-apps` matches the link in quick-start.
- [x] Scope: only the two mdx files changed, 38 insertions, 1 line edited.