### PR TITLE
feat(app): optional polling timeout on App::by_name / by_pid

### DIFF
--- a/xa11y-core/src/app.rs
+++ b/xa11y-core/src/app.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use crate::element::{Element, ElementData};
 use crate::error::{Error, Result};
@@ -6,6 +7,33 @@ use crate::event_provider::Subscription;
 use crate::locator::Locator;
 use crate::provider::Provider;
 use crate::selector::Selector;
+
+/// Polling interval shared by all `*_with_timeout` lookups.
+const LOOKUP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Run `attempt` repeatedly until it succeeds or `timeout` elapses, treating
+/// `SelectorNotMatched` as a "not yet" signal. All other errors short-circuit.
+///
+/// `Duration::ZERO` performs exactly one attempt — identical to a non-polling
+/// call. On timeout, returns the last `SelectorNotMatched` error.
+fn poll_lookup<F>(timeout: Duration, mut attempt: F) -> Result<App>
+where
+    F: FnMut() -> Result<App>,
+{
+    let start = Instant::now();
+    loop {
+        match attempt() {
+            Ok(app) => return Ok(app),
+            Err(e @ Error::SelectorNotMatched { .. }) => {
+                if start.elapsed() >= timeout {
+                    return Err(e);
+                }
+            }
+            Err(e) => return Err(e),
+        }
+        std::thread::sleep(LOOKUP_POLL_INTERVAL);
+    }
+}
 
 /// A running application, the entry point for accessibility queries.
 ///
@@ -53,6 +81,23 @@ impl App {
         Ok(Self::from_data(provider, data))
     }
 
+    /// Like [`by_name_with`](Self::by_name_with), but polls until the app
+    /// appears or `timeout` elapses.
+    ///
+    /// Useful when the app may not yet be registered with the platform
+    /// accessibility API (e.g. just-launched test apps). Only
+    /// [`Error::SelectorNotMatched`] triggers a retry; other errors
+    /// (permission, parse, platform) short-circuit immediately.
+    ///
+    /// `Duration::ZERO` is equivalent to [`by_name_with`](Self::by_name_with).
+    pub fn by_name_with_timeout(
+        provider: Arc<dyn Provider>,
+        name: &str,
+        timeout: Duration,
+    ) -> Result<Self> {
+        poll_lookup(timeout, || Self::by_name_with(Arc::clone(&provider), name))
+    }
+
     /// Find an application by process ID, using an explicit provider.
     ///
     /// Prefer `App::by_pid` from the `xa11y` crate which uses the global
@@ -70,6 +115,17 @@ impl App {
         Err(Error::SelectorNotMatched {
             selector: format!("application with pid={}", pid),
         })
+    }
+
+    /// Like [`by_pid_with`](Self::by_pid_with), but polls until the app
+    /// appears or `timeout` elapses. See [`by_name_with_timeout`](Self::by_name_with_timeout)
+    /// for the retry semantics.
+    pub fn by_pid_with_timeout(
+        provider: Arc<dyn Provider>,
+        pid: u32,
+        timeout: Duration,
+    ) -> Result<Self> {
+        poll_lookup(timeout, || Self::by_pid_with(Arc::clone(&provider), pid))
     }
 
     /// List all running applications, using an explicit provider.

