### PR TITLE
refactor(umbrella): store singleton provider as Arc<dyn Provider>

### DIFF
--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -47,15 +47,19 @@ pub use app_ext::AppExt;
 // Store the provider as an Arc<dyn Provider> so callers can cheaply clone a
 // shared handle without an extra delegation wrapper or a leaked box. Err is
 // carried as a string so we can clone the OnceLock's payload on every access.
+//
+// Provider construction goes through `Arc::new(Concrete)` (not
+// `Arc::from(Box)`), because `Arc::from(Box<dyn Trait>)` allocates a new
+// ArcInner and memcpies the provider data into it — moving the provider to
+// a fresh address. Some provider internals (e.g. the AT-SPI2 zbus
+// connection on Linux) don't tolerate being moved after construction, so we
+// allocate directly into the Arc via `Arc::new` and only then coerce to the
+// `dyn` trait object.
 static PROVIDER: OnceLock<std::result::Result<Arc<dyn Provider>, String>> = OnceLock::new();
 
 #[doc(hidden)]
 pub fn provider() -> Result<Arc<dyn Provider>> {
-    match PROVIDER.get_or_init(|| {
-        create_provider_boxed()
-            .map(Arc::from)
-            .map_err(|e| format!("{e}"))
-    }) {
+    match PROVIDER.get_or_init(|| create_provider_arc().map_err(|e| format!("{e}"))) {
         Ok(arc) => Ok(Arc::clone(arc)),
         Err(msg) => Err(Error::Platform {
             code: -1,
@@ -69,21 +73,21 @@ pub fn provider() -> Result<Arc<dyn Provider>> {
 #[doc(hidden)]
 #[cfg(feature = "testing")]
 pub fn create_provider() -> Result<Arc<dyn Provider>> {
-    create_provider_boxed().map(Arc::from)
+    create_provider_arc()
 }
 
-fn create_provider_boxed() -> Result<Box<dyn Provider>> {
+fn create_provider_arc() -> Result<Arc<dyn Provider>> {
     #[cfg(target_os = "macos")]
     {
-        Ok(Box::new(xa11y_macos::MacOSProvider::new()?))
+        Ok(Arc::new(xa11y_macos::MacOSProvider::new()?))
     }
     #[cfg(target_os = "windows")]
     {
-        Ok(Box::new(xa11y_windows::WindowsProvider::new()?))
+        Ok(Arc::new(xa11y_windows::WindowsProvider::new()?))
     }
     #[cfg(target_os = "linux")]
     {
-        Ok(Box::new(xa11y_linux::LinuxProvider::new()?))
+        Ok(Arc::new(xa11y_linux::LinuxProvider::new()?))
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -44,89 +44,24 @@ pub use app_ext::AppExt;
 
 // ── Internal singleton ──────────────────────────────────────────────────────
 
-static PROVIDER: OnceLock<std::result::Result<&'static dyn Provider, String>> = OnceLock::new();
-
-fn get_provider_ref() -> Result<&'static dyn Provider> {
-    PROVIDER
-        .get_or_init(|| {
-            create_provider_boxed()
-                .map(|b| &*Box::leak(b))
-                .map_err(|e| format!("{e}"))
-        })
-        .as_ref()
-        .copied()
-        .map_err(|msg| Error::Platform {
-            code: -1,
-            message: msg.clone(),
-        })
-}
-
-/// Wrapper that lets a `&'static dyn Provider` be shared as `Arc<dyn Provider>`.
-struct StaticProviderRef(&'static dyn Provider);
-
-impl Provider for StaticProviderRef {
-    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
-        self.0.get_children(element)
-    }
-    fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {
-        self.0.get_parent(element)
-    }
-    fn press(&self, element: &ElementData) -> Result<()> {
-        self.0.press(element)
-    }
-    fn focus(&self, element: &ElementData) -> Result<()> {
-        self.0.focus(element)
-    }
-    fn blur(&self, element: &ElementData) -> Result<()> {
-        self.0.blur(element)
-    }
-    fn toggle(&self, element: &ElementData) -> Result<()> {
-        self.0.toggle(element)
-    }
-    fn select(&self, element: &ElementData) -> Result<()> {
-        self.0.select(element)
-    }
-    fn expand(&self, element: &ElementData) -> Result<()> {
-        self.0.expand(element)
-    }
-    fn collapse(&self, element: &ElementData) -> Result<()> {
-        self.0.collapse(element)
-    }
-    fn show_menu(&self, element: &ElementData) -> Result<()> {
-        self.0.show_menu(element)
-    }
-    fn increment(&self, element: &ElementData) -> Result<()> {
-        self.0.increment(element)
-    }
-    fn decrement(&self, element: &ElementData) -> Result<()> {
-        self.0.decrement(element)
-    }
-    fn scroll_into_view(&self, element: &ElementData) -> Result<()> {
-        self.0.scroll_into_view(element)
-    }
-    fn set_value(&self, element: &ElementData, value: &str) -> Result<()> {
-        self.0.set_value(element, value)
-    }
-    fn set_numeric_value(&self, element: &ElementData, value: f64) -> Result<()> {
-        self.0.set_numeric_value(element, value)
-    }
-    fn type_text(&self, element: &ElementData, text: &str) -> Result<()> {
-        self.0.type_text(element, text)
-    }
-    fn set_text_selection(&self, element: &ElementData, start: u32, end: u32) -> Result<()> {
-        self.0.set_text_selection(element, start, end)
-    }
-    fn perform_action(&self, element: &ElementData, action: &str) -> Result<()> {
-        self.0.perform_action(element, action)
-    }
-    fn subscribe(&self, element: &ElementData) -> Result<Subscription> {
-        self.0.subscribe(element)
-    }
-}
+// Store the provider as an Arc<dyn Provider> so callers can cheaply clone a
+// shared handle without an extra delegation wrapper or a leaked box. Err is
+// carried as a string so we can clone the OnceLock's payload on every access.
+static PROVIDER: OnceLock<std::result::Result<Arc<dyn Provider>, String>> = OnceLock::new();
 
 #[doc(hidden)]
 pub fn provider() -> Result<Arc<dyn Provider>> {
-    Ok(Arc::new(StaticProviderRef(get_provider_ref()?)))
+    match PROVIDER.get_or_init(|| {
+        create_provider_boxed()
+            .map(Arc::from)
+            .map_err(|e| format!("{e}"))
+    }) {
+        Ok(arc) => Ok(Arc::clone(arc)),
+        Err(msg) => Err(Error::Platform {
+            code: -1,
+            message: msg.clone(),
+        }),
+    }
 }
 
 // ── Platform provider construction (internal) ───────────────────────────────


### PR DESCRIPTION
## Summary

Replace the `StaticProviderRef` delegation wrapper (~70 lines of hand-written method forwarding) by storing the provider in the singleton as `Arc<dyn Provider>` directly. `provider()` now just clones the Arc, which is a cheap atomic increment.

## Context

Previous attempt in #129 used a blanket `impl<T: Provider + ?Sized> Provider for &T` in `xa11y-core` and wrapped a `&'static dyn Provider` in `Arc::new`. That broke Linux GTK CI — every GTK test errored with "Available apps: []" while Qt, Windows, and macOS all continued working. Root cause wasn't pinpointed; storing the provider as `Arc<dyn Provider>` from the start sidesteps the question of `Arc<&dyn Provider>` coercion entirely.

## Changes

- `PROVIDER` is now `OnceLock<Result<Arc<dyn Provider>, String>>` instead of `OnceLock<Result<&'static dyn Provider, String>>`.
- `create_provider_boxed()` returns `Box<dyn Provider>` → `Arc::from(Box)` produces `Arc<dyn Provider>`.
- `provider()` matches on the OnceLock's payload and clones the Arc (or clones the error string).
- Removes `StaticProviderRef` struct + its 19 method forwarders.
- Removes the `Box::leak` → `&'static dyn Provider` step and the unused `get_provider_ref()` helper.
- No public API change.

## Test plan
- [x] `cargo xtask check` passes locally
- [ ] Linux CI (the platform where the blanket-impl attempt broke)
- [ ] macOS, Windows CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)