### PR TITLE
fix(linux): resolve GtkMenuButton press via inner toggle (#100)

### DIFF
--- a/docs/site/src/content/docs/guides/platform-details.mdx
+++ b/docs/site/src/content/docs/guides/platform-details.mdx
@@ -128,6 +128,10 @@ The tri-state checked value (`Off` / `On` / `Mixed`) is derived differently:
 - **Linux:** Uses AT-SPI state bits — `Checked` (0x10) and `Mixed` (0x2000).
 - **Windows:** Reads `TogglePattern.CurrentToggleState` — 0 = Off, 1 = On, 2 = Indeterminate.
 
+### GTK press fallback (Linux)
+
+GTK 4 menu-button widgets (`GtkMenuButton`, `AdwMenuButton`, `AdwSplitButton`) present as an outer `push button` accessible that advertises `NActions = 0` wrapping an inner `toggle button` that carries the real `click` action. Calling `press()` on the outer would normally raise `ActionNotSupported`. When the owning application identifies itself as GTK via `Application.ToolkitName == "GTK"`, xa11y-linux instead walks a bounded slice of the outer's subtree (BFS, depth 3, actionable roles only, name must match) and invokes the single actionable descendant it finds. The fallback is strictly scoped: it only runs inside GTK apps, only when the widget's own Action interface is empty, and only when exactly one candidate matches — ambiguous subtrees still surface the original error.
+
 ### Linux Electron and Chromium apps
 
 On Linux, Electron and Chromium-based apps ship with their AT-SPI2 bridge disabled by default for performance. xa11y will connect to the app but its tree will contain only the top-level window — `App.by_name("…").locator("button").count()` returns 0 even though buttons are visible on screen.

--- a/test-apps/gtk/app.py
+++ b/test-apps/gtk/app.py
@@ -135,6 +135,25 @@ class TestWindow(Gtk.ApplicationWindow):
         self.dark_mode_switch.set_tooltip_text("Dark mode")
         switch_group.append(self.dark_mode_switch)
 
+        # ── Menu button (wrapper pattern) ────────────────────────────
+        # Gtk.MenuButton is the stock GNOME "outer push-button wraps inner
+        # toggle-button" pattern.  In AT-SPI2 the outer push-button reports
+        # NActions=0 while the inner toggle-button exposes `click`, so
+        # calling press() on the outer must fall through to the inner under
+        # the GTK-scoped press-fallback in xa11y-linux.
+        menu_group = self._make_group("MenuButton")
+        box.append(menu_group)
+        popover_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        # This label becomes reachable in the AT-SPI tree once the popover
+        # is shown — the integration test uses it to prove the inner
+        # toggle-button was actually activated.
+        popover_box.append(Gtk.Label(label="menu-popover-open"))
+        popover = Gtk.Popover()
+        popover.set_child(popover_box)
+        self.menu_button = Gtk.MenuButton(label="More")
+        self.menu_button.set_popover(popover)
+        menu_group.append(self.menu_button)
+
         # ── List ─────────────────────────────────────────────────────
         list_group = self._make_group("List")
         box.append(list_group)

--- a/tests/gtk/test_widgets.py
+++ b/tests/gtk/test_widgets.py
@@ -255,3 +255,35 @@ def test_button_focus_action_consistency(gtk_app: xa11y.Element) -> None:
         # Verify focus was actually set
         ok_after = find(gtk_app, 'button[name="OK"]')
         assert ok_after.focused, "focus() should set focused state"
+
+
+# ── Menu button (GtkMenuButton press-fallback) ────────────────────────────────
+# GtkMenuButton / AdwMenuButton expose an outer push-button whose AT-SPI2
+# Action interface is empty, wrapping an inner toggle-button that carries the
+# real `click` action. Pressing the outer button via xa11y must transparently
+# resolve to the inner toggle-button; the GTK-scoped fallback in xa11y-linux
+# performs that resolution.
+
+
+def test_menu_button_found(gtk_app: xa11y.Element) -> None:
+    mb = find(gtk_app, 'button[name="More"]')
+    assert mb.role == "button"
+    assert mb.name == "More"
+
+
+def test_menu_button_press_opens_popover(gtk_app: xa11y.Element) -> None:
+    # Before: the popover's inner label is not yet reachable.
+    assert (
+        gtk_app.locator('static_text[name="menu-popover-open"]').elements() == []
+    ), "popover label should not be visible until the MenuButton is pressed"
+
+    # Press the outer push-button. Without the GTK press-fallback this raises
+    # ActionNotSupported because the outer advertises NActions=0; with it,
+    # xa11y-linux resolves to the inner toggle-button and invokes its click.
+    gtk_app.locator('button[name="More"]').press()
+    time.sleep(0.4)
+
+    # After: the popover is showing and its inner label is reachable.
+    label = find(gtk_app, 'static_text[name="menu-popover-open"]')
+    assert label.role == "static_text"
+    assert label.name == "menu-popover-open"

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1,6 +1,6 @@
 //! Real AT-SPI2 backend implementation using zbus D-Bus bindings.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
@@ -360,6 +360,149 @@ impl LinuxProvider {
         // Fixes GitHub issue #98.
 
         (actions, indices)
+    }
+
+    /// Return true when the accessible's application identifies itself as GTK
+    /// via `org.a11y.atspi.Application.ToolkitName`.
+    ///
+    /// Used to scope the press-fallback heuristic for the
+    /// AdwMenuButton/GtkMenuButton wrapper pattern; other toolkits are
+    /// unaffected.
+    fn is_gtk_toolkit(&self, aref: &AccessibleRef) -> bool {
+        let app_root = AccessibleRef {
+            bus_name: aref.bus_name.clone(),
+            path: "/org/a11y/atspi/accessible/root".to_string(),
+        };
+        self.make_proxy(
+            &app_root.bus_name,
+            &app_root.path,
+            "org.a11y.atspi.Application",
+        )
+        .ok()
+        .and_then(|proxy| proxy.get_property::<String>("ToolkitName").ok())
+        .map(|t| t.eq_ignore_ascii_case("GTK"))
+        .unwrap_or(false)
+    }
+
+    /// GTK press-fallback resolver.
+    ///
+    /// Walks the accessible's descendants (BFS, depth-capped) looking for a
+    /// single activatable child that shares the outer widget's name. Returns
+    /// the (ref, action_index) pair when exactly one suitable candidate
+    /// exists at the shallowest matching depth. Returns `None` when the
+    /// subtree contains nothing suitable or multiple equally plausible
+    /// candidates — refusing to guess.
+    ///
+    /// Empirically fixes the `GtkMenuButton` / `AdwMenuButton` wrappers that
+    /// ship in every stock GNOME app (Calculator, Text Editor, Logs, Clocks,
+    /// Characters, …).
+    fn find_gtk_press_fallback(
+        &self,
+        outer: &AccessibleRef,
+        outer_name: &str,
+    ) -> Option<(AccessibleRef, i32)> {
+        let mut queue: VecDeque<(AccessibleRef, u32)> = VecDeque::new();
+        queue.push_back((outer.clone(), 0));
+        let mut visited: usize = 0;
+        let mut shallowest_depth: Option<u32> = None;
+        let mut hits: Vec<(AccessibleRef, i32)> = Vec::new();
+
+        while let Some((node, depth)) = queue.pop_front() {
+            // Once we've found the shallowest level with hits, don't look deeper.
+            if let Some(best) = shallowest_depth {
+                if depth > best {
+                    continue;
+                }
+            }
+            if visited > GTK_FALLBACK_MAX_NODES {
+                break;
+            }
+
+            let role_name = if depth == 0 {
+                String::new()
+            } else {
+                visited += 1;
+                self.get_role_name(&node).unwrap_or_default().to_lowercase()
+            };
+
+            if depth > 0 && is_actionable_atspi_role(&role_name) {
+                if let Some(idx) = self.gtk_fallback_pick(&node, outer_name) {
+                    match shallowest_depth {
+                        Some(d) if depth < d => {
+                            shallowest_depth = Some(depth);
+                            hits.clear();
+                            hits.push((node.clone(), idx));
+                        }
+                        Some(d) if depth == d => hits.push((node.clone(), idx)),
+                        Some(_) => {}
+                        None => {
+                            shallowest_depth = Some(depth);
+                            hits.push((node.clone(), idx));
+                        }
+                    }
+                }
+            }
+
+            // Do not descend into static/decorative roles. Descend through
+            // containers and actionable roles alike (actionable roles may
+            // themselves wrap an inner actionable — e.g. an AdwSplitButton's
+            // primary button inside a toggle-button shell).
+            let stop_descending = depth >= GTK_FALLBACK_MAX_DEPTH
+                || (depth > 0 && is_never_descend_atspi_role(&role_name));
+            if stop_descending {
+                continue;
+            }
+            if let Ok(children) = self.get_atspi_children(&node) {
+                for c in children {
+                    queue.push_back((c, depth + 1));
+                }
+            }
+        }
+
+        if hits.len() == 1 {
+            Some(hits.into_iter().next().unwrap())
+        } else {
+            None
+        }
+    }
+
+    /// Per-node filter for `find_gtk_press_fallback`. Returns the AT-SPI
+    /// action index to invoke when `aref` is a valid fallback candidate.
+    fn gtk_fallback_pick(&self, aref: &AccessibleRef, outer_name: &str) -> Option<i32> {
+        let (_, index_map) = self.get_actions(aref);
+        let idx = *index_map.get("press")?;
+        if !self.is_showing_visible_sensitive(aref) {
+            return None;
+        }
+        // If the outer has a name, require the candidate to share it. Rules
+        // out unrelated suffix widgets (e.g. a switch inside an AdwActionRow
+        // that happens to expose `click`).
+        if !outer_name.is_empty() {
+            let inner_name = self.get_name(aref).unwrap_or_default();
+            if !inner_name.is_empty() && inner_name != outer_name {
+                return None;
+            }
+        }
+        Some(idx)
+    }
+
+    /// True when the accessible's state has SHOWING, VISIBLE, and SENSITIVE
+    /// set. ENABLED is deliberately excluded: in GTK4 it reflects "has an
+    /// enabled GAction bound", which is false for the exact widgets we
+    /// rescue.
+    fn is_showing_visible_sensitive(&self, aref: &AccessibleRef) -> bool {
+        let raw = self.get_state(aref).unwrap_or_default();
+        let bits: u64 = if raw.len() >= 2 {
+            (raw[0] as u64) | ((raw[1] as u64) << 32)
+        } else if raw.len() == 1 {
+            raw[0] as u64
+        } else {
+            0
+        };
+        const SENSITIVE: u64 = 1 << 24;
+        const SHOWING: u64 = 1 << 25;
+        const VISIBLE: u64 = 1 << 30;
+        (bits & (SHOWING | VISIBLE | SENSITIVE)) == (SHOWING | VISIBLE | SENSITIVE)
     }
 
     /// Get value via Value or Text interface.
@@ -1280,13 +1423,26 @@ impl Provider for LinuxProvider {
 
     fn press(&self, element: &ElementData) -> Result<()> {
         let target = self.get_cached(element.handle)?;
-        let index = self
-            .get_action_index(element.handle, "press")
-            .map_err(|_| Error::ActionNotSupported {
-                action: "press".to_string(),
-                role: element.role,
-            })?;
-        self.do_atspi_action_by_index(&target, index)
+        // Fast path: the widget exposes `press` on its own Action interface.
+        if let Ok(index) = self.get_action_index(element.handle, "press") {
+            return self.do_atspi_action_by_index(&target, index);
+        }
+        // GTK-only fallback for the AdwMenuButton / GtkMenuButton pattern:
+        // the outer push-button accessible advertises NActions=0, but its
+        // immediate subtree contains an inner toggle-button (or similar
+        // actionable widget) with the real `click` action. We only apply this
+        // inside GTK — AccessKit, Qt, macOS, Windows all continue to surface
+        // ActionNotSupported as before.
+        if self.is_gtk_toolkit(&target) {
+            let outer_name = self.get_name(&target).unwrap_or_default();
+            if let Some((inner, index)) = self.find_gtk_press_fallback(&target, &outer_name) {
+                return self.do_atspi_action_by_index(&inner, index);
+            }
+        }
+        Err(Error::ActionNotSupported {
+            action: "press".to_string(),
+            role: element.role,
+        })
     }
 
     fn focus(&self, element: &ElementData) -> Result<()> {
@@ -1827,6 +1983,48 @@ pub(crate) fn map_atspi_role_number(role: u32) -> Role {
     }
 }
 
+/// Depth cap for the GTK press-fallback BFS. Wrapper patterns nest at most
+/// two levels (e.g. `AdwSplitButton` → inner toggle-button → inner label);
+/// depth 3 covers them with headroom without letting the walk wander.
+const GTK_FALLBACK_MAX_DEPTH: u32 = 3;
+
+/// Hard cap on visited accessibles per fallback resolution. Defensive — the
+/// depth cap already bounds typical cases to ≤ 20 nodes.
+const GTK_FALLBACK_MAX_NODES: usize = 200;
+
+/// Whether an AT-SPI2 role name represents an activatable widget we are
+/// willing to invoke via the fallback path. Deliberately narrow: roles that
+/// could carry destructive or misleading semantics (e.g. `label` with the
+/// synthesised clipboard/selection actions) are excluded.
+fn is_actionable_atspi_role(role: &str) -> bool {
+    matches!(
+        role,
+        "push button"
+            | "toggle button"
+            | "check box"
+            | "radio button"
+            | "menu item"
+            | "check menu item"
+            | "radio menu item"
+            | "link"
+            | "page tab"
+            | "tab"
+            | "list item"
+            | "tree item"
+    )
+}
+
+/// Roles the BFS refuses to descend into. Static and decorative roles never
+/// lead anywhere useful, and `label` in particular carries a fan-out of
+/// text-editing actions (`clipboard.copy`, `selection.delete`, …) that we
+/// must never reach via a press heuristic.
+fn is_never_descend_atspi_role(role: &str) -> bool {
+    matches!(
+        role,
+        "label" | "separator" | "image" | "icon" | "static" | "caption"
+    )
+}
+
 /// Map an AT-SPI2 action name to its canonical `snake_case` xa11y action name.
 ///
 /// Toolkit-specific aliases are normalised to the single canonical name:
@@ -1976,5 +2174,75 @@ mod tests {
             map_atspi_action_name("Increment"),
             Some("increment".to_string())
         );
+    }
+
+    /// The GTK press-fallback's actionable-role set must include the inner
+    /// toggle-button pattern used by `GtkMenuButton` / `AdwMenuButton`, plus
+    /// the other standard activatable roles we're willing to synthesise a
+    /// click for.
+    #[test]
+    fn test_gtk_fallback_actionable_roles() {
+        for role in [
+            "push button",
+            "toggle button",
+            "check box",
+            "radio button",
+            "menu item",
+            "link",
+            "tab",
+            "list item",
+            "tree item",
+        ] {
+            assert!(
+                is_actionable_atspi_role(role),
+                "{role:?} should be actionable"
+            );
+        }
+    }
+
+    /// Never treat static / decorative accessibles as fallback candidates.
+    /// Particularly important for `label`, whose synthesised text-editing
+    /// actions (`clipboard.copy`, `selection.delete`) must never be invoked
+    /// by a press heuristic.
+    #[test]
+    fn test_gtk_fallback_non_actionable_roles() {
+        for role in [
+            "label",
+            "panel",
+            "filler",
+            "section",
+            "group",
+            "image",
+            "separator",
+            "static",
+            "frame",
+            "window",
+        ] {
+            assert!(
+                !is_actionable_atspi_role(role),
+                "{role:?} must not be treated as actionable"
+            );
+        }
+    }
+
+    /// The BFS stops at static/decorative roles. `label` in particular must
+    /// never be descended into — its children are text spans with bogus
+    /// actions.
+    #[test]
+    fn test_gtk_fallback_never_descend_roles() {
+        for role in ["label", "separator", "image", "icon", "static", "caption"] {
+            assert!(
+                is_never_descend_atspi_role(role),
+                "{role:?} must block BFS descent"
+            );
+        }
+        // Containers — panel / filler / section / group / frame — stay
+        // walkable so the BFS can reach a wrapped inner actionable.
+        for role in ["panel", "filler", "section", "group", "frame"] {
+            assert!(
+                !is_never_descend_atspi_role(role),
+                "container role {role:?} must remain descendable"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- GTK-scoped fallback in `xa11y-linux` for the `GtkMenuButton` / `AdwMenuButton` / `AdwSplitButton` wrapper pattern: when the outer `push button` advertises `NActions=0`, `press()` now walks a bounded slice of its subtree and invokes the single actionable descendant when exactly one matches.
- Strict scope: fires only when `org.a11y.atspi.Application.ToolkitName == "GTK"` and only when the widget's own Action interface has no `press`. Other toolkits (AccessKit, Qt, macOS, Windows) surface `ActionNotSupported` exactly as before.
- BFS is depth-capped (3) with explicit role filters — `label`/`image`/`separator`/`static`/`caption` are never descended into, so the synthetic `clipboard.copy` etc. actions on labels cannot be reached. Ambiguous subtrees (>1 candidate at the shallowest depth) surface the original error rather than guessing.

## Why

Every stock GNOME app ships `GtkMenuButton` / `AdwMenuButton` — Calculator, Text Editor, Characters, Baobab, Logs, Clocks — and in every one the outer `push button` accessible exposes no `press`. Users writing automation against `button[name="Main Menu"]` currently cannot click those buttons at all.

## Test plan

- [x] `cargo xtask fmt --check` (Rust + ruff)
- [x] `cargo xtask lint` (clippy + ruff + Python Rust)
- [x] `cargo xtask test` — all 23 xa11y-linux unit tests pass, including three new pure-logic tests for the actionable / never-descend role sets
- [x] `scripts/run_gtk_tests.sh` — 24 passed, 1 skipped (pre-existing). Two new tests: `test_menu_button_found` and `test_menu_button_press_opens_popover` (asserts the popover's inner label becomes reachable — proves the inner toggle actually fired).

## Docs

Added a paragraph under **Platform caveats → GTK press fallback** in `guides/platform-details.mdx` describing the rule and its scope.

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)