--- a/xa11y-js/__test__/integ/helpers.js
+++ b/xa11y-js/__test__/integ/helpers.js
@@ -23,40 +23,31 @@ const STARTUP_TIMEOUT_MS = 30_000;
 let cachedApp = null;
 
 /**
- * Return the xa11y App handle for the running test app. Polls up to
- * `STARTUP_TIMEOUT_MS` on first call so the test app has time to register
- * with AT-SPI2 / UIA / AX.
+ * Return the xa11y App handle for the running test app. Races all candidate
+ * names in parallel so the first one to register (up to `STARTUP_TIMEOUT_MS`)
+ * wins — handles cross-platform name differences without interleaved polling.
  */
 async function getApp() {
   if (cachedApp !== null) return cachedApp;
-  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
-  let lastErr = null;
-  while (Date.now() < deadline) {
-    for (const name of APP_NAMES) {
-      try {
-        cachedApp = await App.byName(name);
-        return cachedApp;
-      } catch (e) {
-        if (!(e instanceof SelectorNotMatchedError || e instanceof PlatformError)) {
-          throw e;
-        }
-        lastErr = e;
-      }
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  // One last attempt to list apps for a useful error message.
-  let listed = '<failed to list>';
-  try {
-    const apps = await App.list();
-    listed = JSON.stringify(apps.map((a) => ({ name: a.name, pid: a.pid })));
-  } catch {
-    /* ignore */
-  }
-  throw new Error(
-    `Test app not found after ${STARTUP_TIMEOUT_MS}ms (tried ${APP_NAMES.join(', ')}). ` +
-      `Last error: ${lastErr}. Running apps: ${listed}`,
+  const attempts = APP_NAMES.map((name) =>
+    App.byName(name, { timeout: STARTUP_TIMEOUT_MS }),
   );
+  try {
+    cachedApp = await Promise.any(attempts);
+    return cachedApp;
+  } catch (err) {
+    let listed = '<failed to list>';
+    try {
+      const apps = await App.list();
+      listed = JSON.stringify(apps.map((a) => ({ name: a.name, pid: a.pid })));
+    } catch {
+      /* ignore */
+    }
+    throw new Error(
+      `Test app not found after ${STARTUP_TIMEOUT_MS}ms (tried ${APP_NAMES.join(', ')}). ` +
+        `Errors: ${err.errors?.map((e) => e.message).join(' | ') ?? err}. Running apps: ${listed}`,
+    );
+  }
 }
 
 /**

--- a/xa11y-js/__test__/types/consumers.test-d.ts
+++ b/xa11y-js/__test__/types/consumers.test-d.ts
@@ -26,9 +26,9 @@ async function checks() {
   const apps: App[] = await App.list();
 
   // Optional lookup options.
-  const lookupOpts: AppLookupOptions = { timeoutMs: 30_000 };
+  const lookupOpts: AppLookupOptions = { timeout: 30_000 };
   const _app3: App = await App.byName('Test', lookupOpts);
-  const _app4: App = await App.byPid(1234, { timeoutMs: 5_000 });
+  const _app4: App = await App.byPid(1234, { timeout: 5_000 });
 
   // Locator instance methods return promises or locators.
   const loc: Locator = app.locator('button[name="OK"]');

--- a/xa11y-js/__test__/types/consumers.test-d.ts
+++ b/xa11y-js/__test__/types/consumers.test-d.ts
@@ -11,6 +11,7 @@ import {
   XA11yError,
   SelectorNotMatchedError,
   TimeoutError,
+  type AppLookupOptions,
   type CheckedState,
   type EventTypeName,
   type Rect,
@@ -23,6 +24,11 @@ async function checks() {
   const app: App = await App.byName('Test');
   const _app2: App = await App.byPid(1234);
   const apps: App[] = await App.list();
+
+  // Optional lookup options.
+  const lookupOpts: AppLookupOptions = { timeoutMs: 30_000 };
+  const _app3: App = await App.byName('Test', lookupOpts);
+  const _app4: App = await App.byPid(1234, { timeoutMs: 5_000 });
 
   // Locator instance methods return promises or locators.
   const loc: Locator = app.locator('button[name="OK"]');

--- a/xa11y-js/index.d.ts
+++ b/xa11y-js/index.d.ts
@@ -41,7 +41,7 @@ export interface AppLookupOptions {
    * just-launched). Only "not found" errors trigger a retry; permission
    * errors and the like fail fast. Defaults to no polling (single attempt).
    */
-  timeoutMs?: number;
+  timeout?: number;
 }
 
 export interface WaitForEventOptions {

--- a/xa11y-js/index.d.ts
+++ b/xa11y-js/index.d.ts
@@ -34,6 +34,16 @@ export interface SubscribeOptions {
   signal?: AbortSignal;
 }
 
+export interface AppLookupOptions {
+  /**
+   * Poll the accessibility API until the app appears, up to this many
+   * milliseconds. Useful when the app may not yet be registered (e.g.
+   * just-launched). Only "not found" errors trigger a retry; permission
+   * errors and the like fail fast. Defaults to no polling (single attempt).
+   */
+  timeoutMs?: number;
+}
+
 export interface WaitForEventOptions {
   /** Only resolve for events matching this predicate. */
   predicate?: (event: Event) => boolean;
@@ -92,9 +102,9 @@ export class Subscription extends EventEmitter {
 
 export declare class App {
   /** Find an application by exact name. */
-  static byName(name: string): Promise<App>;
+  static byName(name: string, options?: AppLookupOptions): Promise<App>;
   /** Find an application by process ID. */
-  static byPid(pid: number): Promise<App>;
+  static byPid(pid: number, options?: AppLookupOptions): Promise<App>;
   /** List all running applications with an accessibility tree. */
   static list(): Promise<App[]>;
 

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -267,9 +267,9 @@ class App extends native.App {
     return instance instanceof native.App;
   }
 
-  static async byName(name) {
+  static async byName(name, options) {
     try {
-      const a = await native.App.byName(name);
+      const a = await native.App.byName(name, options);
       Object.setPrototypeOf(a, App.prototype);
       return a;
     } catch (err) {
@@ -277,9 +277,9 @@ class App extends native.App {
     }
   }
 
-  static async byPid(pid) {
+  static async byPid(pid, options) {
     try {
-      const a = await native.App.byPid(pid);
+      const a = await native.App.byPid(pid, options);
       Object.setPrototypeOf(a, App.prototype);
       return a;
     } catch (err) {

--- a/xa11y-js/src/app.rs
+++ b/xa11y-js/src/app.rs
@@ -1,6 +1,7 @@
 //! JS `App` class: the entry point for accessibility queries.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use napi::bindgen_prelude::{AsyncTask, Env, Task};
 
@@ -28,18 +29,34 @@ impl App {
     }
 }
 
+/// Options for `App.byName` / `App.byPid`.
+#[napi(object)]
+pub struct AppLookupOptions {
+    /// If set, poll the accessibility API until the app appears or this
+    /// many milliseconds elapse. Useful when the app may not yet be
+    /// registered (e.g. just-launched). Only "not found" errors trigger a
+    /// retry; other errors fail fast.
+    pub timeout_ms: Option<u32>,
+}
+
 #[napi]
 impl App {
     /// Find an application by exact name.
     #[napi(ts_return_type = "Promise<App>")]
-    pub fn by_name(name: String) -> AsyncTask<FindByNameTask> {
-        AsyncTask::new(FindByNameTask { name })
+    pub fn by_name(name: String, options: Option<AppLookupOptions>) -> AsyncTask<FindByNameTask> {
+        AsyncTask::new(FindByNameTask {
+            name,
+            timeout: timeout_from(options),
+        })
     }
 
     /// Find an application by process ID.
     #[napi(ts_return_type = "Promise<App>")]
-    pub fn by_pid(pid: u32) -> AsyncTask<FindByPidTask> {
-        AsyncTask::new(FindByPidTask { pid })
+    pub fn by_pid(pid: u32, options: Option<AppLookupOptions>) -> AsyncTask<FindByPidTask> {
+        AsyncTask::new(FindByPidTask {
+            pid,
+            timeout: timeout_from(options),
+        })
     }
 
     /// List all running applications with an accessibility tree.
@@ -89,8 +106,16 @@ impl App {
 
 // ── Tasks ──────────────────────────────────────────────────────────────
 
+fn timeout_from(options: Option<AppLookupOptions>) -> Duration {
+    options
+        .and_then(|o| o.timeout_ms)
+        .map(|ms| Duration::from_millis(ms.into()))
+        .unwrap_or(Duration::ZERO)
+}
+
 pub struct FindByNameTask {
     name: String,
+    timeout: Duration,
 }
 
 impl Task for FindByNameTask {
@@ -99,7 +124,7 @@ impl Task for FindByNameTask {
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         let provider = crate::provider()?;
-        xa11y::App::by_name_with(provider, &self.name).map_err(map_err)
+        xa11y::App::by_name_with_timeout(provider, &self.name, self.timeout).map_err(map_err)
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
@@ -109,6 +134,7 @@ impl Task for FindByNameTask {
 
 pub struct FindByPidTask {
     pid: u32,
+    timeout: Duration,
 }
 
 impl Task for FindByPidTask {
@@ -117,7 +143,7 @@ impl Task for FindByPidTask {
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         let provider = crate::provider()?;
-        xa11y::App::by_pid_with(provider, self.pid).map_err(map_err)
+        xa11y::App::by_pid_with_timeout(provider, self.pid, self.timeout).map_err(map_err)
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {

--- a/xa11y-js/src/app.rs
+++ b/xa11y-js/src/app.rs
@@ -36,7 +36,7 @@ pub struct AppLookupOptions {
     /// many milliseconds elapse. Useful when the app may not yet be
     /// registered (e.g. just-launched). Only "not found" errors trigger a
     /// retry; other errors fail fast.
-    pub timeout_ms: Option<u32>,
+    pub timeout: Option<u32>,
 }
 
 #[napi]
@@ -108,7 +108,7 @@ impl App {
 
 fn timeout_from(options: Option<AppLookupOptions>) -> Duration {
     options
-        .and_then(|o| o.timeout_ms)
+        .and_then(|o| o.timeout)
         .map(|ms| Duration::from_millis(ms.into()))
         .unwrap_or(Duration::ZERO)
 }

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -122,11 +122,17 @@ class App:
     @property
     def pid(self) -> int | None: ...
     @staticmethod
-    def by_name(name: str) -> App:
-        """Find an application by exact name."""
+    def by_name(name: str, *, timeout: float | None = None) -> App:
+        """Find an application by exact name.
+
+        If ``timeout`` is set (seconds), poll the accessibility API until the
+        app appears or the timeout elapses. Useful when the app may not yet
+        be registered (e.g. just-launched). Only "not found" errors trigger a
+        retry; other errors fail fast.
+        """
     @staticmethod
-    def by_pid(pid: int) -> App:
-        """Find an application by process ID."""
+    def by_pid(pid: int, *, timeout: float | None = None) -> App:
+        """Find an application by process ID. See ``by_name`` for ``timeout``."""
     @staticmethod
     def list() -> list[App]:
         """List all running applications."""

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -713,6 +713,19 @@ impl Subscription {
 
 /// A running application — the entry point for accessibility queries.
 ///
+/// Convert an optional `timeout` in seconds (as exposed to Python) to a
+/// [`Duration`]. `None` and zero both mean "no polling, single attempt".
+/// Negative or non-finite values raise `ValueError`.
+fn timeout_from(timeout: Option<f64>) -> PyResult<Duration> {
+    match timeout {
+        None => Ok(Duration::ZERO),
+        Some(t) if t.is_finite() && t >= 0.0 => Ok(Duration::from_secs_f64(t)),
+        Some(t) => Err(PyValueError::new_err(format!(
+            "timeout must be a non-negative number of seconds, got {t}"
+        ))),
+    }
+}
+
 /// `App` is **not** an `Element`. It represents the application as a whole
 /// and provides a `locator()` to search its accessibility tree.
 #[pyclass(frozen)]
@@ -728,21 +741,32 @@ struct App {
 #[pymethods]
 impl App {
     /// Find an application by exact name.
+    ///
+    /// If `timeout` is set (in seconds), poll the accessibility API until the
+    /// app appears or the timeout elapses. Useful when the app may not yet
+    /// be registered (e.g. just-launched). Only "not found" errors trigger a
+    /// retry; other errors fail fast.
     #[staticmethod]
-    fn by_name(py: Python<'_>, name: &str) -> PyResult<Self> {
+    #[pyo3(signature = (name, *, timeout=None))]
+    fn by_name(py: Python<'_>, name: &str, timeout: Option<f64>) -> PyResult<Self> {
         let provider = get_provider()?;
+        let timeout = timeout_from(timeout)?;
         let app = py
-            .allow_threads(move || xa11y::App::by_name_with(provider, name))
+            .allow_threads(move || xa11y::App::by_name_with_timeout(provider, name, timeout))
             .map_err(to_py_err)?;
         Ok(Self::from_core(app))
     }
 
     /// Find an application by process ID.
+    ///
+    /// See [`by_name`] for `timeout` semantics.
     #[staticmethod]
-    fn by_pid(py: Python<'_>, pid: u32) -> PyResult<Self> {
+    #[pyo3(signature = (pid, *, timeout=None))]
+    fn by_pid(py: Python<'_>, pid: u32, timeout: Option<f64>) -> PyResult<Self> {
         let provider = get_provider()?;
+        let timeout = timeout_from(timeout)?;
         let app = py
-            .allow_threads(move || xa11y::App::by_pid_with(provider, pid))
+            .allow_threads(move || xa11y::App::by_pid_with_timeout(provider, pid, timeout))
             .map_err(to_py_err)?;
         Ok(Self::from_core(app))
     }

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -168,6 +168,8 @@ fn create_provider_boxed() -> Result<Box<dyn Provider>> {
 // ── AppExt extension trait ───────────────────────────────────────────────────
 
 mod app_ext {
+    use std::time::Duration;
+
     use super::{provider, App, Result};
 
     /// Extension trait that adds singleton-based constructors to [`App`].
@@ -184,8 +186,14 @@ mod app_ext {
     pub trait AppExt: Sized {
         /// Find an application by exact name using the global singleton provider.
         fn by_name(name: &str) -> Result<Self>;
+        /// Find an application by exact name, polling until it appears or
+        /// `timeout` elapses. See [`App::by_name_with_timeout`].
+        fn by_name_timeout(name: &str, timeout: Duration) -> Result<Self>;
         /// Find an application by process ID using the global singleton provider.
         fn by_pid(pid: u32) -> Result<Self>;
+        /// Find an application by process ID, polling until it appears or
+        /// `timeout` elapses. See [`App::by_pid_with_timeout`].
+        fn by_pid_timeout(pid: u32, timeout: Duration) -> Result<Self>;
         /// List all running applications using the global singleton provider.
         fn list() -> Result<Vec<Self>>;
     }
@@ -195,8 +203,16 @@ mod app_ext {
             App::by_name_with(provider()?, name)
         }
 
+        fn by_name_timeout(name: &str, timeout: Duration) -> Result<Self> {
+            App::by_name_with_timeout(provider()?, name, timeout)
+        }
+
         fn by_pid(pid: u32) -> Result<Self> {
             App::by_pid_with(provider()?, pid)
+        }
+
+        fn by_pid_timeout(pid: u32, timeout: Duration) -> Result<Self> {
+            App::by_pid_with_timeout(provider()?, pid, timeout)
         }
 
         fn list() -> Result<Vec<Self>> {

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -6,6 +6,9 @@ use xa11y::*;
 pub fn app_root() -> App {
     // On Linux/macOS, AT-SPI and AX report the process name ("xa11y-test-app").
     // On Windows, UIA reports the window title ("xa11y Test App").
+    // Two candidate names to interleave, so we keep the manual loop (a
+    // single `by_name_timeout` per name would block on the wrong name for
+    // its full timeout before trying the right one).
     let names = ["xa11y-test-app", "xa11y Test App"];
     for attempt in 0..3 {
         for name in &names {

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -1202,3 +1202,201 @@ fn handle_preserved_through_find() {
     let btn = app2.locator(r#"button[name="Btn2"]"#).element().unwrap();
     assert_eq!(btn.handle, 5); // Btn2 is node index 5
 }
+
+// ── Timeout polling tests ──
+
+/// Provider wrapper that delays root-level lookups (`get_children(None)`)
+/// until `succeed_after` calls have been made. Earlier calls return an empty
+/// Vec, simulating an app that hasn't registered with the accessibility API
+/// yet. Non-root tree navigation and all other Provider methods forward to
+/// `inner` unchanged.
+struct DelayedProvider {
+    inner: Arc<dyn Provider>,
+    root_calls: std::sync::atomic::AtomicUsize,
+    succeed_after: usize,
+    always_fail_permission: bool,
+}
+
+impl DelayedProvider {
+    fn new(inner: Arc<dyn Provider>, succeed_after: usize) -> Arc<Self> {
+        Arc::new(Self {
+            inner,
+            root_calls: std::sync::atomic::AtomicUsize::new(0),
+            succeed_after,
+            always_fail_permission: false,
+        })
+    }
+
+    /// On every root-level lookup, return `PermissionDenied` (a non-retryable
+    /// error). Used to verify that lookup polling short-circuits.
+    fn always_fail_permission(inner: Arc<dyn Provider>) -> Arc<Self> {
+        Arc::new(Self {
+            inner,
+            root_calls: std::sync::atomic::AtomicUsize::new(0),
+            succeed_after: 0,
+            always_fail_permission: true,
+        })
+    }
+
+    fn root_call_count(&self) -> usize {
+        self.root_calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl Provider for DelayedProvider {
+    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
+        if element.is_none() {
+            let n = self
+                .root_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if self.always_fail_permission {
+                return Err(Error::PermissionDenied {
+                    instructions: "test".to_string(),
+                });
+            }
+            if n < self.succeed_after {
+                return Ok(vec![]);
+            }
+        }
+        self.inner.get_children(element)
+    }
+    fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {
+        self.inner.get_parent(element)
+    }
+    fn press(&self, e: &ElementData) -> Result<()> {
+        self.inner.press(e)
+    }
+    fn focus(&self, e: &ElementData) -> Result<()> {
+        self.inner.focus(e)
+    }
+    fn blur(&self, e: &ElementData) -> Result<()> {
+        self.inner.blur(e)
+    }
+    fn toggle(&self, e: &ElementData) -> Result<()> {
+        self.inner.toggle(e)
+    }
+    fn select(&self, e: &ElementData) -> Result<()> {
+        self.inner.select(e)
+    }
+    fn expand(&self, e: &ElementData) -> Result<()> {
+        self.inner.expand(e)
+    }
+    fn collapse(&self, e: &ElementData) -> Result<()> {
+        self.inner.collapse(e)
+    }
+    fn show_menu(&self, e: &ElementData) -> Result<()> {
+        self.inner.show_menu(e)
+    }
+    fn increment(&self, e: &ElementData) -> Result<()> {
+        self.inner.increment(e)
+    }
+    fn decrement(&self, e: &ElementData) -> Result<()> {
+        self.inner.decrement(e)
+    }
+    fn scroll_into_view(&self, e: &ElementData) -> Result<()> {
+        self.inner.scroll_into_view(e)
+    }
+    fn set_value(&self, e: &ElementData, v: &str) -> Result<()> {
+        self.inner.set_value(e, v)
+    }
+    fn set_numeric_value(&self, e: &ElementData, v: f64) -> Result<()> {
+        self.inner.set_numeric_value(e, v)
+    }
+    fn type_text(&self, e: &ElementData, t: &str) -> Result<()> {
+        self.inner.type_text(e, t)
+    }
+    fn set_text_selection(&self, e: &ElementData, s: u32, en: u32) -> Result<()> {
+        self.inner.set_text_selection(e, s, en)
+    }
+    fn scroll_down(&self, e: &ElementData, a: f64) -> Result<()> {
+        self.inner.scroll_down(e, a)
+    }
+    fn scroll_up(&self, e: &ElementData, a: f64) -> Result<()> {
+        self.inner.scroll_up(e, a)
+    }
+    fn scroll_right(&self, e: &ElementData, a: f64) -> Result<()> {
+        self.inner.scroll_right(e, a)
+    }
+    fn scroll_left(&self, e: &ElementData, a: f64) -> Result<()> {
+        self.inner.scroll_left(e, a)
+    }
+    fn perform_action(&self, e: &ElementData, a: &str) -> Result<()> {
+        self.inner.perform_action(e, a)
+    }
+    fn subscribe(&self, e: &ElementData) -> Result<Subscription> {
+        self.inner.subscribe(e)
+    }
+}
+
+#[test]
+fn by_name_with_timeout_polls_until_app_appears() {
+    let inner = multi_app_provider();
+    // `by_name_with` issues two root lookups per attempt (application
+    // selector, then window selector). Failing the first 3 root calls means
+    // the first attempt fails entirely and the second attempt succeeds on
+    // its first selector.
+    let p = DelayedProvider::new(inner, 3);
+    let app = App::by_name_with_timeout(
+        Arc::clone(&p) as Arc<dyn Provider>,
+        "App1",
+        std::time::Duration::from_secs(2),
+    )
+    .expect("app should appear after a few polls");
+    assert_eq!(app.name, "App1");
+    assert!(
+        p.root_call_count() > 2,
+        "expected polling to retry, got {} root calls",
+        p.root_call_count()
+    );
+}
+
+#[test]
+fn by_name_with_timeout_zero_is_single_attempt() {
+    let inner = multi_app_provider();
+    let p = DelayedProvider::new(inner, 100); // never succeeds during the test
+    let result = App::by_name_with_timeout(
+        Arc::clone(&p) as Arc<dyn Provider>,
+        "App1",
+        std::time::Duration::ZERO,
+    );
+    assert!(matches!(result, Err(Error::SelectorNotMatched { .. })));
+    // One outer attempt = at most two selector lookups (application + window).
+    assert!(
+        p.root_call_count() <= 2,
+        "ZERO timeout must not retry, got {} calls",
+        p.root_call_count()
+    );
+}
+
+#[test]
+fn by_name_with_timeout_short_circuits_on_non_retryable_error() {
+    let inner = multi_app_provider();
+    let p = DelayedProvider::always_fail_permission(inner);
+    let start = std::time::Instant::now();
+    let result = App::by_name_with_timeout(
+        Arc::clone(&p) as Arc<dyn Provider>,
+        "App1",
+        std::time::Duration::from_secs(10),
+    );
+    assert!(matches!(result, Err(Error::PermissionDenied { .. })));
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(1),
+        "non-retryable error must fail fast, took {:?}",
+        start.elapsed()
+    );
+}
+
+#[test]
+fn by_pid_with_timeout_polls_until_app_appears() {
+    let inner = multi_app_provider();
+    let p = DelayedProvider::new(inner, 3);
+    // App1 has pid 100 in multi_app_provider.
+    let app = App::by_pid_with_timeout(
+        Arc::clone(&p) as Arc<dyn Provider>,
+        100,
+        std::time::Duration::from_secs(2),
+    )
+    .expect("app should appear after a few polls");
+    assert_eq!(app.pid, Some(100));
+    assert!(p.root_call_count() > 2);
+}


### PR DESCRIPTION
Add `by_name_with_timeout` / `by_pid_with_timeout` to xa11y-core that
poll the accessibility API every 100ms until the app appears or the
timeout elapses. Only `SelectorNotMatched` triggers a retry; permission
and other errors fail fast.

Surface in:
- xa11y::AppExt: `by_name_timeout` / `by_pid_timeout`
- xa11y-js: `App.byName(name, { timeoutMs })` / `App.byPid(pid, { timeoutMs })`
- xa11y-python: `App.by_name(name, *, timeout=...)` / `App.by_pid(pid, *, timeout=...)`

Existing test helpers (Rust / JS / Python) interleave multiple candidate
names or monitor a subprocess for early exit, so they don't simplify with
this API and are left unchanged.