### PR TITLE
Provider verbs: strict set_numeric_value, role-gated macOS toggle, tenet-3 clarification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ Integration tests use shared helpers from `xa11y/tests/integ/mod.rs`:
 
 3. **Action fidelity.** If an element reports an action name in its `actions` list, calling that action must invoke the original platform action — not a substitute or alias.
 
+   `press`, `toggle`, `focus`, `select`, `expand`, `collapse` are *semantic verbs* — cross-platform concepts. Tenet 3 applies to the semantic verb, not a specific platform API name. For example: `press` on Windows legitimately dispatches to Invoke, Toggle, SelectionItem.Select, or ExpandCollapse based on the element's primary-activation pattern — this is the Windows canonical implementation of "activate this element," matching AXPress on macOS and AT-SPI `DoAction("click")` on Linux. A violation would be advertising `press` in actions but calling a platform API that doesn't implement the semantic (e.g. input simulation, or an unrelated pattern).
+
 4. **Fail surfaceably, not fatally.** Prefer `Result` over `.unwrap()` / `.expect()` in provider and binding code.
    - **Locks**: `.lock().unwrap()` on caches or memoized state should be `.lock().unwrap_or_else(|e| e.into_inner())` — poisoning in a cache is recoverable. Only panic on locks that guard a genuine invariant.
    - **Platform FFI returns**: never `.unwrap()` a CF / AX / UIA / AT-SPI2 return. Propagate as `Error::Platform`.

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1509,6 +1509,17 @@ fn build_snapshot_data(element: AXUIElementRef, pid: Option<u32>, handle: u64) -
         {
             actions.push(set_value_str);
         }
+        // `toggle` is a cross-platform semantic verb; macOS implements it via
+        // AXPress for toggleable roles. Advertise it alongside `press` when
+        // the element both reports AXPress natively and is one of the known
+        // toggleable roles.
+        let toggle_str = "toggle".to_string();
+        if matches!(role, Role::CheckBox | Role::Switch | Role::RadioButton)
+            && ax_actions.iter().any(|a| a == "AXPress")
+            && !actions.contains(&toggle_str)
+        {
+            actions.push(toggle_str);
+        }
 
         let numeric_value = match role {
             Role::Slider | Role::ProgressBar | Role::SpinButton => attrs.value_number,
@@ -1951,6 +1962,15 @@ impl Provider for MacOSProvider {
     }
 
     fn toggle(&self, element: &ElementData) -> Result<()> {
+        if !matches!(
+            element.role,
+            Role::CheckBox | Role::Switch | Role::RadioButton
+        ) {
+            return Err(Error::ActionNotSupported {
+                action: "toggle".to_string(),
+                role: element.role,
+            });
+        }
         let ax = self.get_cached(element.handle)?;
         perform_ax_action(ax.as_ptr(), "AXPress", "toggle", element.role)
     }

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -696,6 +696,16 @@ impl Provider for WindowsProvider {
 
     #[allow(non_upper_case_globals)]
     fn press(&self, element: &ElementData) -> Result<()> {
+        // `press` dispatches to the element's primary-activation UIA pattern:
+        // Invoke (buttons, menu items, links), Toggle (checkboxes, switches),
+        // SelectionItem.Select (list items, radio buttons), or ExpandCollapse
+        // (combo boxes, tree items). These patterns are mutually exclusive in
+        // practice — a given UIA element supports at most one. This mirrors
+        // AXPress on macOS and AT-SPI `DoAction("click")` on Linux, which
+        // likewise collapse all activation under a single verb. Tenet 3
+        // applies to the *semantic* verb (`press` = "activate this element"),
+        // not the underlying API — each branch below is Windows' canonical
+        // implementation of that semantic for the element's pattern.
         let uia_element = self.get_cached(element.handle)?;
         // Try InvokePattern (buttons, menu items)
         if let Ok(pattern) = unsafe {
@@ -946,31 +956,19 @@ impl Provider for WindowsProvider {
 
     fn set_numeric_value(&self, element: &ElementData, value: f64) -> Result<()> {
         let uia_element = self.get_cached(element.handle)?;
-        if let Ok(pattern) = unsafe {
+        let pattern = unsafe {
             uia_element
                 .GetCurrentPatternAs::<IUIAutomationRangeValuePattern>(UIA_RangeValuePatternId)
-        } {
-            unsafe { pattern.SetValue(value) }.map_err(|e| Error::Platform {
-                code: e.code().0 as i64,
-                message: "RangeValue.SetValue failed".to_string(),
-            })?;
-            return Ok(());
         }
-        // Fall back to ValuePattern with string
-        if let Ok(pattern) = unsafe {
-            uia_element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId)
-        } {
-            let s: windows::core::BSTR = value.to_string().into();
-            unsafe { pattern.SetValue(&s) }.map_err(|e| Error::Platform {
-                code: e.code().0 as i64,
-                message: "Value.SetValue failed".to_string(),
-            })?;
-            return Ok(());
-        }
-        Err(Error::Platform {
-            code: -1,
-            message: "No Value or RangeValue pattern".to_string(),
-        })
+        .map_err(|_| Error::ActionNotSupported {
+            action: "set_numeric_value".to_string(),
+            role: element.role,
+        })?;
+        unsafe { pattern.SetValue(value) }.map_err(|e| Error::Platform {
+            code: e.code().0 as i64,
+            message: format!("RangeValue.SetValue failed: {}", e),
+        })?;
+        Ok(())
     }
 
     fn type_text(&self, element: &ElementData, text: &str) -> Result<()> {


### PR DESCRIPTION
## Summary

Follow-up to #127. Resolves three provider tenet items identified in the original review; reframes one of them after a cross-platform-consistency check.

- **Windows `press` — logic unchanged.** Added a doc comment explaining that `press`'s dispatch across Invoke / Toggle / SelectionItem.Select / ExpandCollapse is the UIA-canonical implementation of "activate this element" — parallel to AXPress on macOS and AT-SPI `DoAction("click")` on Linux. This isn't a fallback chain hiding bugs; it's dispatch to the element's primary-activation pattern, which is mutually exclusive in practice. Reverses my earlier proposal to restrict `press` to Invoke — doing so would have made `press(checkbox)` / `press(radio)` / `press(combo)` fail on Windows only, breaking cross-platform automation.

- **Windows `set_numeric_value` — strict (was B3).** Removed the ValuePattern-with-stringified-number fallback. `RangeValuePattern` only; returns `ActionNotSupported` otherwise. Callers who want to write a numeric string to a Value-only field use `set_value("42")` explicitly.

- **macOS `toggle` — role-gated + advertised (was B4).** AX has no `AXToggle` — AXPress is the platform's native toggle. Previously the trait method pressed whatever role you gave it. Now gated to `CheckBox` / `Switch` / `RadioButton`; other roles return `ActionNotSupported`. The actions list now advertises `"toggle"` on those roles when the element's native AX actions include AXPress, so the action list and method behavior agree.

- **AGENTS.md tenet 3 clarification.** Appends one paragraph: verbs like `press`, `toggle`, `focus`, `select`, `expand`, `collapse` are cross-platform semantic concepts, not platform API names. Tenet 3 applies to the semantic, not a specific platform call. A violation is advertising a semantic verb but calling an API that doesn't implement that semantic.

## Test plan
- [x] `cargo xtask check` passes locally
- [ ] Linux CI (unit + integ + Qt + GTK + Tauri)
- [ ] macOS CI (unit + Cocoa)
- [ ] Windows CI (unit + integ + Qt)
- [ ] Python + JS bindings across platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)