### PR TITLE
fix(linux): scope application-flattening to non-registry parents (#132)

### DIFF
--- a/tests/qt/test_04_widgets_extra.py
+++ b/tests/qt/test_04_widgets_extra.py
@@ -30,13 +30,33 @@ def test_selector_nth(qt_app):
     assert first[0].role == "button"
 
 
-# NOTE: The `[enabled="..."]` / `[checked="..."]` attribute-filter tests
-# that used to live here depended on the Linux fast-path selector
-# matcher delegating to a full ElementData build for unknown attrs.
-# That delegation was reverted while isolating an unrelated GTK CI
-# regression. When the delegation comes back (or when the fast-path
-# matcher learns to answer `enabled` / `checked` directly), re-add
-# these cases.
+def test_selector_attribute_enabled_true(qt_app):
+    """Attribute filter ``[enabled="true"]`` matches only enabled elements."""
+    enabled_buttons = qt_app.locator('button[enabled="true"]').elements()
+    assert enabled_buttons
+    for b in enabled_buttons:
+        assert b.enabled is True
+
+
+def test_selector_attribute_enabled_false(qt_app):
+    """Attribute filter ``[enabled="false"]`` matches disabled elements."""
+    # Cancel starts disabled. If a prior test pressed OK it may now be enabled,
+    # so tolerate either arrangement and only verify the filter's invariant.
+    disabled = qt_app.locator('[enabled="false"]').elements()
+    cancel = qt_app.locator('button[name="Cancel"]').element()
+    if not cancel.enabled:
+        assert any(d.name == "Cancel" for d in disabled)
+    else:
+        for d in disabled:
+            assert d.enabled is False
+
+
+def test_selector_attribute_checked_on(qt_app):
+    """Attribute filter ``[checked="on"]`` matches pre-checked widgets."""
+    matches = qt_app.locator('[checked="on"]').elements()
+    names = [m.name for m in matches]
+    # Subscribe and Option A are both initially checked.
+    assert "Subscribe" in names or "Option A" in names
 
 
 def test_selector_descendant_combinator(qt_app):

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use rayon::prelude::*;
-use xa11y_core::selector::{Combinator, MatchOp, SelectorSegment};
+use xa11y_core::selector::{Combinator, SelectorSegment};
 use xa11y_core::{
     ElementData, Error, Provider, Rect, Result, Role, Selector, StateSet, Subscription, Toggled,
 };
@@ -13,6 +13,32 @@ use zbus::blocking::{Connection, Proxy};
 
 /// Global handle counter for mapping ElementData back to AccessibleRefs.
 static NEXT_HANDLE: AtomicU64 = AtomicU64::new(1);
+
+/// Format a normalized state attribute as the same string `xa11y_core::selector::resolve_attr`
+/// would produce, so fast-path matching agrees byte-for-byte with the slow path.
+fn state_attr_to_string(name: &str, s: &StateSet) -> Option<String> {
+    match name {
+        "enabled" => Some(s.enabled.to_string()),
+        "visible" => Some(s.visible.to_string()),
+        "focused" => Some(s.focused.to_string()),
+        "focusable" => Some(s.focusable.to_string()),
+        "selected" => Some(s.selected.to_string()),
+        "editable" => Some(s.editable.to_string()),
+        "modal" => Some(s.modal.to_string()),
+        "required" => Some(s.required.to_string()),
+        "busy" => Some(s.busy.to_string()),
+        "expanded" => s.expanded.map(|b| b.to_string()),
+        "checked" => s.checked.map(|c| {
+            match c {
+                Toggled::On => "on",
+                Toggled::Off => "off",
+                Toggled::Mixed => "mixed",
+            }
+            .to_string()
+        }),
+        _ => None,
+    }
+}
 
 /// Linux accessibility provider using AT-SPI2 over D-Bus.
 pub struct LinuxProvider {
@@ -969,13 +995,29 @@ impl LinuxProvider {
 
     /// Check if an accessible ref matches a simple selector, fetching only the
     /// attributes the selector actually requires.
+    ///
+    /// Filter routing (cheapest first):
+    ///   * `role` / `name` / `value` / `description` — single targeted D-Bus
+    ///     call against this accessible.
+    ///   * Normalized state attrs (`enabled`, `checked`, `focused`, …) —
+    ///     one shared `GetState` call, cached for the rest of this match.
+    ///   * Anything else (custom `raw` keys, `bounds`, numeric values) — fall
+    ///     through to building a full `ElementData` and delegating to
+    ///     [`xa11y_core::selector::matches_simple`]. This is slower but keeps
+    ///     selectors with rare attribute filters semantically equivalent to
+    ///     the default tree-traversal path.
     fn matches_ref(
         &self,
         aref: &AccessibleRef,
         simple: &xa11y_core::selector::SimpleSelector,
     ) -> bool {
-        // Resolve role only if the selector needs it
-        let needs_role = simple.role.is_some() || simple.filters.iter().any(|f| f.attr == "role");
+        // Resolve role only if the selector needs it (for either the role
+        // segment or any role/checked filter — checked depends on role).
+        let needs_role = simple.role.is_some()
+            || simple
+                .filters
+                .iter()
+                .any(|f| matches!(f.attr.as_str(), "role" | "checked"));
         let role = if needs_role {
             Some(self.resolve_role(aref))
         } else {
@@ -990,7 +1032,6 @@ impl LinuxProvider {
                     }
                 }
                 xa11y_core::selector::RoleMatch::Platform(platform_role) => {
-                    // Match against the raw AT-SPI2 role name
                     let raw_role = self.get_role_name(aref).unwrap_or_default();
                     if raw_role != *platform_role {
                         return false;
@@ -999,48 +1040,56 @@ impl LinuxProvider {
             }
         }
 
+        let mut state_set: Option<StateSet> = None;
+
         for filter in &simple.filters {
-            let attr_value: Option<String> = match filter.attr.as_str() {
-                "role" => role.map(|r| r.to_snake_case().to_string()),
+            let attr = filter.attr.as_str();
+            let resolved: Option<Option<String>> = match attr {
+                "role" => Some(role.map(|r| r.to_snake_case().to_string())),
                 "name" => {
                     let name = self.get_name(aref).ok().filter(|s| !s.is_empty());
-                    // Mirror build_element_data: StaticText may have name in Text interface
-                    if name.is_none() && role == Some(Role::StaticText) {
+                    // Mirror build_element_data: StaticText carries its name
+                    // in the Text interface's Value when Name is empty.
+                    let resolved = if name.is_none() && role == Some(Role::StaticText) {
                         self.get_value(aref)
                     } else {
                         name
+                    };
+                    Some(resolved)
+                }
+                "value" => Some(self.get_value(aref)),
+                "description" => Some(self.get_description(aref).ok().filter(|s| !s.is_empty())),
+                "enabled" | "visible" | "focused" | "focusable" | "selected" | "editable"
+                | "modal" | "required" | "busy" | "expanded" | "checked" => {
+                    let s = state_set.get_or_insert_with(|| {
+                        // `parse_states` reads `checked` based on role; pass
+                        // whatever we already resolved (Unknown is a no-op for
+                        // the role-gated `checked` mapping).
+                        self.parse_states(aref, role.unwrap_or(Role::Unknown))
+                    });
+                    Some(state_attr_to_string(attr, s))
+                }
+                _ => None, // Routed through full ElementData below.
+            };
+
+            match resolved {
+                Some(value) => {
+                    if !xa11y_core::selector::match_op(&filter.op, &filter.value, value.as_deref())
+                    {
+                        return false;
                     }
                 }
-                "value" => self.get_value(aref),
-                "description" => self.get_description(aref).ok().filter(|s| !s.is_empty()),
-                // Unknown attributes: not resolvable in lightweight matching
-                _ => None,
-            };
-
-            let matches = match &filter.op {
-                MatchOp::Exact => attr_value.as_deref() == Some(filter.value.as_str()),
-                MatchOp::Contains => {
-                    let fl = filter.value.to_lowercase();
-                    attr_value
-                        .as_deref()
-                        .is_some_and(|v| v.to_lowercase().contains(&fl))
+                None => {
+                    // Filter targets an attribute the fast path doesn't know
+                    // (e.g. `bounds`, `numeric_value`, a custom `raw` key).
+                    // Build the full ElementData once and let the shared
+                    // matcher handle every remaining filter — it dispatches
+                    // to `ElementData` fields and the `raw` map identically
+                    // to the default tree-traversal path.
+                    let pid = None; // pid isn't selector-addressable
+                    let data = self.build_element_data(aref, pid);
+                    return xa11y_core::selector::matches_simple(&data, simple);
                 }
-                MatchOp::StartsWith => {
-                    let fl = filter.value.to_lowercase();
-                    attr_value
-                        .as_deref()
-                        .is_some_and(|v| v.to_lowercase().starts_with(&fl))
-                }
-                MatchOp::EndsWith => {
-                    let fl = filter.value.to_lowercase();
-                    attr_value
-                        .as_deref()
-                        .is_some_and(|v| v.to_lowercase().ends_with(&fl))
-                }
-            };
-
-            if !matches {
-                return false;
             }
         }
 
@@ -1066,7 +1115,14 @@ impl LinuxProvider {
 
         let children = self.get_atspi_children(parent)?;
 
-        // Filter valid children, flattening nested application nodes
+        // Filter invalid refs. Application-node flattening (collapsing a
+        // redundant `application` accessible into its grandchildren) is only
+        // valid when the parent is itself an application — i.e. we have already
+        // descended past the registry. At the registry root, the children *are*
+        // the applications and must not be collapsed, otherwise selectors like
+        // `application` (used by `App::list` / `App::by_name`) match nothing
+        // because the app accessibles get dissolved into their windows.
+        let parent_is_registry = parent.bus_name == "org.a11y.atspi.Registry";
         let mut to_search: Vec<AccessibleRef> = Vec::new();
         for child in children {
             if child.path == "/org/a11y/atspi/null"
@@ -1076,23 +1132,25 @@ impl LinuxProvider {
                 continue;
             }
 
-            let child_role = self.get_role_name(&child).unwrap_or_default();
-            if child_role == "application" {
-                let grandchildren = self.get_atspi_children(&child).unwrap_or_default();
-                for gc in grandchildren {
-                    if gc.path == "/org/a11y/atspi/null"
-                        || gc.bus_name.is_empty()
-                        || gc.path.is_empty()
-                    {
-                        continue;
+            if !parent_is_registry {
+                let child_role = self.get_role_name(&child).unwrap_or_default();
+                if child_role == "application" {
+                    let grandchildren = self.get_atspi_children(&child).unwrap_or_default();
+                    for gc in grandchildren {
+                        if gc.path == "/org/a11y/atspi/null"
+                            || gc.bus_name.is_empty()
+                            || gc.path.is_empty()
+                        {
+                            continue;
+                        }
+                        let gc_role = self.get_role_name(&gc).unwrap_or_default();
+                        if gc_role == "application" {
+                            continue;
+                        }
+                        to_search.push(gc);
                     }
-                    let gc_role = self.get_role_name(&gc).unwrap_or_default();
-                    if gc_role == "application" {
-                        continue;
-                    }
-                    to_search.push(gc);
+                    continue;
                 }
-                continue;
             }
             to_search.push(child);
         }

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -61,72 +61,9 @@ fn get_provider_ref() -> Result<&'static dyn Provider> {
         })
 }
 
-/// Wrapper that lets a `&'static dyn Provider` be shared as `Arc<dyn Provider>`.
-struct StaticProviderRef(&'static dyn Provider);
-
-impl Provider for StaticProviderRef {
-    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
-        self.0.get_children(element)
-    }
-    fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {
-        self.0.get_parent(element)
-    }
-    fn press(&self, element: &ElementData) -> Result<()> {
-        self.0.press(element)
-    }
-    fn focus(&self, element: &ElementData) -> Result<()> {
-        self.0.focus(element)
-    }
-    fn blur(&self, element: &ElementData) -> Result<()> {
-        self.0.blur(element)
-    }
-    fn toggle(&self, element: &ElementData) -> Result<()> {
-        self.0.toggle(element)
-    }
-    fn select(&self, element: &ElementData) -> Result<()> {
-        self.0.select(element)
-    }
-    fn expand(&self, element: &ElementData) -> Result<()> {
-        self.0.expand(element)
-    }
-    fn collapse(&self, element: &ElementData) -> Result<()> {
-        self.0.collapse(element)
-    }
-    fn show_menu(&self, element: &ElementData) -> Result<()> {
-        self.0.show_menu(element)
-    }
-    fn increment(&self, element: &ElementData) -> Result<()> {
-        self.0.increment(element)
-    }
-    fn decrement(&self, element: &ElementData) -> Result<()> {
-        self.0.decrement(element)
-    }
-    fn scroll_into_view(&self, element: &ElementData) -> Result<()> {
-        self.0.scroll_into_view(element)
-    }
-    fn set_value(&self, element: &ElementData, value: &str) -> Result<()> {
-        self.0.set_value(element, value)
-    }
-    fn set_numeric_value(&self, element: &ElementData, value: f64) -> Result<()> {
-        self.0.set_numeric_value(element, value)
-    }
-    fn type_text(&self, element: &ElementData, text: &str) -> Result<()> {
-        self.0.type_text(element, text)
-    }
-    fn set_text_selection(&self, element: &ElementData, start: u32, end: u32) -> Result<()> {
-        self.0.set_text_selection(element, start, end)
-    }
-    fn perform_action(&self, element: &ElementData, action: &str) -> Result<()> {
-        self.0.perform_action(element, action)
-    }
-    fn subscribe(&self, element: &ElementData) -> Result<Subscription> {
-        self.0.subscribe(element)
-    }
-}
-
 #[doc(hidden)]
 pub fn provider() -> Result<Arc<dyn Provider>> {
-    Ok(Arc::new(StaticProviderRef(get_provider_ref()?)))
+    Ok(Arc::new(get_provider_ref()?))
 }
 
 // ── Platform provider construction (internal) ───────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #132. The Linux `find_elements` fast path was unreachable from the singleton `provider()` because `StaticProviderRef` doesn't override `find_elements` — exposing the fast path (e.g. via the blanket `impl Provider for &T`) immediately broke GTK CI in PR #129/#130 with `Available apps: []`. Diagnosed in a container that the fast-path's `collect_matching_refs` was dissolving every application accessible into its grandchildren *at the registry root*, where the children of the registry **are** the apps.

- **Root cause**: `collect_matching_refs` flattens any child whose role is `application` into its grandchildren — meant for the redundant nested `application` node inside an app's a11y tree (matches `LinuxProvider::get_children`'s `Some(parent)` branch). At the registry root, this dissolves every app before the `application` selector can match. `App::list` / `App::by_name` then return `[]` on Linux only.
- **Fix**: skip the flattening when `parent.bus_name == \"org.a11y.atspi.Registry\"`. The tree-traversal path in `LinuxProvider::get_children` already had this distinction; the fast path didn't.
- **Refactor**: now safe to drop the 70-line `StaticProviderRef` delegation and lean on the existing blanket `impl Provider for &T` (already in `xa11y-core` from #129).
- **Bonus**: `matches_ref` learns to answer normalized state filters (`enabled`, `checked`, `focused`, …) via a single shared `GetState` call, and falls through to a full `ElementData` build + `matches_simple` for any other attr (custom `raw` keys, `bounds`, numeric values). Keeps fast/slow paths byte-for-byte consistent with `xa11y_core::selector::resolve_attr`. Re-adds the Qt `[enabled=...]` / `[checked=...]` regression tests previously deleted in #129.

## Verification

Reproduced and validated in a Docker container (Ubuntu 24.04 + `at-spi2-core` + GTK4 + PySide6 + Xvfb + dbus-run-session):

| Suite | Before fix (with naive refactor) | After |
|---|---|---|
| GTK (`scripts/run_gtk_tests.sh`) | 0 / 25 — `Available apps: []` | **25 / 25** |
| Qt (`scripts/run_qt_tests.sh`) | 61 / 61 | **64 / 64** (+3 re-added state-filter tests) |
| AccessKit Rust integ (`scripts/run_integ_tests.sh`) | 99 / 99 | **99 / 99** |
| `cargo test --workspace` | clean | clean |
| `cargo clippy --workspace --all-targets -- -Dwarnings` | clean | clean |

Diagnostic trace from the failing run (refactor + no fix):
- `get_atspi_children(registry)` returns 2 apps (758 successful calls).
- `collect_matching_refs` flattens all 2 into their windows.
- `matches_ref(window, role=Application)` returns false → `phase1 matched 0 refs`.

After fix: same trace, but `parent_is_registry` short-circuits the flatten → `phase1 matched 2 refs` → tests pass in 4.30s (faster than baseline's 5.33s, since the fast path is now actually used).

## Test plan

- [x] GTK integ tests pass on Linux
- [x] Qt integ tests pass on Linux (incl. re-added state-selector tests)
- [x] AccessKit Rust integ tests pass on Linux
- [x] `cargo test --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -Dwarnings` clean
- [ ] CI: macOS unit + Cocoa integ
- [ ] CI: Windows unit + Qt integ + Rust integ
- [ ] CI: Tauri (was previously blocked by the GTK failure in CI's job order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)