### PR TITLE
Input simulation + cross-platform screenshot add-on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            xvfb dbus dbus-x11 \
+            xvfb dbus dbus-x11 fluxbox \
             at-spi2-core \
             libxkbcommon-x11-0 libxkbcommon-x11-dev \
             libxcursor1 libxrandr2 libxi6 \
@@ -496,7 +496,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            xvfb dbus dbus-x11 \
+            xvfb dbus dbus-x11 fluxbox \
             at-spi2-core \
             libxkbcommon-x11-0 libxkbcommon-x11-dev \
             libxcursor1 libxrandr2 libxi6 \
@@ -753,7 +753,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            xvfb dbus dbus-x11 \
+            xvfb dbus dbus-x11 fluxbox \
             at-spi2-core \
             libxkbcommon-x11-0 libxkbcommon-x11-dev \
             libxcursor1 libxrandr2 libxi6 \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,10 +694,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -1028,6 +1062,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1425,6 +1469,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1777,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -2720,6 +2783,7 @@ dependencies = [
 name = "xa11y-core"
 version = "0.6.2"
 dependencies = [
+ "png",
  "serde",
  "serde_json",
  "strum",
@@ -2739,6 +2803,7 @@ dependencies = [
 name = "xa11y-linux"
 version = "0.6.2"
 dependencies = [
+ "png",
  "rayon",
  "serde_json",
  "x11rb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,6 +2741,7 @@ version = "0.6.2"
 dependencies = [
  "rayon",
  "serde_json",
+ "x11rb",
  "xa11y-core",
  "zbus",
 ]

--- a/scripts/run_tauri_tests.sh
+++ b/scripts/run_tauri_tests.sh
@@ -50,6 +50,23 @@ if [[ "$(uname)" == "Linux" ]]; then
         CLEANUP_PIDS+=($!)
         sleep 1
         export DISPLAY="$XVFB_DISPLAY"
+
+        # Start a minimal window manager so synthesised input events (XTest
+        # ButtonPress/KeyPress) reach the Tauri window properly — bare Xvfb
+        # has no focus management, so keyboard events end up at the root
+        # window and never reach the webview.
+        if command -v fluxbox &>/dev/null; then
+            echo "Starting fluxbox (for focus routing under Xvfb)..."
+            fluxbox >/dev/null 2>&1 &
+            CLEANUP_PIDS+=($!)
+            sleep 1
+        else
+            echo "WARNING: fluxbox not installed; input-sim tests may fail."
+            echo "         Install with: sudo apt-get install -y fluxbox"
+            # Signal to pytest to skip input-sim tests rather than fail them
+            # with a confusing "event log is empty" message.
+            export XA11Y_SKIP_INPUT_SIM=1
+        fi
     fi
     echo "DISPLAY=$DISPLAY"
 

--- a/test-apps/tauri/frontend/index.html
+++ b/test-apps/tauri/frontend/index.html
@@ -20,7 +20,13 @@
 </head>
 <body>
 
-  <p><a id="input-events-link" href="input-events.html">input events →</a></p>
+  <p>
+    <button id="input-events-nav"
+            aria-label="Open input events page"
+            onclick="window.location.href='input-events.html'">
+      input events
+    </button>
+  </p>
 
   <!-- Buttons -->
   <fieldset>

--- a/test-apps/tauri/frontend/index.html
+++ b/test-apps/tauri/frontend/index.html
@@ -20,6 +20,8 @@
 </head>
 <body>
 
+  <p><a id="input-events-link" href="input-events.html">input events →</a></p>
+
   <!-- Buttons -->
   <fieldset>
     <legend>Buttons</legend>

--- a/test-apps/tauri/frontend/input-events.html
+++ b/test-apps/tauri/frontend/input-events.html
@@ -19,6 +19,8 @@
       justify-content: center;
       user-select: none;
       outline: none;
+      font: inherit;
+      cursor: default;
     }
     #hit-target:focus { border-color: #0078d7; background: #eef6ff; }
     #event-log { width: 520px; height: 220px; font-family: ui-monospace, monospace; white-space: pre; }
@@ -29,7 +31,13 @@
 </head>
 <body>
 
-  <p><a id="back-link" href="index.html">← widgets</a></p>
+  <p>
+    <button id="back-nav"
+            aria-label="Back to widgets"
+            onclick="window.location.href='index.html'">
+      widgets
+    </button>
+  </p>
 
   <h1>Input event reporter</h1>
   <p>Drive mouse/keyboard events via <code>xa11y::InputSim</code> and read the
@@ -39,10 +47,9 @@
   <fieldset>
     <legend>Hit target</legend>
     <div class="row">
-      <div id="hit-target"
-           tabindex="0"
-           role="region"
-           aria-label="Hit target">Click / scroll / drag here</div>
+      <button id="hit-target"
+              type="button"
+              aria-label="Hit target">Click / scroll / drag here</button>
     </div>
     <div class="last" id="last-mouse" aria-label="Last mouse">last mouse: (none)</div>
   </fieldset>

--- a/test-apps/tauri/frontend/input-events.html
+++ b/test-apps/tauri/frontend/input-events.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>xa11y-tauri-test-app · input events</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 16px; }
+    fieldset { margin-bottom: 16px; padding: 12px; }
+    legend { font-weight: bold; }
+    .row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 8px; }
+    #hit-target {
+      width: 300px;
+      height: 160px;
+      border: 2px dashed #888;
+      background: #f5f5f5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      user-select: none;
+      outline: none;
+    }
+    #hit-target:focus { border-color: #0078d7; background: #eef6ff; }
+    #event-log { width: 520px; height: 220px; font-family: ui-monospace, monospace; white-space: pre; }
+    #typed-text { width: 300px; }
+    .last { font-family: ui-monospace, monospace; color: #333; }
+    a { color: #0078d7; }
+  </style>
+</head>
+<body>
+
+  <p><a id="back-link" href="index.html">← widgets</a></p>
+
+  <h1>Input event reporter</h1>
+  <p>Drive mouse/keyboard events via <code>xa11y::InputSim</code> and read the
+    log via the a11y tree. Each event is one line.</p>
+
+  <!-- Hit target — captures mouse events -->
+  <fieldset>
+    <legend>Hit target</legend>
+    <div class="row">
+      <div id="hit-target"
+           tabindex="0"
+           role="region"
+           aria-label="Hit target">Click / scroll / drag here</div>
+    </div>
+    <div class="last" id="last-mouse" aria-label="Last mouse">last mouse: (none)</div>
+  </fieldset>
+
+  <!-- Typed text — captures type_text() output -->
+  <fieldset>
+    <legend>Typed text</legend>
+    <div class="row">
+      <label for="typed-text">Typed text</label>
+      <input type="text" id="typed-text" aria-label="Typed text" />
+    </div>
+    <div class="last" id="last-key" aria-label="Last key">last key: (none)</div>
+  </fieldset>
+
+  <!-- Event log — what integ tests assert against -->
+  <fieldset>
+    <legend>Event log</legend>
+    <div class="row">
+      <textarea id="event-log" aria-label="Event log" readonly></textarea>
+    </div>
+    <div class="row">
+      <button id="clear-log" aria-label="Clear log">Clear log</button>
+      <span class="last" id="event-count" aria-label="Event count">events: 0</span>
+    </div>
+  </fieldset>
+
+  <script>
+    'use strict';
+
+    const hit = document.getElementById('hit-target');
+    const log = document.getElementById('event-log');
+    const lastMouse = document.getElementById('last-mouse');
+    const lastKey = document.getElementById('last-key');
+    const eventCount = document.getElementById('event-count');
+    const clearBtn = document.getElementById('clear-log');
+    const typedField = document.getElementById('typed-text');
+
+    let count = 0;
+
+    function mods(e) {
+      const m = [];
+      if (e.shiftKey) m.push('shift');
+      if (e.ctrlKey) m.push('ctrl');
+      if (e.altKey) m.push('alt');
+      if (e.metaKey) m.push('meta');
+      return m.length ? m.join(',') : '-';
+    }
+
+    function button(e) {
+      // MouseEvent.button: 0 = left, 1 = middle, 2 = right.
+      return ['left', 'middle', 'right', 'x1', 'x2'][e.button] ?? String(e.button);
+    }
+
+    function append(line) {
+      count += 1;
+      // Prepend so most recent is visible at top without scrolling, and cap
+      // at 200 lines so the log stays readable and the a11y value field
+      // doesn't balloon.
+      const lines = log.value ? log.value.split('\n') : [];
+      lines.unshift(line);
+      if (lines.length > 200) lines.length = 200;
+      log.value = lines.join('\n');
+      eventCount.textContent = `events: ${count}`;
+    }
+
+    // ── Mouse events (captured on the hit target) ────────────────────────
+
+    // `offsetX/Y` on MouseEvent is relative to the target's padding box, which
+    // is what we want for assertions that are independent of screen position.
+    function describeMouse(kind, e) {
+      return `${kind} x=${e.offsetX} y=${e.offsetY} button=${button(e)} mods=${mods(e)} detail=${e.detail}`;
+    }
+
+    for (const kind of ['mousedown', 'mouseup', 'click', 'dblclick', 'contextmenu']) {
+      hit.addEventListener(kind, (e) => {
+        const line = describeMouse(kind, e);
+        append(line);
+        lastMouse.textContent = 'last mouse: ' + line;
+        // Keep the native context-menu from interrupting the test flow.
+        if (kind === 'contextmenu') e.preventDefault();
+      });
+    }
+
+    // Mouse move only when a button is held (drag). Raw moves would flood
+    // the log and aren't what the tests assert against.
+    hit.addEventListener('mousemove', (e) => {
+      if (e.buttons === 0) return;
+      append(`mousemove x=${e.offsetX} y=${e.offsetY} buttons=${e.buttons} mods=${mods(e)}`);
+    });
+
+    hit.addEventListener('wheel', (e) => {
+      const line = `wheel x=${e.offsetX} y=${e.offsetY} dx=${e.deltaX} dy=${e.deltaY} mode=${e.deltaMode}`;
+      append(line);
+      lastMouse.textContent = 'last mouse: ' + line;
+    }, { passive: true });
+
+    // ── Keyboard events (captured on window — any focus) ─────────────────
+
+    // Attached to `window` so chord presses (e.g. Cmd+A in the typed-text
+    // field) are logged regardless of which element has focus. Capture phase
+    // avoids losing events that the focused control preventDefault()s.
+    for (const kind of ['keydown', 'keyup']) {
+      window.addEventListener(kind, (e) => {
+        const line = `${kind} key=${e.key} code=${e.code} mods=${mods(e)} repeat=${e.repeat}`;
+        append(line);
+        lastKey.textContent = 'last key: ' + line;
+      }, true);
+    }
+
+    // ── Clear button ─────────────────────────────────────────────────────
+
+    clearBtn.addEventListener('click', (e) => {
+      // The click on the Clear button itself would otherwise be logged
+      // before we wipe — the stopPropagation keeps the log clean, then
+      // reset the count too.
+      e.stopPropagation();
+      log.value = '';
+      count = 0;
+      eventCount.textContent = 'events: 0';
+      lastMouse.textContent = 'last mouse: (none)';
+      lastKey.textContent = 'last key: (none)';
+      // Typed text clears too so type_text tests start fresh.
+      typedField.value = '';
+    });
+  </script>
+</body>
+</html>

--- a/tests/tauri/conftest.py
+++ b/tests/tauri/conftest.py
@@ -42,3 +42,36 @@ def tauri_app():
         app_names=APP_NAMES,
         content_ready_selector='button[name="OK"]',
     )
+
+
+@pytest.fixture(scope="module")
+def tauri_input_app():
+    """Launch the Tauri app and navigate to the input-events page.
+
+    A module-scoped fixture (separate process) so the event log starts
+    empty and focus state doesn't bleed in from the widget tests.
+    """
+    import time
+
+    _ensure_built()
+    gen = launch_test_app(
+        command=[BINARY],
+        app_names=APP_NAMES,
+        content_ready_selector='button[name="OK"]',
+    )
+    app = next(gen)
+    # Click the link to navigate to input-events.html, then wait for the
+    # hit target to appear in the a11y tree before handing off to tests.
+    app.locator('link[name="input events →"]').press()
+    for _ in range(50):
+        if app.locator('region[name="Hit target"]').exists():
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail("input-events page did not load within 5s")
+    try:
+        yield app
+    finally:
+        # Advance the launch generator to run its teardown.
+        for _ in gen:
+            pass

--- a/tests/tauri/conftest.py
+++ b/tests/tauri/conftest.py
@@ -60,11 +60,15 @@ def tauri_input_app():
         content_ready_selector='button[name="OK"]',
     )
     app = next(gen)
-    # Click the link to navigate to input-events.html, then wait for the
-    # hit target to appear in the a11y tree before handing off to tests.
-    app.locator('link[name="input events →"]').press()
+    # Navigate from the widgets page to input-events.html. The nav control
+    # is a button (not a raw <a>) so press() semantics are unambiguous on
+    # every OS's webview a11y bridge — Linux AT-SPI in particular surfaces
+    # <a> with varying roles depending on the WebKit version.
+    app.locator('button[name="Open input events page"]').press()
+    # The hit target is a button with aria-label="Hit target"; wait for it
+    # to appear in the a11y tree before handing off.
     for _ in range(50):
-        if app.locator('region[name="Hit target"]').exists():
+        if app.locator('button[name="Hit target"]').exists():
             break
         time.sleep(0.1)
     else:

--- a/tests/tauri/test_input_sim.py
+++ b/tests/tauri/test_input_sim.py
@@ -1,0 +1,228 @@
+"""Integration tests for xa11y.input_sim() against the Tauri input-events page.
+
+Each test drives synthesised mouse/keyboard events via `xa11y.input_sim()` and
+asserts the webview received them by reading the event-log textarea's value
+through the accessibility tree.
+
+Every platform needs the host process to hold the input-synthesis permission
+(Accessibility + Input Monitoring on macOS, XTest on X11 — no grant needed
+on Windows). CI on macOS GitHub Actions runners typically lacks the grant,
+so these tests are skipped there via the XA11Y_SKIP_INPUT_SIM env var set
+by the harness.
+
+Hit-target and typed-text fields are identified by role + name (aria-label).
+The event log is a read-only textarea; on macOS/Linux a11y trees it surfaces
+as a `text_field` with the log text as its value.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import time
+
+import pytest
+import xa11y
+
+HIT_TARGET = 'region[name="Hit target"]'
+EVENT_LOG = 'text_field[name="Event log"]'
+TYPED_FIELD = 'text_field[name="Typed text"]'
+CLEAR_BUTTON = 'button[name="Clear log"]'
+
+# Wait up to this long for a log line to appear after we post an event.
+LOG_SETTLE_TIMEOUT = 2.0
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("XA11Y_SKIP_INPUT_SIM") == "1",
+    reason="Input simulation disabled (XA11Y_SKIP_INPUT_SIM=1)",
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _read_log(app: xa11y.App) -> str:
+    """Read the event log textarea value via a11y."""
+    return app.locator(EVENT_LOG).element().value or ""
+
+
+def _wait_for_log(app: xa11y.App, predicate, timeout: float = LOG_SETTLE_TIMEOUT) -> str:
+    """Poll the log until `predicate(text)` returns True or we time out."""
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        last = _read_log(app)
+        if predicate(last):
+            return last
+        time.sleep(0.05)
+    return last
+
+
+def _clear_log(app: xa11y.App) -> None:
+    app.locator(CLEAR_BUTTON).press()
+    # The press itself is a synthetic a11y action (not input sim), so the
+    # log should be empty immediately — but give one tick for the webview
+    # handler to run.
+    _wait_for_log(app, lambda t: t == "", timeout=0.5)
+
+
+def _focus_hit_target(app: xa11y.App) -> None:
+    """Focus the hit target so keyboard events land on a meaningful element."""
+    app.locator(HIT_TARGET).focus()
+
+
+def _focus_typed_field(app: xa11y.App) -> None:
+    app.locator(TYPED_FIELD).focus()
+
+
+def _hit_center(app: xa11y.App) -> tuple[int, int]:
+    """Screen-coordinate center of the hit-target region."""
+    el = app.locator(HIT_TARGET).element()
+    r = el.bounds
+    assert r is not None, "hit target has no bounds"
+    return (r.x + r.width // 2, r.y + r.height // 2)
+
+
+# ── Fixture ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sim() -> xa11y.InputSim:
+    return xa11y.input_sim()
+
+
+# ── Mouse ──────────────────────────────────────────────────────────────────
+
+
+def test_single_click_reports_mousedown_and_up(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    sim.click(_hit_center(tauri_input_app))
+    log = _wait_for_log(tauri_input_app, lambda t: "mouseup" in t and "mousedown" in t)
+    assert "mousedown" in log
+    assert "mouseup" in log
+    assert "click" in log
+    assert "button=left" in log
+
+
+def test_double_click_reports_dblclick(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    sim.double_click(_hit_center(tauri_input_app))
+    log = _wait_for_log(tauri_input_app, lambda t: "dblclick" in t)
+    assert "dblclick" in log, f"expected dblclick in log, got:\n{log}"
+
+
+def test_right_click_reports_right_button(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    sim.right_click(_hit_center(tauri_input_app))
+    log = _wait_for_log(tauri_input_app, lambda t: "button=right" in t)
+    assert "button=right" in log
+
+
+def test_click_on_element_target(tauri_input_app, sim):
+    """Passing an Element as the click target should use its centre bounds."""
+    _clear_log(tauri_input_app)
+    hit_el = tauri_input_app.locator(HIT_TARGET).element()
+    sim.click(hit_el)
+    log = _wait_for_log(tauri_input_app, lambda t: "click" in t)
+    assert "click" in log
+
+
+def test_drag_emits_mousemove_between_down_and_up(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    el = tauri_input_app.locator(HIT_TARGET).element()
+    r = el.bounds
+    assert r is not None
+    # Drag within the hit target — browsers only fire mousemove on the
+    # element that captured the mousedown, so both endpoints must be inside.
+    start = (r.x + 20, r.y + 20)
+    end = (r.x + r.width - 20, r.y + r.height - 20)
+    sim.drag(start, end)
+    log = _wait_for_log(tauri_input_app, lambda t: "mouseup" in t and "mousemove" in t)
+    assert "mousedown" in log
+    assert "mousemove" in log
+    assert "mouseup" in log
+
+
+# ── Keyboard ───────────────────────────────────────────────────────────────
+
+
+def test_key_press_reports_keydown_keyup(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    _focus_hit_target(tauri_input_app)
+    sim.press("a")
+    log = _wait_for_log(tauri_input_app, lambda t: "keyup" in t and "keydown" in t)
+    assert "keydown" in log
+    assert "keyup" in log
+    assert "key=a" in log
+
+
+def test_named_key_press(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    _focus_hit_target(tauri_input_app)
+    sim.press("Enter")
+    log = _wait_for_log(tauri_input_app, lambda t: "keyup" in t)
+    assert "key=Enter" in log
+
+
+def test_chord_reports_modifier(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    _focus_hit_target(tauri_input_app)
+    # Shift+a (capital A via the explicit-shift API contract).
+    sim.chord("a", ["Shift"])
+    log = _wait_for_log(tauri_input_app, lambda t: "keyup" in t and "shift" in t)
+    assert "mods=shift" in log or "shift" in log.split("\n")[0]
+
+
+def test_platform_meta_chord(tauri_input_app, sim):
+    """Cmd/Ctrl+A should fire with the platform 'meta' modifier held."""
+    _clear_log(tauri_input_app)
+    _focus_typed_field(tauri_input_app)
+    sim.type_text("hello")
+    _clear_log(tauri_input_app)
+    sim.chord("a", ["Meta"])
+    log = _wait_for_log(tauri_input_app, lambda t: "keyup" in t and "key=a" in t)
+    assert "meta" in log
+
+
+# ── Typing ─────────────────────────────────────────────────────────────────
+
+
+def test_type_text_writes_to_focused_input(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    _focus_typed_field(tauri_input_app)
+    sim.type_text("hello xa11y")
+    # Poll the typed-text input's value (not the event log) — type_text uses
+    # Unicode / scancode paths that don't always generate synthetic key events
+    # at the DOM level.
+    deadline = time.monotonic() + LOG_SETTLE_TIMEOUT
+    while time.monotonic() < deadline:
+        val = tauri_input_app.locator(TYPED_FIELD).element().value or ""
+        if val == "hello xa11y":
+            return
+        time.sleep(0.05)
+    pytest.fail(f"typed-text field did not receive expected text, got: {val!r}")
+
+
+# ── Scroll ─────────────────────────────────────────────────────────────────
+
+
+def test_scroll_reports_wheel(tauri_input_app, sim):
+    _clear_log(tauri_input_app)
+    sim.scroll(_hit_center(tauri_input_app), dx=0, dy=3)
+    log = _wait_for_log(tauri_input_app, lambda t: "wheel" in t)
+    assert "wheel" in log
+
+
+# ── Smoke ──────────────────────────────────────────────────────────────────
+
+
+def test_input_sim_construct():
+    """Constructing the sim should succeed on every supported platform."""
+    sim = xa11y.input_sim()
+    assert sim is not None
+
+
+def test_platform_matrix_smoke():
+    """Sanity: we know which platform this runs on."""
+    assert platform.system() in ("Darwin", "Linux", "Windows")

--- a/tests/tauri/test_input_sim.py
+++ b/tests/tauri/test_input_sim.py
@@ -175,14 +175,24 @@ def test_chord_reports_modifier(tauri_input_app, sim):
 
 
 def test_platform_meta_chord(tauri_input_app, sim):
-    """Cmd/Ctrl+A should fire with the platform 'meta' modifier held."""
+    """Cmd/Win/Super+A should fire the platform's 'command' key held.
+
+    The browser surfaces this differently per platform:
+      - macOS: Cmd → KeyboardEvent.metaKey (`mods=meta`)
+      - Windows: Win → KeyboardEvent.metaKey (`mods=meta`)
+      - Linux: Super → KeyboardEvent.key == 'Super' (WebKit-GTK doesn't
+        route Super into the metaKey flag, so we check for the key name
+        on the keydown/keyup events instead).
+    """
     _clear_log(tauri_input_app)
     _focus_typed_field(tauri_input_app)
     sim.type_text("hello")
     _clear_log(tauri_input_app)
     sim.chord("a", ["Meta"])
     log = _wait_for_log(tauri_input_app, lambda t: "keyup" in t and "key=a" in t)
-    assert "meta" in log
+    assert "meta" in log or "Super" in log or "Meta" in log, (
+        f"expected platform command modifier in log, got:\n{log}"
+    )
 
 
 # ── Typing ─────────────────────────────────────────────────────────────────

--- a/tests/tauri/test_input_sim.py
+++ b/tests/tauri/test_input_sim.py
@@ -24,8 +24,8 @@ import time
 import pytest
 import xa11y
 
-HIT_TARGET = 'region[name="Hit target"]'
-EVENT_LOG = 'text_field[name="Event log"]'
+HIT_TARGET = 'button[name="Hit target"]'
+EVENT_LOG = 'text_area[name="Event log"]'
 TYPED_FIELD = 'text_field[name="Typed text"]'
 CLEAR_BUTTON = 'button[name="Clear log"]'
 

--- a/xa11y-core/Cargo.toml
+++ b/xa11y-core/Cargo.toml
@@ -13,6 +13,7 @@ strict-roles = []
 test-support = []
 
 [dependencies]
+png = "0.17"
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { version = "0.28", features = ["derive"] }

--- a/xa11y-core/src/error.rs
+++ b/xa11y-core/src/error.rs
@@ -46,6 +46,16 @@ pub enum Error {
     #[error("Invalid action data: {message}")]
     InvalidActionData { message: String },
 
+    /// The element has no bounds (e.g. an off-screen or virtual node), so a
+    /// screen point can't be computed for input simulation.
+    #[error("Element has no bounds")]
+    NoElementBounds,
+
+    /// The requested operation has no implementation on this platform/session
+    /// (e.g. pointer warp on Wayland without a portal grant).
+    #[error("Unsupported: {feature}")]
+    Unsupported { feature: String },
+
     /// A platform-specific error occurred.
     #[error("Platform error ({code}): {message}")]
     Platform { code: i64, message: String },

--- a/xa11y-core/src/input.rs
+++ b/xa11y-core/src/input.rs
@@ -16,10 +16,24 @@
 //!   macOS, Wayland portal grants on Linux, etc.).
 //!
 //! There is **no implicit bridge** between the two: an accessibility-action
-//! failure never falls back to input simulation, and `InputSim` never inspects
-//! or auto-resolves the a11y tree on behalf of the caller. If you want to
-//! click an element, you compute its bounds (via the a11y API) and pass them
-//! in — see [`IntoPoint`] and [`InputSim::point_for`].
+//! failure never falls back to input simulation, and [`InputSim`] never
+//! inspects or auto-resolves the a11y tree on behalf of the caller. If you
+//! want to click an element, you compute its bounds (via the a11y API) and
+//! pass them in — see [`IntoPoint`] and [`point_for`].
+//!
+//! # Layout
+//!
+//! [`InputSim`] exposes two sub-handles:
+//!
+//! - [`InputSim::mouse`] → [`Mouse`] for pointer operations (`click`, `drag`,
+//!   `scroll`, `down`/`up`).
+//! - [`InputSim::keyboard`] → [`Keyboard`] for key operations (`press`,
+//!   `chord`, `down`/`up`, `type_text`).
+//!
+//! Modifier keys (`Shift`, `Ctrl`, `Alt`, `Meta`) are regular variants of
+//! [`Key`] — there is no separate `Modifier` type. `Key::Char(c)` represents
+//! the unshifted physical key; use [`Key::Shift`] explicitly for uppercase
+//! or shifted symbols (see [`Key`] for the rationale).
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -43,12 +57,6 @@ pub struct Point {
 
 impl Point {
     pub const fn new(x: i32, y: i32) -> Self {
-        Self { x, y }
-    }
-}
-
-impl From<(i32, i32)> for Point {
-    fn from((x, y): (i32, i32)) -> Self {
         Self { x, y }
     }
 }
@@ -124,7 +132,7 @@ impl IntoPoint for Point {
 
 impl IntoPoint for (i32, i32) {
     fn into_point(self) -> Result<Point> {
-        Ok(self.into())
+        Ok(Point::new(self.0, self.1))
     }
 }
 
@@ -170,28 +178,51 @@ impl ScrollDelta {
 
 // ── Keyboard ────────────────────────────────────────────────────────
 
-/// A keyboard modifier.
+/// A keyboard key.
+///
+/// Modifier keys (`Shift`, `Ctrl`, `Alt`, `Meta`) are regular variants of this
+/// enum — they are not a separate type. This matches the physical reality that
+/// modifiers are keys like any other, and the convention of Playwright,
+/// Puppeteer, Selenium, pyautogui, `SendInput`, and `XTest`.
+///
+/// # `Key::Char` semantics
+///
+/// `Key::Char(c)` represents **the physical key labeled with the unshifted
+/// character `c`**. It does **not** auto-synthesise `Shift`. To produce an
+/// uppercase letter or shifted symbol, hold [`Key::Shift`] explicitly:
+///
+/// ```ignore
+/// // Cmd+A (select all):
+/// keyboard.chord(Key::Char('a'), &[Key::Meta]);
+///
+/// // Uppercase 'A':
+/// keyboard.chord(Key::Char('a'), &[Key::Shift]);
+/// ```
+///
+/// For this reason, `Key::Char` **rejects ASCII uppercase letters at the API
+/// boundary** ([`Error::InvalidActionData`]). This prevents the common
+/// footgun where `chord(Key::Char('K'), &[Key::Meta])` is read as "Cmd+K"
+/// but would silently mean "Cmd+Shift+K" under auto-shift semantics.
+///
+/// To type arbitrary text (with IME support and correct case handling), use
+/// [`Keyboard::type_text`] — `Key` is for single-key presses.
+///
+/// # `Meta`
 ///
 /// `Meta` is the platform's "command" modifier: Cmd on macOS, Win on Windows,
-/// Super on Linux. Use this when you want a portable shortcut; backends are
-/// responsible for the platform mapping.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Modifier {
+/// Super on Linux. Backends are responsible for the platform mapping.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Key {
+    /// A printable character (lowercase, no shifted symbols). Backends
+    /// translate this to the matching physical key. See the type-level docs
+    /// for the rationale on rejecting uppercase letters.
+    Char(char),
+
+    // Modifiers (held-key form — combine with other keys via `chord`).
     Shift,
     Ctrl,
     Alt,
     Meta,
-}
-
-/// A single key for a press / release.
-///
-/// For typing arbitrary text (with IME support and correct shift handling),
-/// prefer [`InputSim::type_text`] over a sequence of `Key::Char` taps.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Key {
-    /// A printable character. Backends are responsible for any modifier
-    /// synthesis required to produce it (e.g. shift for `'A'`).
-    Char(char),
 
     Enter,
     Escape,
@@ -215,16 +246,39 @@ pub enum Key {
     F(u8),
 }
 
+impl Key {
+    /// Validate a key for use at the API boundary.
+    ///
+    /// Returns [`Error::InvalidActionData`] for `Key::Char` with an ASCII
+    /// uppercase letter — callers must lowercase and hold [`Key::Shift`]
+    /// explicitly. See the type-level docs.
+    pub(crate) fn validate(&self) -> Result<()> {
+        if let Key::Char(c) = self {
+            if c.is_ascii_uppercase() {
+                return Err(Error::InvalidActionData {
+                    message: format!(
+                        "Key::Char('{c}') is uppercase; use Key::Char('{}') \
+                         with Key::Shift held to produce an uppercase letter",
+                        c.to_ascii_lowercase()
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
 // ── Click / drag option structs ─────────────────────────────────────
 
-/// Options for [`InputSim::click_with`].
+/// Options for [`Mouse::click_with`].
 #[derive(Debug, Clone)]
 pub struct ClickOptions {
     pub button: MouseButton,
     /// Number of consecutive clicks (1 = single, 2 = double, …).
     pub count: u32,
-    /// Modifiers held for the duration of the click.
-    pub modifiers: Vec<Modifier>,
+    /// Keys held (pressed but not released) for the duration of the click —
+    /// typically modifier keys like [`Key::Shift`] or [`Key::Meta`].
+    pub held: Vec<Key>,
     /// Anchor used when the target is an [`Element`]. Ignored for raw points.
     pub anchor: Anchor,
 }
@@ -234,17 +288,18 @@ impl Default for ClickOptions {
         Self {
             button: MouseButton::Left,
             count: 1,
-            modifiers: Vec::new(),
+            held: Vec::new(),
             anchor: Anchor::Center,
         }
     }
 }
 
-/// Options for [`InputSim::drag_with`].
+/// Options for [`Mouse::drag_with`].
 #[derive(Debug, Clone)]
 pub struct DragOptions {
     pub button: MouseButton,
-    pub modifiers: Vec<Modifier>,
+    /// Keys held for the duration of the drag.
+    pub held: Vec<Key>,
     /// Total time over which the drag is performed. Backends interpolate
     /// pointer movement across this duration.
     pub duration: Duration,
@@ -254,7 +309,7 @@ impl Default for DragOptions {
     fn default() -> Self {
         Self {
             button: MouseButton::Left,
-            modifiers: Vec::new(),
+            held: Vec::new(),
             duration: Duration::from_millis(150),
         }
     }
@@ -287,11 +342,11 @@ pub trait InputProvider: Send + Sync {
     /// Move the pointer to `to` without pressing any buttons.
     fn pointer_move(&self, to: Point) -> Result<()>;
 
-    /// Press `button` at the current pointer location.
-    fn pointer_press(&self, button: MouseButton) -> Result<()>;
+    /// Press `button` at the current pointer location (no release).
+    fn pointer_down(&self, button: MouseButton) -> Result<()>;
 
     /// Release `button` at the current pointer location.
-    fn pointer_release(&self, button: MouseButton) -> Result<()>;
+    fn pointer_up(&self, button: MouseButton) -> Result<()>;
 
     /// Click `button` at `at`, repeated `count` times. The backend is
     /// responsible for honouring the OS double-click interval when `count > 1`.
@@ -311,39 +366,51 @@ pub trait InputProvider: Send + Sync {
 
     // ── Keyboard ────────────────────────────────────────────────────
 
-    /// Press `key` (no release).
+    /// Press `key` (no release). Use [`key_up`](Self::key_up) to release.
+    ///
+    /// Modifiers are just keys: hold `Key::Shift` via `key_down(&Key::Shift)`.
     fn key_down(&self, key: &Key) -> Result<()>;
 
     /// Release `key`.
     fn key_up(&self, key: &Key) -> Result<()>;
 
-    /// Press and release `key` while `modifiers` are held.
-    fn key_tap(&self, key: &Key, modifiers: &[Modifier]) -> Result<()>;
+    /// Press and release `key` while `held` are held down.
+    fn key_tap(&self, key: &Key, held: &[Key]) -> Result<()>;
 
     /// Type `text` as literal user input.
     ///
     /// Backends should prefer the OS's text-input path (with IME support)
     /// over synthesising individual key presses where possible.
     fn type_text(&self, text: &str) -> Result<()>;
-
-    // ── Modifier holds ──────────────────────────────────────────────
-
-    /// Press a modifier (without release). Pair with [`modifier_up`](Self::modifier_up).
-    fn modifier_down(&self, modifier: Modifier) -> Result<()>;
-
-    /// Release a previously pressed modifier.
-    fn modifier_up(&self, modifier: Modifier) -> Result<()>;
 }
 
 // ── Public façade ───────────────────────────────────────────────────
 
 /// Synthesises OS-level pointer and keyboard events.
 ///
-/// `InputSim` is a thin façade over an [`InputProvider`] backend. Use it only
-/// when the accessibility action layer cannot express the interaction you
-/// need — see the [module docs](self) for the rationale.
+/// `InputSim` is a thin façade over an [`InputProvider`] backend. Methods are
+/// organised by input device: [`InputSim::mouse`] returns a [`Mouse`] handle
+/// with pointer operations, [`InputSim::keyboard`] returns a [`Keyboard`]
+/// handle with key operations. This structure matches Playwright and
+/// Puppeteer's `page.mouse.*` / `page.keyboard.*` layout and keeps the combo
+/// verbs (`click`, `press`) unambiguous even though `Element::press` exists
+/// at the a11y layer.
+///
+/// Use this only when the accessibility action layer cannot express the
+/// interaction you need — see the [module docs](self) for the rationale.
 ///
 /// `InputSim` is cheap to clone (it shares the backend via `Arc`).
+///
+/// # Example
+///
+/// ```ignore
+/// # use xa11y_core::{input::*, Element};
+/// # fn go(sim: InputSim, button: Element) -> xa11y_core::Result<()> {
+/// sim.mouse().click(&button)?;
+/// sim.keyboard().chord(Key::Char('a'), &[Key::Meta])?; // Cmd/Ctrl+A
+/// sim.keyboard().type_text("hello")?;
+/// # Ok(()) }
+/// ```
 #[derive(Clone)]
 pub struct InputSim {
     backend: Arc<dyn InputProvider>,
@@ -359,8 +426,33 @@ impl InputSim {
         &self.backend
     }
 
-    // ── Pointer ─────────────────────────────────────────────────────
+    /// Handle for pointer operations.
+    pub fn mouse(&self) -> Mouse<'_> {
+        Mouse {
+            backend: &self.backend,
+        }
+    }
 
+    /// Handle for keyboard operations.
+    pub fn keyboard(&self) -> Keyboard<'_> {
+        Keyboard {
+            backend: &self.backend,
+        }
+    }
+
+    /// Resolve an element's current bounds to a screen point using `anchor`.
+    /// Equivalent to the free function [`point_for`].
+    pub fn point_for(&self, element: &Element, anchor: Anchor) -> Result<Point> {
+        point_for(element, anchor)
+    }
+}
+
+/// Pointer operations. Obtain via [`InputSim::mouse`].
+pub struct Mouse<'a> {
+    backend: &'a Arc<dyn InputProvider>,
+}
+
+impl Mouse<'_> {
     /// Left-click `target` once at its [`Anchor::Center`] (for elements) or
     /// at the literal point.
     pub fn click(&self, target: impl IntoPoint) -> Result<()> {
@@ -368,16 +460,19 @@ impl InputSim {
         self.backend.pointer_click(pt, MouseButton::Left, 1)
     }
 
-    /// Click with explicit options (button, count, modifiers, anchor).
+    /// Click with explicit options (button, count, held keys, anchor).
     ///
     /// `opts.anchor` is used only when `target` is an [`Element`]; for raw
     /// points it is ignored.
     pub fn click_with(&self, target: ClickTarget<'_>, opts: ClickOptions) -> Result<()> {
+        for k in &opts.held {
+            k.validate()?;
+        }
         let pt = match target {
             ClickTarget::Point(p) => p,
             ClickTarget::Element(el) => point_for(el, opts.anchor)?,
         };
-        with_modifiers(self.backend.as_ref(), &opts.modifiers, || {
+        with_keys_held(self.backend.as_ref(), &opts.held, || {
             self.backend.pointer_click(pt, opts.button, opts.count)
         })
     }
@@ -392,6 +487,16 @@ impl InputSim {
     pub fn right_click(&self, target: impl IntoPoint) -> Result<()> {
         let pt = target.into_point()?;
         self.backend.pointer_click(pt, MouseButton::Right, 1)
+    }
+
+    /// Press `button` at the current pointer location (no release).
+    pub fn down(&self, button: MouseButton) -> Result<()> {
+        self.backend.pointer_down(button)
+    }
+
+    /// Release `button` at the current pointer location.
+    pub fn up(&self, button: MouseButton) -> Result<()> {
+        self.backend.pointer_up(button)
     }
 
     /// Move the pointer to `target` without pressing any buttons.
@@ -416,9 +521,12 @@ impl InputSim {
         to: impl IntoPoint,
         opts: DragOptions,
     ) -> Result<()> {
+        for k in &opts.held {
+            k.validate()?;
+        }
         let from = from.into_point()?;
         let to = to.into_point()?;
-        with_modifiers(self.backend.as_ref(), &opts.modifiers, || {
+        with_keys_held(self.backend.as_ref(), &opts.held, || {
             self.backend
                 .pointer_drag(from, to, opts.button, opts.duration)
         })
@@ -429,49 +537,62 @@ impl InputSim {
         let pt = target.into_point()?;
         self.backend.pointer_scroll(pt, delta)
     }
+}
 
-    // ── Keyboard ────────────────────────────────────────────────────
+/// Keyboard operations. Obtain via [`InputSim::keyboard`].
+pub struct Keyboard<'a> {
+    backend: &'a Arc<dyn InputProvider>,
+}
 
-    /// Type literal text into whichever element currently has keyboard focus.
-    ///
-    /// `InputSim` does not focus the target for you — call the appropriate
-    /// accessibility action (e.g. `Element::focus` via the provider) first.
-    pub fn type_text(&self, text: &str) -> Result<()> {
-        self.backend.type_text(text)
-    }
-
-    /// Tap `key` (press + release) with no modifiers.
-    pub fn key(&self, key: Key) -> Result<()> {
+impl Keyboard<'_> {
+    /// Tap `key` (press + release) with no other keys held.
+    pub fn press(&self, key: Key) -> Result<()> {
+        key.validate()?;
         self.backend.key_tap(&key, &[])
     }
 
-    /// Tap `key` while `modifiers` are held.
+    /// Tap `key` while `held` are held down.
     ///
-    /// Example: `chord(Key::Char('a'), &[Modifier::Meta])` for select-all.
-    pub fn chord(&self, key: Key, modifiers: &[Modifier]) -> Result<()> {
-        self.backend.key_tap(&key, modifiers)
+    /// Modifiers are ordinary keys in this API — pass `Key::Shift`,
+    /// `Key::Ctrl`, `Key::Alt`, or `Key::Meta` via `held`.
+    ///
+    /// ```ignore
+    /// // Cmd/Ctrl+A:
+    /// keyboard.chord(Key::Char('a'), &[Key::Meta])?;
+    /// ```
+    pub fn chord(&self, key: Key, held: &[Key]) -> Result<()> {
+        key.validate()?;
+        for k in held {
+            k.validate()?;
+        }
+        self.backend.key_tap(&key, held)
     }
 
-    /// Press `key` without releasing. Pair with [`key_up`](Self::key_up).
-    pub fn key_down(&self, key: Key) -> Result<()> {
+    /// Press `key` without releasing. Pair with [`up`](Self::up).
+    pub fn down(&self, key: Key) -> Result<()> {
+        key.validate()?;
         self.backend.key_down(&key)
     }
 
     /// Release a previously pressed key.
-    pub fn key_up(&self, key: Key) -> Result<()> {
+    pub fn up(&self, key: Key) -> Result<()> {
+        key.validate()?;
         self.backend.key_up(&key)
     }
 
-    // ── Geometry helpers ────────────────────────────────────────────
-
-    /// Resolve an element's current bounds to a screen point using `anchor`.
-    /// Equivalent to the free function [`point_for`].
-    pub fn point_for(&self, element: &Element, anchor: Anchor) -> Result<Point> {
-        point_for(element, anchor)
+    /// Type literal text into whichever element currently has keyboard focus.
+    ///
+    /// `Keyboard` does not focus the target for you — call the appropriate
+    /// accessibility action (e.g. `Element::focus` via the provider) first.
+    ///
+    /// Unlike [`press`](Self::press), this accepts any text (including
+    /// uppercase and shifted symbols); backends handle the case/shift synthesis.
+    pub fn type_text(&self, text: &str) -> Result<()> {
+        self.backend.type_text(text)
     }
 }
 
-/// Explicit target for [`InputSim::click_with`]: either a raw point or an
+/// Explicit target for [`Mouse::click_with`]: either a raw point or an
 /// element to anchor against.
 pub enum ClickTarget<'a> {
     Point(Point),
@@ -486,7 +607,7 @@ impl From<Point> for ClickTarget<'_> {
 
 impl From<(i32, i32)> for ClickTarget<'_> {
     fn from(t: (i32, i32)) -> Self {
-        Self::Point(t.into())
+        Self::Point(Point::new(t.0, t.1))
     }
 }
 
@@ -496,20 +617,20 @@ impl<'a> From<&'a Element> for ClickTarget<'a> {
     }
 }
 
-/// Run `body` with each modifier in `mods` held down, releasing them all
-/// (in reverse order) before returning. Errors during release are returned
-/// only when `body` succeeded — a body failure takes precedence.
-fn with_modifiers<F>(backend: &dyn InputProvider, mods: &[Modifier], body: F) -> Result<()>
+/// Run `body` with each key in `keys` held down, releasing them all (in
+/// reverse order) before returning. Errors during release are returned only
+/// when `body` succeeded — a body failure takes precedence.
+fn with_keys_held<F>(backend: &dyn InputProvider, keys: &[Key], body: F) -> Result<()>
 where
     F: FnOnce() -> Result<()>,
 {
-    for m in mods {
-        backend.modifier_down(*m)?;
+    for k in keys {
+        backend.key_down(k)?;
     }
     let result = body();
     let mut release_err: Option<Error> = None;
-    for m in mods.iter().rev() {
-        if let Err(e) = backend.modifier_up(*m) {
+    for k in keys.iter().rev() {
+        if let Err(e) = backend.key_up(k) {
             // Keep the first release error so we can surface it if the body
             // succeeded; if the body already failed, the body error wins.
             if release_err.is_none() {

--- a/xa11y-core/src/input.rs
+++ b/xa11y-core/src/input.rs
@@ -1,0 +1,525 @@
+//! Input simulation: synthesised pointer and keyboard events.
+//!
+//! Input simulation is **separate from** the accessibility action layer
+//! ([`crate::Provider`], [`crate::Element`], [`crate::Locator`]). The two
+//! mechanisms are fundamentally different:
+//!
+//! - **Accessibility actions** (`element.press()`, `locator.toggle()`) call
+//!   the platform's a11y API directly. They work without the target window
+//!   being focused or visible, are deterministic, and are the preferred way
+//!   to drive a UI.
+//! - **Input simulation** ([`InputSim`]) generates OS-level pointer/keyboard
+//!   events at the system event layer. Use it only for interactions that have
+//!   no a11y equivalent (drag-and-drop, scroll wheels, complex shortcut
+//!   sequences). Most platforms require the target window to be foregrounded
+//!   and require additional permissions (Accessibility + Input Monitoring on
+//!   macOS, Wayland portal grants on Linux, etc.).
+//!
+//! There is **no implicit bridge** between the two: an accessibility-action
+//! failure never falls back to input simulation, and `InputSim` never inspects
+//! or auto-resolves the a11y tree on behalf of the caller. If you want to
+//! click an element, you compute its bounds (via the a11y API) and pass them
+//! in — see [`IntoPoint`] and [`InputSim::point_for`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::element::{Element, Rect};
+use crate::error::{Error, Result};
+
+// ── Geometry ────────────────────────────────────────────────────────
+
+/// A 2D point in screen coordinates.
+///
+/// Coordinates are integer screen pixels in the platform's native coordinate
+/// space. On macOS this is points (the OS handles HiDPI scaling for input
+/// events); on Windows and Linux this is physical pixels. Origin is top-left
+/// of the primary display; negative values are valid on multi-monitor setups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl Point {
+    pub const fn new(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<(i32, i32)> for Point {
+    fn from((x, y): (i32, i32)) -> Self {
+        Self { x, y }
+    }
+}
+
+/// Where on an element to land a pointer event.
+///
+/// All anchors are computed against the element's [`Rect`] *at the time of the
+/// input call*, not at element-fetch time — but only if the caller supplies a
+/// fresh element. `InputSim` will not re-traverse the a11y tree on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum Anchor {
+    #[default]
+    Center,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+    /// Pixel offset from the element's top-left corner.
+    Offset {
+        dx: i32,
+        dy: i32,
+    },
+}
+
+/// Compute a [`Point`] inside a [`Rect`] using the given [`Anchor`].
+pub fn anchor_point(rect: &Rect, anchor: Anchor) -> Point {
+    let (x, y, w, h) = (rect.x, rect.y, rect.width as i32, rect.height as i32);
+    match anchor {
+        Anchor::Center => Point::new(x + w / 2, y + h / 2),
+        Anchor::TopLeft => Point::new(x, y),
+        Anchor::TopRight => Point::new(x + w, y),
+        Anchor::BottomLeft => Point::new(x, y + h),
+        Anchor::BottomRight => Point::new(x + w, y + h),
+        Anchor::Offset { dx, dy } => Point::new(x + dx, y + dy),
+    }
+}
+
+/// Resolve an [`Element`]'s current bounds to a screen [`Point`] using `anchor`.
+///
+/// Reads `element.bounds`. Returns [`Error::NoElementBounds`] if the element
+/// has no bounds (e.g. an off-screen or virtual node).
+///
+/// **Staleness:** `Element` is a snapshot — its bounds were captured when the
+/// caller fetched it from the provider. If the UI may have moved since then,
+/// re-fetch the element first (e.g. via [`crate::Locator`]).
+pub fn point_for(element: &Element, anchor: Anchor) -> Result<Point> {
+    let bounds = element.bounds.ok_or(Error::NoElementBounds)?;
+    Ok(anchor_point(&bounds, anchor))
+}
+
+// ── Targets ─────────────────────────────────────────────────────────
+
+/// A target that can be lowered to a screen [`Point`].
+///
+/// Implemented for:
+/// - [`Point`] and `(i32, i32)` — used as-is.
+/// - `&`[`Element`] — uses the element's `bounds` field at the call site, with
+///   [`Anchor::Center`]. For a non-default anchor, call [`point_for`] yourself
+///   and pass the resulting `Point`.
+///
+/// Not implemented for [`crate::Locator`]: the caller must explicitly resolve
+/// the locator to an `Element` first. This keeps the cost of provider traffic
+/// (and the failure mode) visible at the call site.
+pub trait IntoPoint {
+    fn into_point(self) -> Result<Point>;
+}
+
+impl IntoPoint for Point {
+    fn into_point(self) -> Result<Point> {
+        Ok(self)
+    }
+}
+
+impl IntoPoint for (i32, i32) {
+    fn into_point(self) -> Result<Point> {
+        Ok(self.into())
+    }
+}
+
+impl IntoPoint for &Element {
+    fn into_point(self) -> Result<Point> {
+        point_for(self, Anchor::Center)
+    }
+}
+
+// ── Pointer ─────────────────────────────────────────────────────────
+
+/// A mouse button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum MouseButton {
+    #[default]
+    Left,
+    Right,
+    Middle,
+}
+
+/// Direction and magnitude of a scroll event, in platform "ticks" (typically
+/// one notch of a physical scroll wheel). Positive `dy` scrolls content
+/// downward (i.e. moves the viewport up); positive `dx` scrolls right.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct ScrollDelta {
+    pub dx: i32,
+    pub dy: i32,
+}
+
+impl ScrollDelta {
+    pub const fn new(dx: i32, dy: i32) -> Self {
+        Self { dx, dy }
+    }
+
+    pub const fn vertical(dy: i32) -> Self {
+        Self { dx: 0, dy }
+    }
+
+    pub const fn horizontal(dx: i32) -> Self {
+        Self { dx, dy: 0 }
+    }
+}
+
+// ── Keyboard ────────────────────────────────────────────────────────
+
+/// A keyboard modifier.
+///
+/// `Meta` is the platform's "command" modifier: Cmd on macOS, Win on Windows,
+/// Super on Linux. Use this when you want a portable shortcut; backends are
+/// responsible for the platform mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Modifier {
+    Shift,
+    Ctrl,
+    Alt,
+    Meta,
+}
+
+/// A single key for a press / release.
+///
+/// For typing arbitrary text (with IME support and correct shift handling),
+/// prefer [`InputSim::type_text`] over a sequence of `Key::Char` taps.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Key {
+    /// A printable character. Backends are responsible for any modifier
+    /// synthesis required to produce it (e.g. shift for `'A'`).
+    Char(char),
+
+    Enter,
+    Escape,
+    Backspace,
+    Tab,
+    Space,
+    Delete,
+    Insert,
+
+    ArrowUp,
+    ArrowDown,
+    ArrowLeft,
+    ArrowRight,
+
+    Home,
+    End,
+    PageUp,
+    PageDown,
+
+    /// A function key. `n` is 1-based (`F(1)` = F1).
+    F(u8),
+}
+
+// ── Click / drag option structs ─────────────────────────────────────
+
+/// Options for [`InputSim::click_with`].
+#[derive(Debug, Clone)]
+pub struct ClickOptions {
+    pub button: MouseButton,
+    /// Number of consecutive clicks (1 = single, 2 = double, …).
+    pub count: u32,
+    /// Modifiers held for the duration of the click.
+    pub modifiers: Vec<Modifier>,
+    /// Anchor used when the target is an [`Element`]. Ignored for raw points.
+    pub anchor: Anchor,
+}
+
+impl Default for ClickOptions {
+    fn default() -> Self {
+        Self {
+            button: MouseButton::Left,
+            count: 1,
+            modifiers: Vec::new(),
+            anchor: Anchor::Center,
+        }
+    }
+}
+
+/// Options for [`InputSim::drag_with`].
+#[derive(Debug, Clone)]
+pub struct DragOptions {
+    pub button: MouseButton,
+    pub modifiers: Vec<Modifier>,
+    /// Total time over which the drag is performed. Backends interpolate
+    /// pointer movement across this duration.
+    pub duration: Duration,
+}
+
+impl Default for DragOptions {
+    fn default() -> Self {
+        Self {
+            button: MouseButton::Left,
+            modifiers: Vec::new(),
+            duration: Duration::from_millis(150),
+        }
+    }
+}
+
+// ── Backend trait ───────────────────────────────────────────────────
+
+/// Platform backend trait for synthesised user input.
+///
+/// Implementors generate OS-level pointer and keyboard events. Each method
+/// corresponds to a single, low-level operation; the higher-level
+/// [`InputSim`] composes these into ergonomic actions.
+///
+/// **This trait is intentionally separate from [`crate::Provider`].** A
+/// backend that only knows how to read the accessibility tree should not
+/// implement `InputProvider`, and vice versa. Crates may implement both for
+/// the same platform but the two surfaces never call into each other.
+///
+/// # Errors
+///
+/// Implementations should return:
+/// - [`Error::PermissionDenied`] when the OS denies the synthesis permission.
+/// - [`Error::Unsupported`] when the operation has no platform implementation
+///   (e.g. pointer warp on a session that disallows it). Do **not** silently
+///   degrade — surface the missing capability per Tenet 1.
+/// - [`Error::Platform`] for raw OS failures.
+pub trait InputProvider: Send + Sync {
+    // ── Pointer ─────────────────────────────────────────────────────
+
+    /// Move the pointer to `to` without pressing any buttons.
+    fn pointer_move(&self, to: Point) -> Result<()>;
+
+    /// Press `button` at the current pointer location.
+    fn pointer_press(&self, button: MouseButton) -> Result<()>;
+
+    /// Release `button` at the current pointer location.
+    fn pointer_release(&self, button: MouseButton) -> Result<()>;
+
+    /// Click `button` at `at`, repeated `count` times. The backend is
+    /// responsible for honouring the OS double-click interval when `count > 1`.
+    fn pointer_click(&self, at: Point, button: MouseButton, count: u32) -> Result<()>;
+
+    /// Press `button` at `from`, move to `to` over `duration`, then release.
+    fn pointer_drag(
+        &self,
+        from: Point,
+        to: Point,
+        button: MouseButton,
+        duration: Duration,
+    ) -> Result<()>;
+
+    /// Scroll by `delta` ticks at `at`.
+    fn pointer_scroll(&self, at: Point, delta: ScrollDelta) -> Result<()>;
+
+    // ── Keyboard ────────────────────────────────────────────────────
+
+    /// Press `key` (no release).
+    fn key_down(&self, key: &Key) -> Result<()>;
+
+    /// Release `key`.
+    fn key_up(&self, key: &Key) -> Result<()>;
+
+    /// Press and release `key` while `modifiers` are held.
+    fn key_tap(&self, key: &Key, modifiers: &[Modifier]) -> Result<()>;
+
+    /// Type `text` as literal user input.
+    ///
+    /// Backends should prefer the OS's text-input path (with IME support)
+    /// over synthesising individual key presses where possible.
+    fn type_text(&self, text: &str) -> Result<()>;
+
+    // ── Modifier holds ──────────────────────────────────────────────
+
+    /// Press a modifier (without release). Pair with [`modifier_up`](Self::modifier_up).
+    fn modifier_down(&self, modifier: Modifier) -> Result<()>;
+
+    /// Release a previously pressed modifier.
+    fn modifier_up(&self, modifier: Modifier) -> Result<()>;
+}
+
+// ── Public façade ───────────────────────────────────────────────────
+
+/// Synthesises OS-level pointer and keyboard events.
+///
+/// `InputSim` is a thin façade over an [`InputProvider`] backend. Use it only
+/// when the accessibility action layer cannot express the interaction you
+/// need — see the [module docs](self) for the rationale.
+///
+/// `InputSim` is cheap to clone (it shares the backend via `Arc`).
+#[derive(Clone)]
+pub struct InputSim {
+    backend: Arc<dyn InputProvider>,
+}
+
+impl InputSim {
+    pub fn new(backend: Arc<dyn InputProvider>) -> Self {
+        Self { backend }
+    }
+
+    /// Get the backing provider for advanced or composite sequences.
+    pub fn backend(&self) -> &Arc<dyn InputProvider> {
+        &self.backend
+    }
+
+    // ── Pointer ─────────────────────────────────────────────────────
+
+    /// Left-click `target` once at its [`Anchor::Center`] (for elements) or
+    /// at the literal point.
+    pub fn click(&self, target: impl IntoPoint) -> Result<()> {
+        let pt = target.into_point()?;
+        self.backend.pointer_click(pt, MouseButton::Left, 1)
+    }
+
+    /// Click with explicit options (button, count, modifiers, anchor).
+    ///
+    /// `opts.anchor` is used only when `target` is an [`Element`]; for raw
+    /// points it is ignored.
+    pub fn click_with(&self, target: ClickTarget<'_>, opts: ClickOptions) -> Result<()> {
+        let pt = match target {
+            ClickTarget::Point(p) => p,
+            ClickTarget::Element(el) => point_for(el, opts.anchor)?,
+        };
+        with_modifiers(self.backend.as_ref(), &opts.modifiers, || {
+            self.backend.pointer_click(pt, opts.button, opts.count)
+        })
+    }
+
+    /// Convenience for a left double-click at `target`.
+    pub fn double_click(&self, target: impl IntoPoint) -> Result<()> {
+        let pt = target.into_point()?;
+        self.backend.pointer_click(pt, MouseButton::Left, 2)
+    }
+
+    /// Convenience for a right-click at `target`.
+    pub fn right_click(&self, target: impl IntoPoint) -> Result<()> {
+        let pt = target.into_point()?;
+        self.backend.pointer_click(pt, MouseButton::Right, 1)
+    }
+
+    /// Move the pointer to `target` without pressing any buttons.
+    pub fn move_to(&self, target: impl IntoPoint) -> Result<()> {
+        let pt = target.into_point()?;
+        self.backend.pointer_move(pt)
+    }
+
+    /// Press the left button at `from`, move to `to`, release. Default
+    /// duration: 150 ms. Use [`drag_with`](Self::drag_with) to customise.
+    pub fn drag(&self, from: impl IntoPoint, to: impl IntoPoint) -> Result<()> {
+        let from = from.into_point()?;
+        let to = to.into_point()?;
+        self.backend
+            .pointer_drag(from, to, MouseButton::Left, Duration::from_millis(150))
+    }
+
+    /// Drag with explicit options.
+    pub fn drag_with(
+        &self,
+        from: impl IntoPoint,
+        to: impl IntoPoint,
+        opts: DragOptions,
+    ) -> Result<()> {
+        let from = from.into_point()?;
+        let to = to.into_point()?;
+        with_modifiers(self.backend.as_ref(), &opts.modifiers, || {
+            self.backend
+                .pointer_drag(from, to, opts.button, opts.duration)
+        })
+    }
+
+    /// Scroll at `target` by `delta` ticks.
+    pub fn scroll(&self, target: impl IntoPoint, delta: ScrollDelta) -> Result<()> {
+        let pt = target.into_point()?;
+        self.backend.pointer_scroll(pt, delta)
+    }
+
+    // ── Keyboard ────────────────────────────────────────────────────
+
+    /// Type literal text into whichever element currently has keyboard focus.
+    ///
+    /// `InputSim` does not focus the target for you — call the appropriate
+    /// accessibility action (e.g. `Element::focus` via the provider) first.
+    pub fn type_text(&self, text: &str) -> Result<()> {
+        self.backend.type_text(text)
+    }
+
+    /// Tap `key` (press + release) with no modifiers.
+    pub fn key(&self, key: Key) -> Result<()> {
+        self.backend.key_tap(&key, &[])
+    }
+
+    /// Tap `key` while `modifiers` are held.
+    ///
+    /// Example: `chord(Key::Char('a'), &[Modifier::Meta])` for select-all.
+    pub fn chord(&self, key: Key, modifiers: &[Modifier]) -> Result<()> {
+        self.backend.key_tap(&key, modifiers)
+    }
+
+    /// Press `key` without releasing. Pair with [`key_up`](Self::key_up).
+    pub fn key_down(&self, key: Key) -> Result<()> {
+        self.backend.key_down(&key)
+    }
+
+    /// Release a previously pressed key.
+    pub fn key_up(&self, key: Key) -> Result<()> {
+        self.backend.key_up(&key)
+    }
+
+    // ── Geometry helpers ────────────────────────────────────────────
+
+    /// Resolve an element's current bounds to a screen point using `anchor`.
+    /// Equivalent to the free function [`point_for`].
+    pub fn point_for(&self, element: &Element, anchor: Anchor) -> Result<Point> {
+        point_for(element, anchor)
+    }
+}
+
+/// Explicit target for [`InputSim::click_with`]: either a raw point or an
+/// element to anchor against.
+pub enum ClickTarget<'a> {
+    Point(Point),
+    Element(&'a Element),
+}
+
+impl From<Point> for ClickTarget<'_> {
+    fn from(p: Point) -> Self {
+        Self::Point(p)
+    }
+}
+
+impl From<(i32, i32)> for ClickTarget<'_> {
+    fn from(t: (i32, i32)) -> Self {
+        Self::Point(t.into())
+    }
+}
+
+impl<'a> From<&'a Element> for ClickTarget<'a> {
+    fn from(el: &'a Element) -> Self {
+        Self::Element(el)
+    }
+}
+
+/// Run `body` with each modifier in `mods` held down, releasing them all
+/// (in reverse order) before returning. Errors during release are returned
+/// only when `body` succeeded — a body failure takes precedence.
+fn with_modifiers<F>(backend: &dyn InputProvider, mods: &[Modifier], body: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    for m in mods {
+        backend.modifier_down(*m)?;
+    }
+    let result = body();
+    let mut release_err: Option<Error> = None;
+    for m in mods.iter().rev() {
+        if let Err(e) = backend.modifier_up(*m) {
+            // Keep the first release error so we can surface it if the body
+            // succeeded; if the body already failed, the body error wins.
+            if release_err.is_none() {
+                release_err = Some(e);
+            }
+        }
+    }
+    match (result, release_err) {
+        (Err(e), _) => Err(e),
+        (Ok(()), Some(e)) => Err(e),
+        (Ok(()), None) => Ok(()),
+    }
+}

--- a/xa11y-core/src/input.rs
+++ b/xa11y-core/src/input.rs
@@ -319,9 +319,10 @@ impl Default for DragOptions {
 
 /// Platform backend trait for synthesised user input.
 ///
-/// Implementors generate OS-level pointer and keyboard events. Each method
-/// corresponds to a single, low-level operation; the higher-level
-/// [`InputSim`] composes these into ergonomic actions.
+/// Implementors generate OS-level pointer and keyboard events. Most methods
+/// correspond to a single low-level operation; a few (marked "provided") are
+/// synthesised by default but may be overridden when a platform has a
+/// higher-fidelity primitive.
 ///
 /// **This trait is intentionally separate from [`crate::Provider`].** A
 /// backend that only knows how to read the accessibility tree should not
@@ -337,7 +338,7 @@ impl Default for DragOptions {
 ///   degrade — surface the missing capability per Tenet 1.
 /// - [`Error::Platform`] for raw OS failures.
 pub trait InputProvider: Send + Sync {
-    // ── Pointer ─────────────────────────────────────────────────────
+    // ── Pointer (required) ──────────────────────────────────────────
 
     /// Move the pointer to `to` without pressing any buttons.
     fn pointer_move(&self, to: Point) -> Result<()>;
@@ -349,22 +350,15 @@ pub trait InputProvider: Send + Sync {
     fn pointer_up(&self, button: MouseButton) -> Result<()>;
 
     /// Click `button` at `at`, repeated `count` times. The backend is
-    /// responsible for honouring the OS double-click interval when `count > 1`.
+    /// responsible for honouring the OS double-click interval when
+    /// `count > 1` and for any platform-specific click-state bookkeeping
+    /// (e.g. `kCGMouseEventClickState` on macOS).
     fn pointer_click(&self, at: Point, button: MouseButton, count: u32) -> Result<()>;
-
-    /// Press `button` at `from`, move to `to` over `duration`, then release.
-    fn pointer_drag(
-        &self,
-        from: Point,
-        to: Point,
-        button: MouseButton,
-        duration: Duration,
-    ) -> Result<()>;
 
     /// Scroll by `delta` ticks at `at`.
     fn pointer_scroll(&self, at: Point, delta: ScrollDelta) -> Result<()>;
 
-    // ── Keyboard ────────────────────────────────────────────────────
+    // ── Keyboard (required) ─────────────────────────────────────────
 
     /// Press `key` (no release). Use [`key_up`](Self::key_up) to release.
     ///
@@ -374,14 +368,45 @@ pub trait InputProvider: Send + Sync {
     /// Release `key`.
     fn key_up(&self, key: &Key) -> Result<()>;
 
-    /// Press and release `key` while `held` are held down.
-    fn key_tap(&self, key: &Key, held: &[Key]) -> Result<()>;
-
     /// Type `text` as literal user input.
     ///
     /// Backends should prefer the OS's text-input path (with IME support)
     /// over synthesising individual key presses where possible.
     fn type_text(&self, text: &str) -> Result<()>;
+
+    // ── Pointer (provided, override for platform fidelity) ──────────
+
+    /// Press `button` at `from`, interpolate to `to` over `duration`, release.
+    ///
+    /// The default synthesis posts `pointer_down` → a series of `pointer_move`
+    /// calls (≈60 Hz cadence) → `pointer_up`. Backends **should override** to
+    /// emit platform-specific drag events where they differ from move events
+    /// — on macOS, drag-and-drop source apps filter for
+    /// `kCGEventLeftMouseDragged`, which is distinct from
+    /// `kCGEventMouseMoved`. On Windows and X11 the default synthesis is
+    /// usually sufficient.
+    fn pointer_drag(
+        &self,
+        from: Point,
+        to: Point,
+        button: MouseButton,
+        duration: Duration,
+    ) -> Result<()> {
+        const STEP: Duration = Duration::from_millis(16);
+        self.pointer_move(from)?;
+        self.pointer_down(button)?;
+        let steps = (duration.as_millis() / STEP.as_millis().max(1)).max(1) as i32;
+        for i in 1..=steps {
+            let t = i as f64 / steps as f64;
+            let x = from.x + ((to.x - from.x) as f64 * t).round() as i32;
+            let y = from.y + ((to.y - from.y) as f64 * t).round() as i32;
+            self.pointer_move(Point::new(x, y))?;
+            if i < steps {
+                std::thread::sleep(STEP);
+            }
+        }
+        self.pointer_up(button)
+    }
 }
 
 // ── Public façade ───────────────────────────────────────────────────
@@ -548,7 +573,8 @@ impl Keyboard<'_> {
     /// Tap `key` (press + release) with no other keys held.
     pub fn press(&self, key: Key) -> Result<()> {
         key.validate()?;
-        self.backend.key_tap(&key, &[])
+        self.backend.key_down(&key)?;
+        self.backend.key_up(&key)
     }
 
     /// Tap `key` while `held` are held down.
@@ -565,7 +591,10 @@ impl Keyboard<'_> {
         for k in held {
             k.validate()?;
         }
-        self.backend.key_tap(&key, held)
+        with_keys_held(self.backend.as_ref(), held, || {
+            self.backend.key_down(&key)?;
+            self.backend.key_up(&key)
+        })
     }
 
     /// Press `key` without releasing. Pair with [`up`](Self::up).

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod element;
 pub mod error;
 pub mod event;
 pub mod event_provider;
+pub mod input;
 pub mod locator;
 pub mod provider;
 pub mod role;
@@ -21,6 +22,10 @@ pub use element::{Element, ElementData, RawPlatformData, Rect, StateSet, Toggled
 pub use error::{Error, Result};
 pub use event::{ElementState, Event, EventKind, StateFlag};
 pub use event_provider::{CancelHandle, EventReceiver, RecvStatus, Subscription, SubscriptionIter};
+pub use input::{
+    anchor_point, point_for, Anchor, ClickOptions, ClickTarget, DragOptions, InputProvider,
+    InputSim, IntoPoint, Key, Modifier, MouseButton, Point, ScrollDelta,
+};
 pub use locator::Locator;
 pub use provider::Provider;
 pub use role::{unknown_role, Role};

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -24,7 +24,7 @@ pub use event::{ElementState, Event, EventKind, StateFlag};
 pub use event_provider::{CancelHandle, EventReceiver, RecvStatus, Subscription, SubscriptionIter};
 pub use input::{
     anchor_point, point_for, Anchor, ClickOptions, ClickTarget, DragOptions, InputProvider,
-    InputSim, IntoPoint, Key, Modifier, MouseButton, Point, ScrollDelta,
+    InputSim, IntoPoint, Key, Keyboard, Mouse, MouseButton, Point, ScrollDelta,
 };
 pub use locator::Locator;
 pub use provider::Provider;

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod input;
 pub mod locator;
 pub mod provider;
 pub mod role;
+pub mod screenshot;
 pub mod selector;
 
 /// Shared in-memory mock Provider. Gated behind `test-support` so only the
@@ -29,6 +30,7 @@ pub use input::{
 pub use locator::Locator;
 pub use provider::Provider;
 pub use role::{unknown_role, Role};
+pub use screenshot::{Screenshot, ScreenshotProvider, Screenshotter};
 pub use selector::Selector;
 
 /// Maximum tree traversal depth for providers. Prevents stack overflow from

--- a/xa11y-core/src/screenshot.rs
+++ b/xa11y-core/src/screenshot.rs
@@ -1,0 +1,156 @@
+//! Screenshot capture: pixel-level snapshots of the screen or a region.
+//!
+//! Screenshot is **separate from** both the accessibility action layer
+//! ([`crate::Provider`]) and the input-synthesis layer ([`crate::InputProvider`]).
+//! Backends that only capture pixels do not know how to read the a11y tree,
+//! synthesise input, or raise/activate windows — they are pure pixel readers.
+//!
+//! # What you get
+//!
+//! [`Screenshotter`] returns a [`Screenshot`] carrying raw RGBA8 pixels in
+//! **physical** (device) pixels — the same resolution the compositor renders
+//! at. On HiDPI displays that means pixel dimensions exceed the logical bounds
+//! you passed in; [`Screenshot::scale`] records the ratio. Call
+//! [`Screenshot::to_png`] or [`Screenshot::save_png`] to encode.
+//!
+//! # No auto-raise
+//!
+//! Capturing an element that is occluded or off-screen returns whatever pixels
+//! are at those coordinates — the target window is **not** raised or
+//! activated. If you need the element in the foreground, do that explicitly
+//! before calling [`Screenshotter::capture_element`].
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::element::{Element, Rect};
+use crate::error::{Error, Result};
+
+/// Platform backend trait for screen capture.
+///
+/// Implementors snapshot pixels from a display or a sub-region. They must
+/// return **physical** (device) pixels — never downscaled to logical points —
+/// and report the scale factor alongside the pixel buffer.
+///
+/// # Errors
+///
+/// - [`Error::PermissionDenied`] when the OS denies the capture permission
+///   (e.g. macOS Screen Recording).
+/// - [`Error::Unsupported`] when the current session has no capture path
+///   (e.g. Linux with neither X11 DISPLAY nor a working Wayland portal).
+/// - [`Error::Platform`] for raw OS / FFI failures.
+pub trait ScreenshotProvider: Send + Sync {
+    /// Capture the primary display in full.
+    fn capture_full(&self) -> Result<Screenshot>;
+
+    /// Capture a sub-rectangle specified in logical screen coordinates
+    /// (the same coordinate space as [`Rect`] in `Element::bounds`).
+    fn capture_region(&self, rect: Rect) -> Result<Screenshot>;
+}
+
+/// A captured image: raw RGBA8 pixels plus dimensions and scale.
+///
+/// `width` and `height` are in **physical** pixels. `scale` is the ratio of
+/// physical to logical (1.0 on standard displays, 2.0 on typical Retina /
+/// 1.5/1.75/2.0 on common Windows/Linux HiDPI configurations). `pixels.len()`
+/// equals `width * height * 4`.
+#[derive(Debug, Clone)]
+pub struct Screenshot {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+    pub scale: f32,
+}
+
+impl Screenshot {
+    /// Encode as PNG and return the bytes.
+    pub fn to_png(&self) -> Result<Vec<u8>> {
+        let expected = (self.width as usize)
+            .checked_mul(self.height as usize)
+            .and_then(|n| n.checked_mul(4))
+            .ok_or_else(|| Error::Platform {
+                code: -1,
+                message: "screenshot dimensions overflow".into(),
+            })?;
+        if self.pixels.len() != expected {
+            return Err(Error::Platform {
+                code: -1,
+                message: format!(
+                    "screenshot pixel buffer size {} does not match {}x{} RGBA ({} bytes)",
+                    self.pixels.len(),
+                    self.width,
+                    self.height,
+                    expected
+                ),
+            });
+        }
+
+        let mut out = Vec::new();
+        {
+            let mut encoder = png::Encoder::new(&mut out, self.width, self.height);
+            encoder.set_color(png::ColorType::Rgba);
+            encoder.set_depth(png::BitDepth::Eight);
+            let mut writer = encoder.write_header().map_err(png_err)?;
+            writer.write_image_data(&self.pixels).map_err(png_err)?;
+        }
+        Ok(out)
+    }
+
+    /// Encode as PNG and write to `path`.
+    pub fn save_png(&self, path: impl AsRef<Path>) -> Result<()> {
+        let bytes = self.to_png()?;
+        std::fs::write(path, bytes).map_err(|e| Error::Platform {
+            code: e.raw_os_error().unwrap_or(-1) as i64,
+            message: format!("save_png: {e}"),
+        })
+    }
+}
+
+fn png_err(e: png::EncodingError) -> Error {
+    Error::Platform {
+        code: -1,
+        message: format!("png encode: {e}"),
+    }
+}
+
+/// Handle for capturing screenshots. Cheap to clone — shares a single backend.
+#[derive(Clone)]
+pub struct Screenshotter {
+    backend: Arc<dyn ScreenshotProvider>,
+}
+
+impl Screenshotter {
+    pub fn new(backend: Arc<dyn ScreenshotProvider>) -> Self {
+        Self { backend }
+    }
+
+    /// Access the underlying provider for composite sequences.
+    pub fn backend(&self) -> &Arc<dyn ScreenshotProvider> {
+        &self.backend
+    }
+
+    /// Capture the full primary display.
+    pub fn capture(&self) -> Result<Screenshot> {
+        self.backend.capture_full()
+    }
+
+    /// Capture an explicit sub-rectangle of the screen.
+    pub fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
+        self.backend.capture_region(rect)
+    }
+
+    /// Capture the pixels under an element's current bounds.
+    ///
+    /// Returns [`Error::NoElementBounds`] if the element reports no bounds.
+    /// The target window is **not** raised or activated — see module docs.
+    pub fn capture_element(&self, element: &Element) -> Result<Screenshot> {
+        let rect = element.bounds.ok_or(Error::NoElementBounds)?;
+        self.backend.capture_region(rect)
+    }
+}
+
+impl std::fmt::Debug for Screenshotter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Screenshotter").finish_non_exhaustive()
+    }
+}

--- a/xa11y-js/Cargo.lock
+++ b/xa11y-js/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -225,6 +237,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -359,10 +380,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -611,13 +651,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "napi"
 version = "3.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb7848c221fb7bb789e02f01875287ebb1e078b92a6566a34de01ef8806e7c2b"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "ctor",
  "futures",
  "napi-build",
@@ -717,6 +767,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,7 +868,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -893,6 +956,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1166,7 +1235,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1367,7 +1436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -1429,6 +1498,7 @@ dependencies = [
 name = "xa11y-core"
 version = "0.6.2"
 dependencies = [
+ "png",
  "serde",
  "serde_json",
  "strum",
@@ -1450,6 +1520,7 @@ dependencies = [
 name = "xa11y-linux"
 version = "0.6.2"
 dependencies = [
+ "png",
  "rayon",
  "serde_json",
  "x11rb",

--- a/xa11y-js/Cargo.lock
+++ b/xa11y-js/Cargo.lock
@@ -472,6 +472,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1398,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xa11y"
 version = "0.6.2"
 dependencies = [
@@ -1425,6 +1452,7 @@ version = "0.6.2"
 dependencies = [
  "rayon",
  "serde_json",
+ "x11rb",
  "xa11y-core",
  "zbus",
 ]

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -102,6 +102,8 @@ const CODE_TO_CLASS = {
   XA11Y_INVALID_SELECTOR: InvalidSelectorError,
   XA11Y_INVALID_ACTION_DATA: InvalidActionDataError,
   XA11Y_PLATFORM: PlatformError,
+  XA11Y_NO_ELEMENT_BOUNDS: InvalidActionDataError,
+  XA11Y_UNSUPPORTED: ActionNotSupportedError,
 };
 
 /** Convert any thrown value into a typed xa11y error if it carries our tag. */

--- a/xa11y-js/src/errors.rs
+++ b/xa11y-js/src/errors.rs
@@ -18,6 +18,8 @@ pub mod codes {
     pub const INVALID_SELECTOR: &str = "XA11Y_INVALID_SELECTOR";
     pub const INVALID_ACTION_DATA: &str = "XA11Y_INVALID_ACTION_DATA";
     pub const PLATFORM: &str = "XA11Y_PLATFORM";
+    pub const NO_ELEMENT_BOUNDS: &str = "XA11Y_NO_ELEMENT_BOUNDS";
+    pub const UNSUPPORTED: &str = "XA11Y_UNSUPPORTED";
 }
 
 /// Convert an `xa11y::Error` into a `napi::Error`. The `reason` field doubles
@@ -60,6 +62,13 @@ pub fn map_err(e: xa11y::Error) -> Error {
             codes::PLATFORM,
             format!("Platform error ({code}): {message}"),
         ),
+        xa11y::Error::NoElementBounds => (
+            codes::NO_ELEMENT_BOUNDS,
+            "Element has no bounds; cannot compute a screen point".to_string(),
+        ),
+        xa11y::Error::Unsupported { feature } => {
+            (codes::UNSUPPORTED, format!("Unsupported: {feature}"))
+        }
     };
 
     // Encode the tag at the start of the message so the JS wrapper can split

--- a/xa11y-linux/Cargo.toml
+++ b/xa11y-linux/Cargo.toml
@@ -13,3 +13,10 @@ serde_json = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 rayon = "1"
 zbus = { version = "5", default-features = false, features = ["async-io", "blocking-api"] }
+# X11 + XTest for the input-simulation backend. Wayland is intentionally not
+# supported at this layer (callers get Error::Unsupported); libei/portal can
+# be added later behind a feature.
+x11rb = { version = "0.13", default-features = false, features = ["xtest"] }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+x11rb = { version = "0.13", default-features = false }

--- a/xa11y-linux/Cargo.toml
+++ b/xa11y-linux/Cargo.toml
@@ -11,6 +11,7 @@ xa11y-core = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+png = "0.17"
 rayon = "1"
 zbus = { version = "5", default-features = false, features = ["async-io", "blocking-api"] }
 # X11 + XTest for the input-simulation backend. Wayland is intentionally not

--- a/xa11y-linux/src/input.rs
+++ b/xa11y-linux/src/input.rs
@@ -1,0 +1,358 @@
+//! Linux input-simulation backend using X11 + XTEST.
+//!
+//! Connects to the X server on construction and drives the XTest extension
+//! (`fake_input`) for pointer motion, button events, scroll, and keyboard.
+//!
+//! **Wayland is not supported** at this layer. If `WAYLAND_DISPLAY` is set and
+//! `DISPLAY` is not, [`LinuxInputProvider::new`] returns [`Error::Unsupported`]
+//! — per Tenet 1 we refuse to fall back silently. A future backend based on
+//! `libei` / `org.freedesktop.portal.RemoteDesktop` can be added behind a
+//! feature flag.
+//!
+//! Key mapping goes keysym → keycode via `GetKeyboardMapping`, which we query
+//! once at connect time and re-query when the server notifies us of a layout
+//! change. `Key::Char` for printable ASCII uses the codepoint as its keysym;
+//! [`Keyboard::type_text`](xa11y_core::input::Keyboard::type_text) looks up
+//! each character in the same keymap table and holds Shift when it appears in
+//! the shifted column.
+
+use std::sync::{Mutex, RwLock};
+
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+    ConnectionExt as _, GetKeyboardMappingReply, Keycode, Screen, Window, BUTTON_PRESS_EVENT,
+    BUTTON_RELEASE_EVENT, KEY_PRESS_EVENT, KEY_RELEASE_EVENT, MOTION_NOTIFY_EVENT,
+};
+use x11rb::protocol::xtest::ConnectionExt as _;
+use x11rb::rust_connection::RustConnection;
+
+use xa11y_core::input::{InputProvider, Key, MouseButton, Point, ScrollDelta};
+use xa11y_core::{Error, Result};
+
+// X11 keysyms — lifted from /usr/include/X11/keysymdef.h. Only the keysyms
+// named by [`Key`] plus the modifiers we need to hold for shifted text.
+const XK_SHIFT_L: u32 = 0xffe1;
+const XK_CONTROL_L: u32 = 0xffe3;
+const XK_ALT_L: u32 = 0xffe9;
+const XK_SUPER_L: u32 = 0xffeb;
+const XK_RETURN: u32 = 0xff0d;
+const XK_ESCAPE: u32 = 0xff1b;
+const XK_BACKSPACE: u32 = 0xff08;
+const XK_TAB: u32 = 0xff09;
+const XK_DELETE: u32 = 0xffff;
+const XK_INSERT: u32 = 0xff63;
+const XK_UP: u32 = 0xff52;
+const XK_DOWN: u32 = 0xff54;
+const XK_LEFT: u32 = 0xff51;
+const XK_RIGHT: u32 = 0xff53;
+const XK_HOME: u32 = 0xff50;
+const XK_END: u32 = 0xff57;
+const XK_PAGE_UP: u32 = 0xff55;
+const XK_PAGE_DOWN: u32 = 0xff56;
+const XK_F1: u32 = 0xffbe;
+// XK_F24 = 0xffd5; 1..=24 is contiguous starting at XK_F1.
+
+/// Keymap snapshot built from `GetKeyboardMapping`. For each keysym we care
+/// about we store the keycode plus whether it lives in the shifted column
+/// (column 1) rather than the unshifted column (column 0).
+struct Keymap {
+    min_keycode: u8,
+    syms_per_code: u8,
+    syms: Vec<u32>,
+}
+
+impl Keymap {
+    fn from_reply(reply: GetKeyboardMappingReply, min_keycode: u8) -> Self {
+        Self {
+            min_keycode,
+            syms_per_code: reply.keysyms_per_keycode,
+            syms: reply.keysyms,
+        }
+    }
+
+    /// Locate a keysym in the map. Returns `(keycode, needs_shift)` — the
+    /// caller must hold Shift iff `needs_shift` is true.
+    fn lookup(&self, keysym: u32) -> Option<(Keycode, bool)> {
+        let per = self.syms_per_code as usize;
+        if per == 0 {
+            return None;
+        }
+        for (code_index, chunk) in self.syms.chunks(per).enumerate() {
+            // Column 0 is the unshifted level, column 1 the shifted level.
+            // Some keys repeat the column-0 keysym into column 1 when there
+            // is no shifted binding; that's fine — either lookup succeeds.
+            if chunk.first() == Some(&keysym) {
+                return Some((self.min_keycode + code_index as u8, false));
+            }
+            if per >= 2 && chunk.get(1) == Some(&keysym) {
+                return Some((self.min_keycode + code_index as u8, true));
+            }
+        }
+        None
+    }
+}
+
+/// XTest-backed [`InputProvider`].
+pub struct LinuxInputProvider {
+    /// Connection is `!Sync`; guard all server traffic with the mutex.
+    conn: Mutex<RustConnection>,
+    root: Window,
+    keymap: RwLock<Keymap>,
+}
+
+impl LinuxInputProvider {
+    /// Connect to `$DISPLAY` and initialise XTest state.
+    ///
+    /// Returns [`Error::Unsupported`] if the session is Wayland-only
+    /// (`WAYLAND_DISPLAY` is set and `DISPLAY` is not). Returns
+    /// [`Error::Platform`] for any X protocol / connection failure.
+    pub fn new() -> Result<Self> {
+        let display_set = std::env::var_os("DISPLAY").is_some();
+        let wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+        if !display_set {
+            let feature = if wayland {
+                "input simulation on Wayland (X11 DISPLAY not set)".to_string()
+            } else {
+                "input simulation (no X11 DISPLAY)".to_string()
+            };
+            return Err(Error::Unsupported { feature });
+        }
+
+        let (conn, screen_num) = RustConnection::connect(None).map_err(platform)?;
+        let setup = conn.setup().clone();
+        let screen: &Screen = setup
+            .roots
+            .get(screen_num)
+            .ok_or_else(|| platform_msg("X server reported no screens"))?;
+        let root = screen.root;
+
+        let min_keycode = setup.min_keycode;
+        let max_keycode = setup.max_keycode;
+        if max_keycode < min_keycode {
+            return Err(platform_msg("X server reported an empty keycode range"));
+        }
+        let count = max_keycode - min_keycode + 1;
+        let reply = conn
+            .get_keyboard_mapping(min_keycode, count)
+            .map_err(platform)?
+            .reply()
+            .map_err(platform)?;
+        let keymap = Keymap::from_reply(reply, min_keycode);
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+            root,
+            keymap: RwLock::new(keymap),
+        })
+    }
+
+    fn with_conn<F, R>(&self, f: F) -> Result<R>
+    where
+        F: FnOnce(&RustConnection) -> Result<R>,
+    {
+        let guard = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        f(&guard)
+    }
+
+    fn send(&self, type_: u8, detail: u8, x: i16, y: i16) -> Result<()> {
+        self.with_conn(|conn| {
+            conn.xtest_fake_input(type_, detail, 0, self.root, x, y, 0)
+                .map_err(platform)?
+                .check()
+                .map_err(platform)?;
+            conn.flush().map_err(platform)?;
+            Ok(())
+        })
+    }
+
+    fn key_event(&self, keysym: u32, press: bool) -> Result<()> {
+        let (keycode, _shift) = {
+            let map = self.keymap.read().unwrap_or_else(|e| e.into_inner());
+            map.lookup(keysym).ok_or_else(|| Error::Unsupported {
+                feature: format!("keysym 0x{keysym:04x} has no keycode in the current X layout"),
+            })?
+        };
+        let type_ = if press {
+            KEY_PRESS_EVENT
+        } else {
+            KEY_RELEASE_EVENT
+        };
+        self.send(type_, keycode, 0, 0)
+    }
+
+    fn button_event(&self, button: u8, press: bool) -> Result<()> {
+        let type_ = if press {
+            BUTTON_PRESS_EVENT
+        } else {
+            BUTTON_RELEASE_EVENT
+        };
+        self.send(type_, button, 0, 0)
+    }
+
+    /// Resolve a [`Key`] to its X11 keysym, returning
+    /// [`Error::InvalidActionData`] for out-of-range `Key::F(n)`.
+    fn keysym_for(&self, key: &Key) -> Result<u32> {
+        let keysym = match key {
+            Key::Shift => XK_SHIFT_L,
+            Key::Ctrl => XK_CONTROL_L,
+            Key::Alt => XK_ALT_L,
+            Key::Meta => XK_SUPER_L,
+            Key::Enter => XK_RETURN,
+            Key::Escape => XK_ESCAPE,
+            Key::Backspace => XK_BACKSPACE,
+            Key::Tab => XK_TAB,
+            Key::Space => 0x0020,
+            Key::Delete => XK_DELETE,
+            Key::Insert => XK_INSERT,
+            Key::ArrowUp => XK_UP,
+            Key::ArrowDown => XK_DOWN,
+            Key::ArrowLeft => XK_LEFT,
+            Key::ArrowRight => XK_RIGHT,
+            Key::Home => XK_HOME,
+            Key::End => XK_END,
+            Key::PageUp => XK_PAGE_UP,
+            Key::PageDown => XK_PAGE_DOWN,
+            Key::F(n) => {
+                if *n < 1 || *n > 24 {
+                    return Err(Error::InvalidActionData {
+                        message: format!("F{n} is out of range (1..=24)"),
+                    });
+                }
+                XK_F1 + (*n as u32 - 1)
+            }
+            Key::Char(c) => char_keysym(*c),
+        };
+        Ok(keysym)
+    }
+}
+
+/// Convert a character to its X11 keysym. ASCII 0x20..=0x7e maps directly;
+/// everything above uses the Unicode plane (`0x01000000 | codepoint`).
+fn char_keysym(c: char) -> u32 {
+    let cp = c as u32;
+    if (0x20..=0x7e).contains(&cp) {
+        cp
+    } else {
+        0x0100_0000 | cp
+    }
+}
+
+fn platform<E: std::fmt::Display>(e: E) -> Error {
+    Error::Platform {
+        code: -1,
+        message: e.to_string(),
+    }
+}
+
+fn platform_msg(msg: &str) -> Error {
+    Error::Platform {
+        code: -1,
+        message: msg.to_string(),
+    }
+}
+
+/// Clamp an `i32` screen coordinate into the `i16` range that XTest takes.
+/// X11 coordinates are 16-bit; this matches how libX11 itself narrows them.
+fn clamp_coord(v: i32) -> i16 {
+    v.clamp(i16::MIN as i32, i16::MAX as i32) as i16
+}
+
+impl InputProvider for LinuxInputProvider {
+    fn pointer_move(&self, to: Point) -> Result<()> {
+        // detail=0 on MOTION_NOTIFY means absolute coordinates relative to root.
+        self.send(MOTION_NOTIFY_EVENT, 0, clamp_coord(to.x), clamp_coord(to.y))
+    }
+
+    fn pointer_down(&self, button: MouseButton) -> Result<()> {
+        self.button_event(button_number(button), true)
+    }
+
+    fn pointer_up(&self, button: MouseButton) -> Result<()> {
+        self.button_event(button_number(button), false)
+    }
+
+    fn pointer_click(&self, at: Point, button: MouseButton, count: u32) -> Result<()> {
+        if count == 0 {
+            return Ok(());
+        }
+        self.pointer_move(at)?;
+        let btn = button_number(button);
+        for _ in 0..count {
+            self.button_event(btn, true)?;
+            self.button_event(btn, false)?;
+        }
+        Ok(())
+    }
+
+    fn pointer_scroll(&self, at: Point, delta: ScrollDelta) -> Result<()> {
+        self.pointer_move(at)?;
+        // X11 scroll-wheel convention: button 4 = up, 5 = down, 6 = left, 7 = right.
+        // The input-sim contract: positive dy scrolls content down (viewport
+        // up), which is the "wheel rolled toward the user" direction — that's
+        // button 5 on X11. Matches Windows' positive-delta / scroll-down
+        // mapping implicitly the other way around, but "positive dy moves
+        // content down" is the doc'd invariant.
+        for _ in 0..delta.dy.abs() {
+            let btn = if delta.dy > 0 { 5 } else { 4 };
+            self.button_event(btn, true)?;
+            self.button_event(btn, false)?;
+        }
+        for _ in 0..delta.dx.abs() {
+            let btn = if delta.dx > 0 { 7 } else { 6 };
+            self.button_event(btn, true)?;
+            self.button_event(btn, false)?;
+        }
+        Ok(())
+    }
+
+    fn key_down(&self, key: &Key) -> Result<()> {
+        let keysym = self.keysym_for(key)?;
+        self.key_event(keysym, true)
+    }
+
+    fn key_up(&self, key: &Key) -> Result<()> {
+        let keysym = self.keysym_for(key)?;
+        self.key_event(keysym, false)
+    }
+
+    fn type_text(&self, text: &str) -> Result<()> {
+        // For each character, look up its keysym; if the keymap has it in the
+        // shifted column, hold Shift for that press. This is the X11 analogue
+        // of the KEYEVENTF_UNICODE path on Windows — both aim to be robust
+        // against the active keyboard layout.
+        for c in text.chars() {
+            let keysym = char_keysym(c);
+            let (keycode, needs_shift) = {
+                let map = self.keymap.read().unwrap_or_else(|e| e.into_inner());
+                match map.lookup(keysym) {
+                    Some(v) => v,
+                    None => {
+                        return Err(Error::Unsupported {
+                            feature: format!(
+                                "character '{c}' (keysym 0x{keysym:04x}) has no keycode \
+                                 in the current X keyboard layout"
+                            ),
+                        });
+                    }
+                }
+            };
+            if needs_shift {
+                self.key_event(XK_SHIFT_L, true)?;
+            }
+            self.send(KEY_PRESS_EVENT, keycode, 0, 0)?;
+            self.send(KEY_RELEASE_EVENT, keycode, 0, 0)?;
+            if needs_shift {
+                self.key_event(XK_SHIFT_L, false)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn button_number(button: MouseButton) -> u8 {
+    match button {
+        MouseButton::Left => 1,
+        MouseButton::Middle => 2,
+        MouseButton::Right => 3,
+    }
+}

--- a/xa11y-linux/src/lib.rs
+++ b/xa11y-linux/src/lib.rs
@@ -13,13 +13,19 @@ mod events;
 mod input;
 
 #[cfg(target_os = "linux")]
+mod screenshot;
+
+#[cfg(target_os = "linux")]
 pub use atspi::LinuxProvider;
 
 #[cfg(target_os = "linux")]
 pub use input::LinuxInputProvider;
 
+#[cfg(target_os = "linux")]
+pub use screenshot::LinuxScreenshot;
+
 #[cfg(not(target_os = "linux"))]
 mod stub;
 
 #[cfg(not(target_os = "linux"))]
-pub use stub::{LinuxInputProvider, LinuxProvider};
+pub use stub::{LinuxInputProvider, LinuxProvider, LinuxScreenshot};

--- a/xa11y-linux/src/lib.rs
+++ b/xa11y-linux/src/lib.rs
@@ -10,10 +10,16 @@ mod atspi;
 mod events;
 
 #[cfg(target_os = "linux")]
+mod input;
+
+#[cfg(target_os = "linux")]
 pub use atspi::LinuxProvider;
+
+#[cfg(target_os = "linux")]
+pub use input::LinuxInputProvider;
 
 #[cfg(not(target_os = "linux"))]
 mod stub;
 
 #[cfg(not(target_os = "linux"))]
-pub use stub::LinuxProvider;
+pub use stub::{LinuxInputProvider, LinuxProvider};

--- a/xa11y-linux/src/screenshot.rs
+++ b/xa11y-linux/src/screenshot.rs
@@ -1,0 +1,350 @@
+//! Linux screen capture. X11 path uses `GetImage` on the root window; Wayland
+//! path uses `org.freedesktop.portal.Screenshot` (PNG file URI returned by
+//! xdg-desktop-portal, decoded back into RGBA).
+//!
+//! Wayland portal capture **prompts the user** for consent the first time per
+//! session (subsequent calls may be auto-approved depending on the portal
+//! implementation) and captures the full screen only — regions are cropped
+//! client-side from the full capture.
+//!
+//! Scale factor is reported as 1.0 on both paths: X11 has no canonical way to
+//! read the user's HiDPI scale from the wire protocol (it's in Xft.dpi / XRDB
+//! or the compositor), and the portal returns already-composited pixels.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{ConnectionExt as _, ImageFormat};
+use x11rb::rust_connection::RustConnection;
+use zbus::blocking::Connection as ZbusConnection;
+use zbus::blocking::Proxy;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
+
+use xa11y_core::{Error, Rect, Result, Screenshot, ScreenshotProvider};
+
+/// Choose the Linux screenshot backend based on session environment.
+pub struct LinuxScreenshot {
+    backend: Backend,
+}
+
+enum Backend {
+    X11 {
+        conn: Mutex<RustConnection>,
+        root_width: u16,
+        root_height: u16,
+        root: u32,
+    },
+    Wayland {
+        conn: ZbusConnection,
+    },
+}
+
+impl LinuxScreenshot {
+    pub fn new() -> Result<Self> {
+        let display_set = std::env::var_os("DISPLAY").is_some();
+        let wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+
+        if display_set {
+            let (conn, screen_num) =
+                RustConnection::connect(None).map_err(|e| Error::Platform {
+                    code: -1,
+                    message: format!("X11 connect: {e}"),
+                })?;
+            let screen = conn
+                .setup()
+                .roots
+                .get(screen_num)
+                .ok_or_else(|| Error::Platform {
+                    code: -1,
+                    message: "X server reported no screens".into(),
+                })?;
+            let root = screen.root;
+            let root_width = screen.width_in_pixels;
+            let root_height = screen.height_in_pixels;
+            Ok(Self {
+                backend: Backend::X11 {
+                    conn: Mutex::new(conn),
+                    root,
+                    root_width,
+                    root_height,
+                },
+            })
+        } else if wayland {
+            let conn = ZbusConnection::session().map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("session bus connect: {e}"),
+            })?;
+            Ok(Self {
+                backend: Backend::Wayland { conn },
+            })
+        } else {
+            Err(Error::Unsupported {
+                feature: "screenshot (no DISPLAY or WAYLAND_DISPLAY set)".into(),
+            })
+        }
+    }
+
+    fn capture_x11(
+        &self,
+        conn: &Mutex<RustConnection>,
+        root: u32,
+        root_w: u16,
+        root_h: u16,
+        rect: Option<Rect>,
+    ) -> Result<Screenshot> {
+        let (x, y, w, h) = match rect {
+            None => (0_i16, 0_i16, root_w, root_h),
+            Some(r) => {
+                let x = i16::try_from(r.x).map_err(|_| Error::Platform {
+                    code: -1,
+                    message: "rect x out of i16 range".into(),
+                })?;
+                let y = i16::try_from(r.y).map_err(|_| Error::Platform {
+                    code: -1,
+                    message: "rect y out of i16 range".into(),
+                })?;
+                let w = u16::try_from(r.width).map_err(|_| Error::Platform {
+                    code: -1,
+                    message: "rect width out of u16 range".into(),
+                })?;
+                let h = u16::try_from(r.height).map_err(|_| Error::Platform {
+                    code: -1,
+                    message: "rect height out of u16 range".into(),
+                })?;
+                (x, y, w, h)
+            }
+        };
+        if w == 0 || h == 0 {
+            return Err(Error::Platform {
+                code: -1,
+                message: "zero-sized capture rect".into(),
+            });
+        }
+
+        let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
+        let reply = guard
+            .get_image(ImageFormat::Z_PIXMAP, root, x, y, w, h, !0)
+            .map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("GetImage: {e}"),
+            })?
+            .reply()
+            .map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("GetImage reply: {e}"),
+            })?;
+
+        // Most modern X servers return Z_PIXMAP at 32 bpp for 24-bit visuals,
+        // with layout BGRX on little-endian. Detect and convert to RGBA.
+        let bpp = (reply.data.len() / (w as usize * h as usize)) as u32;
+        if bpp != 4 {
+            return Err(Error::Platform {
+                code: -1,
+                message: format!("unsupported X11 pixmap layout: {bpp} bytes/pixel (expected 4)"),
+            });
+        }
+
+        let mut rgba = Vec::with_capacity(reply.data.len());
+        for chunk in reply.data.chunks_exact(4) {
+            // X11 BGRX little-endian → RGBA
+            rgba.push(chunk[2]);
+            rgba.push(chunk[1]);
+            rgba.push(chunk[0]);
+            rgba.push(0xFF);
+        }
+
+        Ok(Screenshot {
+            width: w as u32,
+            height: h as u32,
+            pixels: rgba,
+            scale: 1.0,
+        })
+    }
+
+    fn capture_wayland(&self, conn: &ZbusConnection, rect: Option<Rect>) -> Result<Screenshot> {
+        let proxy = Proxy::new(
+            conn,
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+            "org.freedesktop.portal.Screenshot",
+        )
+        .map_err(|e| Error::Platform {
+            code: -1,
+            message: format!("portal Screenshot proxy: {e}"),
+        })?;
+
+        let mut options: HashMap<&str, Value> = HashMap::new();
+        options.insert("interactive", Value::Bool(false));
+        options.insert("modal", Value::Bool(false));
+
+        let request_path: OwnedObjectPath =
+            proxy
+                .call("Screenshot", &("", options))
+                .map_err(|e| Error::Platform {
+                    code: -1,
+                    message: format!("portal Screenshot call: {e}"),
+                })?;
+
+        let request = Proxy::new(
+            conn,
+            "org.freedesktop.portal.Desktop",
+            &request_path,
+            "org.freedesktop.portal.Request",
+        )
+        .map_err(|e| Error::Platform {
+            code: -1,
+            message: format!("portal Request proxy: {e}"),
+        })?;
+
+        // Block for Response(response: u, results: a{sv}). First signal wins.
+        let mut signals = request
+            .receive_signal("Response")
+            .map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("receive_signal: {e}"),
+            })?;
+        let msg = signals.next().ok_or_else(|| Error::Platform {
+            code: -1,
+            message: "portal Response signal channel closed".into(),
+        })?;
+        let (response, results): (u32, HashMap<String, OwnedValue>) =
+            msg.body().deserialize().map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("portal Response deserialize: {e}"),
+            })?;
+        if response != 0 {
+            return Err(Error::PermissionDenied {
+                instructions: format!("xdg-desktop-portal Screenshot denied (response={response})"),
+            });
+        }
+        let uri_val = results.get("uri").ok_or_else(|| Error::Platform {
+            code: -1,
+            message: "portal Response missing 'uri' key".into(),
+        })?;
+        let uri: String = uri_val
+            .downcast_ref::<String>()
+            .map_err(|_| Error::Platform {
+                code: -1,
+                message: "portal Response 'uri' is not a string".into(),
+            })?;
+        let path = uri.strip_prefix("file://").ok_or_else(|| Error::Platform {
+            code: -1,
+            message: format!("portal URI not file://: {uri}"),
+        })?;
+        let bytes = std::fs::read(path).map_err(|e| Error::Platform {
+            code: e.raw_os_error().unwrap_or(-1) as i64,
+            message: format!("read portal PNG: {e}"),
+        })?;
+        // Best-effort cleanup of portal tmpfile.
+        let _ = std::fs::remove_file(path);
+
+        let shot = decode_png_to_rgba(&bytes)?;
+        match rect {
+            None => Ok(shot),
+            Some(r) => crop_rgba(shot, r),
+        }
+    }
+}
+
+impl ScreenshotProvider for LinuxScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        match &self.backend {
+            Backend::X11 {
+                conn,
+                root,
+                root_width,
+                root_height,
+            } => self.capture_x11(conn, *root, *root_width, *root_height, None),
+            Backend::Wayland { conn } => self.capture_wayland(conn, None),
+        }
+    }
+
+    fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
+        match &self.backend {
+            Backend::X11 {
+                conn,
+                root,
+                root_width,
+                root_height,
+            } => self.capture_x11(conn, *root, *root_width, *root_height, Some(rect)),
+            Backend::Wayland { conn } => self.capture_wayland(conn, Some(rect)),
+        }
+    }
+}
+
+fn decode_png_to_rgba(bytes: &[u8]) -> Result<Screenshot> {
+    let decoder = png::Decoder::new(bytes);
+    let mut reader = decoder.read_info().map_err(|e| Error::Platform {
+        code: -1,
+        message: format!("png decode header: {e}"),
+    })?;
+    let info = reader.info().clone();
+    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let frame = reader.next_frame(&mut buf).map_err(|e| Error::Platform {
+        code: -1,
+        message: format!("png decode frame: {e}"),
+    })?;
+    buf.truncate(frame.buffer_size());
+
+    let rgba = match (info.color_type, info.bit_depth) {
+        (png::ColorType::Rgba, png::BitDepth::Eight) => buf,
+        (png::ColorType::Rgb, png::BitDepth::Eight) => {
+            let mut out = Vec::with_capacity((info.width * info.height * 4) as usize);
+            for px in buf.chunks_exact(3) {
+                out.extend_from_slice(&[px[0], px[1], px[2], 0xFF]);
+            }
+            out
+        }
+        (ct, bd) => {
+            return Err(Error::Platform {
+                code: -1,
+                message: format!("unsupported portal PNG format: {ct:?} @ {bd:?}"),
+            });
+        }
+    };
+
+    Ok(Screenshot {
+        width: info.width,
+        height: info.height,
+        pixels: rgba,
+        scale: 1.0,
+    })
+}
+
+fn crop_rgba(shot: Screenshot, rect: Rect) -> Result<Screenshot> {
+    let Screenshot {
+        width: sw,
+        height: sh,
+        pixels,
+        scale,
+    } = shot;
+    let x = rect.x.max(0) as u32;
+    let y = rect.y.max(0) as u32;
+    if x >= sw || y >= sh {
+        return Err(Error::Platform {
+            code: -1,
+            message: "crop rect outside captured image".into(),
+        });
+    }
+    let w = rect.width.min(sw - x);
+    let h = rect.height.min(sh - y);
+    if w == 0 || h == 0 {
+        return Err(Error::Platform {
+            code: -1,
+            message: "crop rect has zero size".into(),
+        });
+    }
+    let mut out = Vec::with_capacity((w * h * 4) as usize);
+    for row in 0..h {
+        let start = ((y + row) * sw + x) as usize * 4;
+        let end = start + (w as usize) * 4;
+        out.extend_from_slice(&pixels[start..end]);
+    }
+    Ok(Screenshot {
+        width: w,
+        height: h,
+        pixels: out,
+        scale,
+    })
+}

--- a/xa11y-linux/src/stub.rs
+++ b/xa11y-linux/src/stub.rs
@@ -1,7 +1,9 @@
 //! Stub backend for non-Linux platforms (allows compilation on all targets).
 
 use xa11y_core::input::{InputProvider, Key, MouseButton, Point, ScrollDelta};
-use xa11y_core::{ElementData, Error, Provider, Result, Subscription};
+use xa11y_core::{
+    ElementData, Error, Provider, Rect, Result, Screenshot, ScreenshotProvider, Subscription,
+};
 
 #[derive(Default)]
 pub struct LinuxProvider;
@@ -47,6 +49,26 @@ impl InputProvider for LinuxInputProvider {
         unreachable!()
     }
     fn type_text(&self, _: &str) -> Result<()> {
+        unreachable!()
+    }
+}
+
+pub struct LinuxScreenshot;
+
+impl LinuxScreenshot {
+    pub fn new() -> Result<Self> {
+        Err(Error::Platform {
+            code: -1,
+            message: "Linux screenshot backend only available on Linux".to_string(),
+        })
+    }
+}
+
+impl ScreenshotProvider for LinuxScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        unreachable!()
+    }
+    fn capture_region(&self, _: Rect) -> Result<Screenshot> {
         unreachable!()
     }
 }

--- a/xa11y-linux/src/stub.rs
+++ b/xa11y-linux/src/stub.rs
@@ -1,5 +1,6 @@
 //! Stub backend for non-Linux platforms (allows compilation on all targets).
 
+use xa11y_core::input::{InputProvider, Key, MouseButton, Point, ScrollDelta};
 use xa11y_core::{ElementData, Error, Provider, Result, Subscription};
 
 #[derive(Default)]
@@ -8,6 +9,45 @@ pub struct LinuxProvider;
 impl LinuxProvider {
     pub fn new() -> Result<Self> {
         Ok(Self)
+    }
+}
+
+#[derive(Default)]
+pub struct LinuxInputProvider;
+
+impl LinuxInputProvider {
+    pub fn new() -> Result<Self> {
+        Err(Error::Platform {
+            code: -1,
+            message: "Linux input backend only available on Linux".to_string(),
+        })
+    }
+}
+
+impl InputProvider for LinuxInputProvider {
+    fn pointer_move(&self, _: Point) -> Result<()> {
+        unreachable!()
+    }
+    fn pointer_down(&self, _: MouseButton) -> Result<()> {
+        unreachable!()
+    }
+    fn pointer_up(&self, _: MouseButton) -> Result<()> {
+        unreachable!()
+    }
+    fn pointer_click(&self, _: Point, _: MouseButton, _: u32) -> Result<()> {
+        unreachable!()
+    }
+    fn pointer_scroll(&self, _: Point, _: ScrollDelta) -> Result<()> {
+        unreachable!()
+    }
+    fn key_down(&self, _: &Key) -> Result<()> {
+        unreachable!()
+    }
+    fn key_up(&self, _: &Key) -> Result<()> {
+        unreachable!()
+    }
+    fn type_text(&self, _: &str) -> Result<()> {
+        unreachable!()
     }
 }
 

--- a/xa11y-linux/tests/input_smoke.rs
+++ b/xa11y-linux/tests/input_smoke.rs
@@ -1,0 +1,65 @@
+//! Smoke test for [`xa11y_linux::LinuxInputProvider`] against a live X server.
+//!
+//! Requires an X display — run under `xvfb-run`. Marked `#[ignore]` so it
+//! doesn't fire in the normal unit-test pass.
+
+#![cfg(target_os = "linux")]
+
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::ConnectionExt as _;
+
+use xa11y_core::input::{InputProvider, Key, MouseButton, Point};
+use xa11y_linux::LinuxInputProvider;
+
+fn with_verifier<F: FnOnce(&LinuxInputProvider, x11rb::rust_connection::RustConnection, u32)>(
+    f: F,
+) {
+    let provider = LinuxInputProvider::new().expect("LinuxInputProvider::new");
+    let (conn, screen_num) =
+        x11rb::rust_connection::RustConnection::connect(None).expect("verifier connect");
+    let root = conn.setup().roots[screen_num].root;
+    f(&provider, conn, root);
+}
+
+#[test]
+#[ignore]
+fn pointer_move_updates_pointer_position() {
+    with_verifier(|provider, conn, root| {
+        provider
+            .pointer_move(Point::new(123, 45))
+            .expect("pointer_move");
+        let reply = conn.query_pointer(root).unwrap().reply().unwrap();
+        assert_eq!(
+            (reply.root_x, reply.root_y),
+            (123, 45),
+            "pointer should be at (123,45), got ({},{})",
+            reply.root_x,
+            reply.root_y
+        );
+    });
+}
+
+#[test]
+#[ignore]
+fn pointer_click_does_not_panic() {
+    with_verifier(|provider, _conn, _root| {
+        provider
+            .pointer_click(Point::new(50, 50), MouseButton::Left, 1)
+            .expect("pointer_click");
+        provider
+            .pointer_click(Point::new(60, 60), MouseButton::Left, 2)
+            .expect("double click");
+    });
+}
+
+#[test]
+#[ignore]
+fn keyboard_press_and_type_do_not_panic() {
+    with_verifier(|provider, _conn, _root| {
+        provider.key_down(&Key::Char('a')).expect("key_down a");
+        provider.key_up(&Key::Char('a')).expect("key_up a");
+        provider.type_text("Hello, world!").expect("type_text");
+        provider.key_down(&Key::Enter).expect("key_down Enter");
+        provider.key_up(&Key::Enter).expect("key_up Enter");
+    });
+}

--- a/xa11y-macos/build.rs
+++ b/xa11y-macos/build.rs
@@ -6,10 +6,13 @@ fn main() {
         cc::Build::new()
             .file("src/exception_safe.m")
             .flag("-fobjc-exceptions")
+            .flag("-fobjc-arc")
             .flag("-fmodules")
             .compile("exception_safe");
 
         println!("cargo:rustc-link-lib=framework=ApplicationServices");
+        println!("cargo:rustc-link-lib=framework=CoreGraphics");
         println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=ScreenCaptureKit");
     }
 }

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1267,7 +1267,7 @@ impl MacOSProvider {
     /// CGWindowListCopyWindowInfo. Without this permission, the list
     /// contains only system chrome (layer != 0). With it, app windows
     /// (layer 0) are included.
-    fn has_screen_recording_permission() -> bool {
+    pub(crate) fn has_screen_recording_permission() -> bool {
         let info = unsafe { safe_cg_window_list_copy(0, 0) };
         if info.is_null() {
             return false;

--- a/xa11y-macos/src/exception_safe.m
+++ b/xa11y-macos/src/exception_safe.m
@@ -6,7 +6,11 @@
 // aborts on foreign exceptions in extern "C" functions.
 
 #import <ApplicationServices/ApplicationServices.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
+#import <ScreenCaptureKit/ScreenCaptureKit.h>
+#include <stdlib.h>
+#include <string.h>
 
 // ── Attribute Access ─────────────────────────────────────────────────────────
 
@@ -351,6 +355,171 @@ CFTypeRef safe_ax_value_create_cf_range(CFIndex location, CFIndex length) {
         return AXValueCreate(kAXValueCFRangeType, &range);
     } @catch (NSException *e) {
         return NULL;
+    }
+}
+
+// ── Screen Capture (ScreenCaptureKit) ────────────────────────────────────────
+
+// Capture the primary display (or a sub-rect in logical screen points) into an
+// RGBA8 buffer. The buffer is malloc'd and ownership transfers to the caller,
+// who must free it via `safe_cg_free_pixels`.
+//
+// Uses ScreenCaptureKit's SCScreenshotManager. CGDisplayCreateImage family was
+// obsoleted in macOS 15.0; SCK is the only supported path forward.
+//
+// `use_rect`: 0 = full display, non-zero = use rect_x/y/w/h (logical points,
+//   in global screen space — same coords as Element.bounds).
+// `out_pixels`: on success, points to `(*out_width) * (*out_height) * 4` bytes
+//   of RGBA8888 data (R, G, B, A per pixel; row-major; tightly packed).
+// `out_scale`: ratio of physical image pixels to logical input points
+//   (1.0 on standard displays, 2.0 on typical Retina).
+//
+// Returns 0 on success; negative value on failure:
+//   -1  SCShareableContent query failed / no displays
+//   -2  SCScreenshotManager returned no image
+//   -3  pixel buffer allocation failed
+//   -4  bitmap context creation failed
+//   -5  requested rect has zero / negative dimensions
+//   -9999 ObjC exception
+int safe_cg_capture_rgba(
+    int use_rect,
+    double rect_x, double rect_y, double rect_w, double rect_h,
+    uint8_t **out_pixels,
+    uint32_t *out_width,
+    uint32_t *out_height,
+    double *out_scale
+) {
+    @try {
+        if (out_pixels) *out_pixels = NULL;
+        if (out_width) *out_width = 0;
+        if (out_height) *out_height = 0;
+        if (out_scale) *out_scale = 1.0;
+
+        if (use_rect && (rect_w <= 0.0 || rect_h <= 0.0)) {
+            return -5;
+        }
+
+        // Step 1: fetch shareable content (async → sync via semaphore).
+        __block SCShareableContent *content = nil;
+        __block NSError *contentError = nil;
+        dispatch_semaphore_t sem1 = dispatch_semaphore_create(0);
+        [SCShareableContent getShareableContentWithCompletionHandler:
+            ^(SCShareableContent *c, NSError *e) {
+                content = c;
+                contentError = e;
+                dispatch_semaphore_signal(sem1);
+            }];
+        dispatch_semaphore_wait(sem1, DISPATCH_TIME_FOREVER);
+        if (content == nil || content.displays.count == 0) {
+            if (contentError) {
+                NSLog(@"xa11y SCShareableContent error: %@", contentError);
+            }
+            return -1;
+        }
+
+        SCDisplay *display = content.displays[0];
+        CGRect logical_bounds = display.frame;
+        double disp_scale = (logical_bounds.size.width > 0.0)
+            ? ((double)display.width / (double)logical_bounds.size.width)
+            : 1.0;
+
+        // Step 2: build the capture configuration.
+        double src_x = use_rect ? rect_x : logical_bounds.origin.x;
+        double src_y = use_rect ? rect_y : logical_bounds.origin.y;
+        double src_w = use_rect ? rect_w : logical_bounds.size.width;
+        double src_h = use_rect ? rect_h : logical_bounds.size.height;
+
+        size_t phys_w = (size_t)(src_w * disp_scale + 0.5);
+        size_t phys_h = (size_t)(src_h * disp_scale + 0.5);
+        if (phys_w == 0 || phys_h == 0) return -5;
+
+        SCContentFilter *filter = [[SCContentFilter alloc]
+            initWithDisplay:display excludingWindows:@[]];
+        SCStreamConfiguration *config = [[SCStreamConfiguration alloc] init];
+        config.width = phys_w;
+        config.height = phys_h;
+        config.pixelFormat = 'BGRA';   // kCVPixelFormatType_32BGRA
+        config.colorSpaceName = kCGColorSpaceSRGB;
+        config.showsCursor = NO;
+        if (use_rect) {
+            // SCK sourceRect is in the display's local (logical) coordinates.
+            config.sourceRect = CGRectMake(
+                src_x - logical_bounds.origin.x,
+                src_y - logical_bounds.origin.y,
+                src_w, src_h
+            );
+            config.destinationRect = CGRectMake(0, 0, (CGFloat)phys_w, (CGFloat)phys_h);
+        }
+
+        // Step 3: capture one image (async → sync via semaphore).
+        __block CGImageRef image = NULL;
+        __block NSError *captureError = nil;
+        dispatch_semaphore_t sem2 = dispatch_semaphore_create(0);
+        [SCScreenshotManager
+            captureImageWithFilter:filter
+                    configuration:config
+                completionHandler:^(CGImageRef img, NSError *e) {
+                    captureError = e;
+                    if (img) {
+                        image = CGImageRetain(img);
+                    }
+                    dispatch_semaphore_signal(sem2);
+                }];
+        dispatch_semaphore_wait(sem2, DISPATCH_TIME_FOREVER);
+        if (image == NULL) {
+            if (captureError) {
+                NSLog(@"xa11y SCScreenshotManager error: %@", captureError);
+            }
+            return -2;
+        }
+
+        size_t w = CGImageGetWidth(image);
+        size_t h = CGImageGetHeight(image);
+        if (w == 0 || h == 0) {
+            CGImageRelease(image);
+            return -2;
+        }
+
+        // Step 4: blit into a fresh RGBA8 buffer.
+        size_t row_bytes = w * 4;
+        size_t buf_size = row_bytes * h;
+        uint8_t *buf = (uint8_t *)malloc(buf_size);
+        if (buf == NULL) {
+            CGImageRelease(image);
+            return -3;
+        }
+        memset(buf, 0, buf_size);
+
+        CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+        // RGBA8888 big-endian — R, G, B, A in memory order.
+        CGContextRef ctx = CGBitmapContextCreate(
+            buf, w, h, 8, row_bytes, cs,
+            kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big
+        );
+        CGColorSpaceRelease(cs);
+        if (ctx == NULL) {
+            free(buf);
+            CGImageRelease(image);
+            return -4;
+        }
+        CGContextDrawImage(ctx, CGRectMake(0, 0, (CGFloat)w, (CGFloat)h), image);
+        CGContextRelease(ctx);
+        CGImageRelease(image);
+
+        *out_pixels = buf;
+        *out_width = (uint32_t)w;
+        *out_height = (uint32_t)h;
+        *out_scale = disp_scale;
+        return 0;
+    } @catch (NSException *e) {
+        return -9999;
+    }
+}
+
+// Release a buffer returned from `safe_cg_capture_rgba`.
+void safe_cg_free_pixels(uint8_t *pixels) {
+    if (pixels != NULL) {
+        free(pixels);
     }
 }
 

--- a/xa11y-macos/src/input.rs
+++ b/xa11y-macos/src/input.rs
@@ -1,0 +1,493 @@
+//! macOS input-simulation backend using Quartz `CGEvent` APIs.
+//!
+//! Posts synthesised pointer and keyboard events to the HID event tap
+//! (`kCGHIDEventTap`). Requires the host process to have the **Accessibility**
+//! and **Input Monitoring** privacy grants — absent those, the OS silently
+//! drops events (there is no API-level error signal). The backend itself only
+//! surfaces failures from `CGEvent*` allocation.
+//!
+//! Drag events: `pointer_drag` is overridden to emit the distinct
+//! `kCGEventLeftMouseDragged` / `…RightMouseDragged` / `…OtherMouseDragged`
+//! types between the down and up — drag-and-drop source views filter on
+//! those and ignore ordinary `kCGEventMouseMoved`.
+//!
+//! `type_text` uses `CGEventKeyboardSetUnicodeString` so case, IME, and
+//! dead-key composition are produced by the OS text path rather than being
+//! synthesised against the active keyboard layout.
+
+use std::ffi::c_void;
+use std::sync::Mutex;
+
+use core_foundation::base::{CFRelease, CFTypeRef};
+
+use xa11y_core::input::{InputProvider, Key, MouseButton, Point, ScrollDelta};
+use xa11y_core::{Error, Result};
+
+// ── Quartz / CoreGraphics FFI ───────────────────────────────────────
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct CGPoint {
+    x: f64,
+    y: f64,
+}
+
+type CGEventRef = *mut c_void;
+type CGEventSourceRef = *mut c_void;
+
+// CGEventTapLocation
+const K_CG_HID_EVENT_TAP: u32 = 0;
+
+// CGEventType
+const K_CG_EVENT_LEFT_MOUSE_DOWN: u32 = 1;
+const K_CG_EVENT_LEFT_MOUSE_UP: u32 = 2;
+const K_CG_EVENT_RIGHT_MOUSE_DOWN: u32 = 3;
+const K_CG_EVENT_RIGHT_MOUSE_UP: u32 = 4;
+const K_CG_EVENT_MOUSE_MOVED: u32 = 5;
+const K_CG_EVENT_LEFT_MOUSE_DRAGGED: u32 = 6;
+const K_CG_EVENT_RIGHT_MOUSE_DRAGGED: u32 = 7;
+const K_CG_EVENT_OTHER_MOUSE_DOWN: u32 = 25;
+const K_CG_EVENT_OTHER_MOUSE_UP: u32 = 26;
+const K_CG_EVENT_OTHER_MOUSE_DRAGGED: u32 = 27;
+
+// CGMouseButton
+const K_CG_MOUSE_BUTTON_LEFT: u32 = 0;
+const K_CG_MOUSE_BUTTON_RIGHT: u32 = 1;
+const K_CG_MOUSE_BUTTON_CENTER: u32 = 2;
+
+// CGScrollEventUnit
+const K_CG_SCROLL_EVENT_UNIT_LINE: u32 = 1;
+
+// CGEventField
+const K_CG_MOUSE_EVENT_CLICK_STATE: u32 = 1;
+
+// CGEventFlags (modifier flags applied at post time).
+const K_CG_EVENT_FLAG_MASK_SHIFT: u64 = 0x0002_0000;
+const K_CG_EVENT_FLAG_MASK_CONTROL: u64 = 0x0004_0000;
+const K_CG_EVENT_FLAG_MASK_ALTERNATE: u64 = 0x0008_0000;
+const K_CG_EVENT_FLAG_MASK_COMMAND: u64 = 0x0010_0000;
+
+#[link(name = "ApplicationServices", kind = "framework")]
+unsafe extern "C" {
+    fn CGEventCreateMouseEvent(
+        source: CGEventSourceRef,
+        mouse_type: u32,
+        mouse_cursor_position: CGPoint,
+        mouse_button: u32,
+    ) -> CGEventRef;
+
+    fn CGEventCreateScrollWheelEvent(
+        source: CGEventSourceRef,
+        units: u32,
+        wheel_count: u32,
+        wheel1: i32,
+        wheel2: i32,
+        wheel3: i32,
+    ) -> CGEventRef;
+
+    fn CGEventCreateKeyboardEvent(
+        source: CGEventSourceRef,
+        virtual_key: u16,
+        key_down: bool,
+    ) -> CGEventRef;
+
+    fn CGEventPost(tap: u32, event: CGEventRef);
+
+    fn CGEventSetIntegerValueField(event: CGEventRef, field: u32, value: i64);
+
+    fn CGEventSetFlags(event: CGEventRef, flags: u64);
+
+    fn CGEventKeyboardSetUnicodeString(event: CGEventRef, length: usize, chars: *const u16);
+}
+
+// ── Provider ────────────────────────────────────────────────────────
+
+/// CGEvent-backed [`InputProvider`].
+///
+/// All calls serialise through an internal mutex so interleaving threads can't
+/// scramble the posted event stream (macOS delivers events globally to the
+/// focused app, so ordering is session-wide).
+#[derive(Default)]
+pub struct MacOSInputProvider {
+    lock: Mutex<()>,
+}
+
+impl MacOSInputProvider {
+    pub fn new() -> Result<Self> {
+        Ok(Self::default())
+    }
+
+    fn post(&self, event: CGEventRef) -> Result<()> {
+        if event.is_null() {
+            return Err(Error::Platform {
+                code: -1,
+                message: "CGEventCreate* returned NULL".to_string(),
+            });
+        }
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: `event` is a valid CGEventRef we just created; CGEventPost
+        // takes an owned +0 borrow and does not consume it.
+        unsafe {
+            CGEventPost(K_CG_HID_EVENT_TAP, event);
+            CFRelease(event as CFTypeRef);
+        }
+        Ok(())
+    }
+
+    fn post_with_flags(&self, event: CGEventRef, flags: u64) -> Result<()> {
+        if event.is_null() {
+            return Err(Error::Platform {
+                code: -1,
+                message: "CGEventCreate* returned NULL".to_string(),
+            });
+        }
+        // SAFETY: `event` is a valid CGEventRef.
+        unsafe { CGEventSetFlags(event, flags) };
+        self.post(event)
+    }
+
+    fn mouse_event(&self, ty: u32, at: Point, button: u32) -> Result<CGEventRef> {
+        let pt = CGPoint {
+            x: at.x as f64,
+            y: at.y as f64,
+        };
+        // SAFETY: nil source is valid per the CGEventSource docs ("Use NULL to
+        // create a combined state from the pasted-in event source defaults").
+        let ev = unsafe { CGEventCreateMouseEvent(std::ptr::null_mut(), ty, pt, button) };
+        if ev.is_null() {
+            return Err(Error::Platform {
+                code: -1,
+                message: format!("CGEventCreateMouseEvent failed (type={ty})"),
+            });
+        }
+        Ok(ev)
+    }
+
+    fn keyboard_event(&self, vk: u16, down: bool) -> Result<CGEventRef> {
+        // SAFETY: nil source is allowed by CGEventSource contract.
+        let ev = unsafe { CGEventCreateKeyboardEvent(std::ptr::null_mut(), vk, down) };
+        if ev.is_null() {
+            return Err(Error::Platform {
+                code: -1,
+                message: "CGEventCreateKeyboardEvent failed".to_string(),
+            });
+        }
+        Ok(ev)
+    }
+}
+
+// ── Mapping helpers ─────────────────────────────────────────────────
+
+fn cg_button(b: MouseButton) -> u32 {
+    match b {
+        MouseButton::Left => K_CG_MOUSE_BUTTON_LEFT,
+        MouseButton::Right => K_CG_MOUSE_BUTTON_RIGHT,
+        MouseButton::Middle => K_CG_MOUSE_BUTTON_CENTER,
+    }
+}
+
+fn cg_button_down(b: MouseButton) -> u32 {
+    match b {
+        MouseButton::Left => K_CG_EVENT_LEFT_MOUSE_DOWN,
+        MouseButton::Right => K_CG_EVENT_RIGHT_MOUSE_DOWN,
+        MouseButton::Middle => K_CG_EVENT_OTHER_MOUSE_DOWN,
+    }
+}
+
+fn cg_button_up(b: MouseButton) -> u32 {
+    match b {
+        MouseButton::Left => K_CG_EVENT_LEFT_MOUSE_UP,
+        MouseButton::Right => K_CG_EVENT_RIGHT_MOUSE_UP,
+        MouseButton::Middle => K_CG_EVENT_OTHER_MOUSE_UP,
+    }
+}
+
+fn cg_button_dragged(b: MouseButton) -> u32 {
+    match b {
+        MouseButton::Left => K_CG_EVENT_LEFT_MOUSE_DRAGGED,
+        MouseButton::Right => K_CG_EVENT_RIGHT_MOUSE_DRAGGED,
+        MouseButton::Middle => K_CG_EVENT_OTHER_MOUSE_DRAGGED,
+    }
+}
+
+/// Virtual key code for a [`Key`]. Codes are the standard HIToolbox
+/// `Events.h` keycodes (USB HID usage page → physical key on a US layout
+/// for letters/digits).
+fn vk_for(key: &Key) -> Result<u16> {
+    let vk = match key {
+        Key::Shift => 0x38,
+        Key::Ctrl => 0x3B,
+        Key::Alt => 0x3A,
+        Key::Meta => 0x37,
+        Key::Enter => 0x24,
+        Key::Escape => 0x35,
+        Key::Backspace => 0x33,
+        Key::Tab => 0x30,
+        Key::Space => 0x31,
+        Key::Delete => 0x75,
+        // macOS has no "Insert" key. The "Help" key on older keyboards
+        // occupies the same position and is the conventional mapping.
+        Key::Insert => 0x72,
+        Key::ArrowUp => 0x7E,
+        Key::ArrowDown => 0x7D,
+        Key::ArrowLeft => 0x7B,
+        Key::ArrowRight => 0x7C,
+        Key::Home => 0x73,
+        Key::End => 0x77,
+        Key::PageUp => 0x74,
+        Key::PageDown => 0x79,
+        Key::F(n) => match n {
+            1 => 0x7A,
+            2 => 0x78,
+            3 => 0x63,
+            4 => 0x76,
+            5 => 0x60,
+            6 => 0x61,
+            7 => 0x62,
+            8 => 0x64,
+            9 => 0x65,
+            10 => 0x6D,
+            11 => 0x67,
+            12 => 0x6F,
+            13 => 0x69,
+            14 => 0x6B,
+            15 => 0x71,
+            16 => 0x6A,
+            17 => 0x40,
+            18 => 0x4F,
+            19 => 0x50,
+            20 => 0x5A,
+            _ => {
+                return Err(Error::InvalidActionData {
+                    message: format!("F{n} has no HIToolbox keycode on macOS"),
+                });
+            }
+        },
+        Key::Char(c) => vk_for_char(*c)?,
+    };
+    Ok(vk)
+}
+
+/// Virtual key code for `Key::Char`. The [`Key`] contract guarantees `c` is
+/// not ASCII uppercase. Letters, digits, and common US-layout punctuation
+/// are mapped here; anything else returns [`Error::Unsupported`] and the
+/// caller is expected to use `Keyboard::type_text` instead.
+fn vk_for_char(c: char) -> Result<u16> {
+    let vk = match c {
+        'a' => 0x00,
+        'b' => 0x0B,
+        'c' => 0x08,
+        'd' => 0x02,
+        'e' => 0x0E,
+        'f' => 0x03,
+        'g' => 0x05,
+        'h' => 0x04,
+        'i' => 0x22,
+        'j' => 0x26,
+        'k' => 0x28,
+        'l' => 0x25,
+        'm' => 0x2E,
+        'n' => 0x2D,
+        'o' => 0x1F,
+        'p' => 0x23,
+        'q' => 0x0C,
+        'r' => 0x0F,
+        's' => 0x01,
+        't' => 0x11,
+        'u' => 0x20,
+        'v' => 0x09,
+        'w' => 0x0D,
+        'x' => 0x07,
+        'y' => 0x10,
+        'z' => 0x06,
+        '0' => 0x1D,
+        '1' => 0x12,
+        '2' => 0x13,
+        '3' => 0x14,
+        '4' => 0x15,
+        '5' => 0x17,
+        '6' => 0x16,
+        '7' => 0x1A,
+        '8' => 0x1C,
+        '9' => 0x19,
+        ';' => 0x29,
+        '/' => 0x2C,
+        '`' => 0x32,
+        '[' => 0x21,
+        '\\' => 0x2A,
+        ']' => 0x1E,
+        '\'' => 0x27,
+        ',' => 0x2B,
+        '.' => 0x2F,
+        '-' => 0x1B,
+        '=' => 0x18,
+        _ => {
+            return Err(Error::Unsupported {
+                feature: format!(
+                    "Key::Char('{c}') has no HIToolbox virtual-key mapping; \
+                     use Keyboard::type_text for arbitrary characters"
+                ),
+            });
+        }
+    };
+    Ok(vk)
+}
+
+// ── InputProvider impl ──────────────────────────────────────────────
+
+impl InputProvider for MacOSInputProvider {
+    fn pointer_move(&self, to: Point) -> Result<()> {
+        // For mouse-moved the button argument is ignored.
+        let ev = self.mouse_event(K_CG_EVENT_MOUSE_MOVED, to, K_CG_MOUSE_BUTTON_LEFT)?;
+        self.post(ev)
+    }
+
+    fn pointer_down(&self, button: MouseButton) -> Result<()> {
+        // CGEvent needs a position; pass (0,0) — the system uses the current
+        // cursor location for button-only events anyway, but supplying a point
+        // keeps the struct well-formed.
+        let ev = self.mouse_event(cg_button_down(button), Point::new(0, 0), cg_button(button))?;
+        self.post(ev)
+    }
+
+    fn pointer_up(&self, button: MouseButton) -> Result<()> {
+        let ev = self.mouse_event(cg_button_up(button), Point::new(0, 0), cg_button(button))?;
+        self.post(ev)
+    }
+
+    fn pointer_click(&self, at: Point, button: MouseButton, count: u32) -> Result<()> {
+        if count == 0 {
+            return Ok(());
+        }
+        self.pointer_move(at)?;
+        // `kCGMouseEventClickState` tells the OS which click in a sequence this
+        // is (1 = single, 2 = double, …). We emit N paired down/up events
+        // with increasing click-state so AppKit/Cocoa recognises multi-clicks
+        // regardless of the OS double-click timing window.
+        for i in 1..=count {
+            let down = self.mouse_event(cg_button_down(button), at, cg_button(button))?;
+            // SAFETY: down is a valid CGEventRef.
+            unsafe {
+                CGEventSetIntegerValueField(down, K_CG_MOUSE_EVENT_CLICK_STATE, i as i64);
+            }
+            self.post(down)?;
+            let up = self.mouse_event(cg_button_up(button), at, cg_button(button))?;
+            unsafe {
+                CGEventSetIntegerValueField(up, K_CG_MOUSE_EVENT_CLICK_STATE, i as i64);
+            }
+            self.post(up)?;
+        }
+        Ok(())
+    }
+
+    fn pointer_scroll(&self, at: Point, delta: ScrollDelta) -> Result<()> {
+        self.pointer_move(at)?;
+        // Quartz scroll convention: positive wheel1 = scroll up (content down),
+        // which matches the xa11y ScrollDelta doc invariant ("positive dy
+        // scrolls content down").
+        // SAFETY: nil source is valid.
+        let ev = unsafe {
+            CGEventCreateScrollWheelEvent(
+                std::ptr::null_mut(),
+                K_CG_SCROLL_EVENT_UNIT_LINE,
+                2,
+                delta.dy,
+                delta.dx,
+                0,
+            )
+        };
+        if ev.is_null() {
+            return Err(Error::Platform {
+                code: -1,
+                message: "CGEventCreateScrollWheelEvent failed".to_string(),
+            });
+        }
+        self.post(ev)
+    }
+
+    fn key_down(&self, key: &Key) -> Result<()> {
+        let vk = vk_for(key)?;
+        let ev = self.keyboard_event(vk, true)?;
+        // Modifier keys posted as ordinary key-down don't set the event-flags
+        // bit that Cocoa inspects for "is Shift held". Apply the flag here so
+        // subsequent events in the same posting window see the modifier.
+        let flags = modifier_flag_for(key);
+        if flags != 0 {
+            self.post_with_flags(ev, flags)
+        } else {
+            self.post(ev)
+        }
+    }
+
+    fn key_up(&self, key: &Key) -> Result<()> {
+        let vk = vk_for(key)?;
+        let ev = self.keyboard_event(vk, false)?;
+        self.post(ev)
+    }
+
+    fn type_text(&self, text: &str) -> Result<()> {
+        // CGEventKeyboardSetUnicodeString replaces the synthetic keystroke
+        // the event would normally generate with the supplied UTF-16 string,
+        // so we get correct case/IME without synthesising shift chords.
+        for chunk in text.chars().collect::<Vec<_>>().chunks(20) {
+            let s: String = chunk.iter().collect();
+            let utf16: Vec<u16> = s.encode_utf16().collect();
+            let ev = self.keyboard_event(0, true)?;
+            // SAFETY: `utf16.as_ptr()` is valid for `utf16.len()` u16 reads
+            // for the duration of the call.
+            unsafe {
+                CGEventKeyboardSetUnicodeString(ev, utf16.len(), utf16.as_ptr());
+            }
+            self.post(ev)?;
+            let ev = self.keyboard_event(0, false)?;
+            unsafe {
+                CGEventKeyboardSetUnicodeString(ev, utf16.len(), utf16.as_ptr());
+            }
+            self.post(ev)?;
+        }
+        Ok(())
+    }
+
+    fn pointer_drag(
+        &self,
+        from: Point,
+        to: Point,
+        button: MouseButton,
+        duration: std::time::Duration,
+    ) -> Result<()> {
+        // Drag-and-drop source views on macOS filter for
+        // kCGEventLeftMouseDragged / …RightMouseDragged / …OtherMouseDragged
+        // specifically — ordinary kCGEventMouseMoved between the down and up
+        // is ignored by DnD. Synthesise the sequence ourselves using the
+        // right dragged-event type instead of relying on the core trait's
+        // default (which emits mouse-moved).
+        const STEP: std::time::Duration = std::time::Duration::from_millis(16);
+        self.pointer_move(from)?;
+        self.pointer_down(button)?;
+        let step_ms = STEP.as_millis().max(1);
+        let steps = (duration.as_millis() / step_ms).max(1) as i32;
+        let dragged_ty = cg_button_dragged(button);
+        let cg_btn = cg_button(button);
+        for i in 1..=steps {
+            let t = i as f64 / steps as f64;
+            let x = from.x + ((to.x - from.x) as f64 * t).round() as i32;
+            let y = from.y + ((to.y - from.y) as f64 * t).round() as i32;
+            let ev = self.mouse_event(dragged_ty, Point::new(x, y), cg_btn)?;
+            self.post(ev)?;
+            if i < steps {
+                std::thread::sleep(STEP);
+            }
+        }
+        self.pointer_up(button)
+    }
+}
+
+fn modifier_flag_for(key: &Key) -> u64 {
+    match key {
+        Key::Shift => K_CG_EVENT_FLAG_MASK_SHIFT,
+        Key::Ctrl => K_CG_EVENT_FLAG_MASK_CONTROL,
+        Key::Alt => K_CG_EVENT_FLAG_MASK_ALTERNATE,
+        Key::Meta => K_CG_EVENT_FLAG_MASK_COMMAND,
+        _ => 0,
+    }
+}

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -2,12 +2,17 @@
 
 #[cfg(target_os = "macos")]
 mod ax;
+#[cfg(target_os = "macos")]
+mod input;
 
 #[cfg(target_os = "macos")]
 pub use ax::MacOSProvider;
+#[cfg(target_os = "macos")]
+pub use input::MacOSInputProvider;
 
 #[cfg(not(target_os = "macos"))]
 mod stub {
+    use xa11y_core::input::{InputProvider, Key, MouseButton, Point, ScrollDelta};
     use xa11y_core::*;
 
     pub struct MacOSProvider;
@@ -18,6 +23,45 @@ mod stub {
                 code: -1,
                 message: "macOS backend only available on macOS".to_string(),
             })
+        }
+    }
+
+    #[derive(Default)]
+    pub struct MacOSInputProvider;
+
+    impl MacOSInputProvider {
+        pub fn new() -> Result<Self> {
+            Err(Error::Platform {
+                code: -1,
+                message: "macOS input backend only available on macOS".to_string(),
+            })
+        }
+    }
+
+    impl InputProvider for MacOSInputProvider {
+        fn pointer_move(&self, _: Point) -> Result<()> {
+            unreachable!()
+        }
+        fn pointer_down(&self, _: MouseButton) -> Result<()> {
+            unreachable!()
+        }
+        fn pointer_up(&self, _: MouseButton) -> Result<()> {
+            unreachable!()
+        }
+        fn pointer_click(&self, _: Point, _: MouseButton, _: u32) -> Result<()> {
+            unreachable!()
+        }
+        fn pointer_scroll(&self, _: Point, _: ScrollDelta) -> Result<()> {
+            unreachable!()
+        }
+        fn key_down(&self, _: &Key) -> Result<()> {
+            unreachable!()
+        }
+        fn key_up(&self, _: &Key) -> Result<()> {
+            unreachable!()
+        }
+        fn type_text(&self, _: &str) -> Result<()> {
+            unreachable!()
         }
     }
 
@@ -83,7 +127,7 @@ mod stub {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub use stub::MacOSProvider;
+pub use stub::{MacOSInputProvider, MacOSProvider};
 
 #[cfg(test)]
 mod tests {

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -4,11 +4,15 @@
 mod ax;
 #[cfg(target_os = "macos")]
 mod input;
+#[cfg(target_os = "macos")]
+mod screenshot;
 
 #[cfg(target_os = "macos")]
 pub use ax::MacOSProvider;
 #[cfg(target_os = "macos")]
 pub use input::MacOSInputProvider;
+#[cfg(target_os = "macos")]
+pub use screenshot::MacOSScreenshot;
 
 #[cfg(not(target_os = "macos"))]
 mod stub {
@@ -35,6 +39,26 @@ mod stub {
                 code: -1,
                 message: "macOS input backend only available on macOS".to_string(),
             })
+        }
+    }
+
+    pub struct MacOSScreenshot;
+
+    impl MacOSScreenshot {
+        pub fn new() -> Result<Self> {
+            Err(Error::Platform {
+                code: -1,
+                message: "macOS screenshot backend only available on macOS".to_string(),
+            })
+        }
+    }
+
+    impl ScreenshotProvider for MacOSScreenshot {
+        fn capture_full(&self) -> Result<Screenshot> {
+            unreachable!()
+        }
+        fn capture_region(&self, _: Rect) -> Result<Screenshot> {
+            unreachable!()
         }
     }
 
@@ -127,7 +151,7 @@ mod stub {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub use stub::{MacOSInputProvider, MacOSProvider};
+pub use stub::{MacOSInputProvider, MacOSProvider, MacOSScreenshot};
 
 #[cfg(test)]
 mod tests {

--- a/xa11y-macos/src/screenshot.rs
+++ b/xa11y-macos/src/screenshot.rs
@@ -1,0 +1,144 @@
+//! macOS screen capture backend via CGDisplayCreateImage.
+//!
+//! Returns physical (device) pixels as RGBA8. Requires the Screen Recording
+//! TCC permission — checked at construction time, same as `MacOSProvider`.
+
+use xa11y_core::{Error, Rect, Result, Screenshot, ScreenshotProvider};
+
+use crate::ax::MacOSProvider;
+
+extern "C" {
+    fn safe_cg_capture_rgba(
+        use_rect: i32,
+        rect_x: f64,
+        rect_y: f64,
+        rect_w: f64,
+        rect_h: f64,
+        out_pixels: *mut *mut u8,
+        out_width: *mut u32,
+        out_height: *mut u32,
+        out_scale: *mut f64,
+    ) -> i32;
+    fn safe_cg_free_pixels(pixels: *mut u8);
+}
+
+pub struct MacOSScreenshot;
+
+impl MacOSScreenshot {
+    pub fn new() -> Result<Self> {
+        if !MacOSProvider::has_screen_recording_permission() {
+            return Err(Error::PermissionDenied {
+                instructions: "Enable Screen Recording in System Settings → Privacy & Security → \
+                 Screen & System Audio Recording."
+                    .to_string(),
+            });
+        }
+        Ok(Self)
+    }
+
+    fn capture(&self, rect: Option<Rect>) -> Result<Screenshot> {
+        let (use_rect, rx, ry, rw, rh) = match rect {
+            Some(r) => (
+                1_i32,
+                f64::from(r.x),
+                f64::from(r.y),
+                f64::from(r.width),
+                f64::from(r.height),
+            ),
+            None => (0, 0.0, 0.0, 0.0, 0.0),
+        };
+
+        let mut pixels: *mut u8 = std::ptr::null_mut();
+        let mut width: u32 = 0;
+        let mut height: u32 = 0;
+        let mut scale: f64 = 1.0;
+
+        let rc = unsafe {
+            safe_cg_capture_rgba(
+                use_rect,
+                rx,
+                ry,
+                rw,
+                rh,
+                &mut pixels,
+                &mut width,
+                &mut height,
+                &mut scale,
+            )
+        };
+
+        if rc != 0 || pixels.is_null() {
+            // -1: SCShareableContent query failed / returned no displays —
+            // typically means the Screen Recording TCC grant is missing for
+            // this binary. macOS 15+ silently denies without prompting once
+            // a "no" decision is cached.
+            let err = match rc {
+                -1 => Error::PermissionDenied {
+                    instructions: "ScreenCaptureKit could not enumerate displays. Enable Screen \
+                                   Recording for this binary in System Settings → Privacy & \
+                                   Security → Screen & System Audio Recording."
+                        .to_string(),
+                },
+                -2 => Error::Platform {
+                    code: -2,
+                    message: "SCScreenshotManager returned no image".into(),
+                },
+                -3 => Error::Platform {
+                    code: -3,
+                    message: "pixel buffer allocation failed".into(),
+                },
+                -4 => Error::Platform {
+                    code: -4,
+                    message: "bitmap context creation failed".into(),
+                },
+                -5 => Error::Platform {
+                    code: -5,
+                    message: "requested rect has zero/negative dimensions".into(),
+                },
+                -9999 => Error::Platform {
+                    code: -9999,
+                    message: "ObjC exception during capture".into(),
+                },
+                other => Error::Platform {
+                    code: i64::from(other),
+                    message: format!("SCK capture failed with code {other}"),
+                },
+            };
+            return Err(err);
+        }
+        if width == 0 || height == 0 {
+            unsafe { safe_cg_free_pixels(pixels) };
+            return Err(Error::Platform {
+                code: -2,
+                message: "captured image has zero dimensions".into(),
+            });
+        }
+
+        let size = (width as usize)
+            .checked_mul(height as usize)
+            .and_then(|n| n.checked_mul(4))
+            .ok_or_else(|| Error::Platform {
+                code: -1,
+                message: "screenshot dimensions overflow".into(),
+            })?;
+        let pixels_vec = unsafe { std::slice::from_raw_parts(pixels, size) }.to_vec();
+        unsafe { safe_cg_free_pixels(pixels) };
+
+        Ok(Screenshot {
+            width,
+            height,
+            pixels: pixels_vec,
+            scale: scale as f32,
+        })
+    }
+}
+
+impl ScreenshotProvider for MacOSScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        self.capture(None)
+    }
+
+    fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
+        self.capture(Some(rect))
+    }
+}

--- a/xa11y-python/Cargo.lock
+++ b/xa11y-python/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -216,6 +228,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -319,10 +340,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -494,6 +534,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +580,19 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -684,7 +747,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -772,6 +835,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1042,7 +1111,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1243,7 +1312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -1305,6 +1374,7 @@ dependencies = [
 name = "xa11y-core"
 version = "0.6.2"
 dependencies = [
+ "png",
  "serde",
  "serde_json",
  "strum",
@@ -1315,6 +1385,7 @@ dependencies = [
 name = "xa11y-linux"
 version = "0.6.2"
 dependencies = [
+ "png",
  "rayon",
  "serde_json",
  "x11rb",

--- a/xa11y-python/Cargo.lock
+++ b/xa11y-python/Cargo.lock
@@ -356,6 +356,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1274,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xa11y"
 version = "0.6.2"
 dependencies = [
@@ -1290,6 +1317,7 @@ version = "0.6.2"
 dependencies = [
  "rayon",
  "serde_json",
+ "x11rb",
  "xa11y-core",
  "zbus",
 ]

--- a/xa11y-python/python/xa11y/__init__.py
+++ b/xa11y-python/python/xa11y/__init__.py
@@ -15,6 +15,7 @@ from xa11y._native import (
     Element,
     Event,
     EventType,
+    InputSim,
     InvalidActionDataError,
     InvalidSelectorError,
     Locator,
@@ -25,6 +26,7 @@ from xa11y._native import (
     Subscription,
     TimeoutError,
     XA11yError,
+    input_sim,
     locator,
 )
 
@@ -35,6 +37,7 @@ __all__ = [
     "Element",
     "Event",
     "EventType",
+    "InputSim",
     "InvalidActionDataError",
     "InvalidSelectorError",
     "Locator",
@@ -45,5 +48,6 @@ __all__ = [
     "Subscription",
     "TimeoutError",
     "XA11yError",
+    "input_sim",
     "locator",
 ]

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -956,6 +956,147 @@ impl App {
     }
 }
 
+// ── Input simulation ────────────────────────────────────────────────────────
+
+/// Input-simulation façade. Constructed via [`input_sim()`][input_sim_fn].
+///
+/// Methods accept targets as either a `(x, y)` tuple or an `Element` (uses
+/// centre bounds). `Key` values are Python strings — see [`_parse_key`] for
+/// the grammar; short version: printable characters are literal
+/// (`"a"`, `"7"`, `";"`), named keys use their Pascal name (`"Enter"`,
+/// `"ArrowUp"`, `"F5"`), modifiers are `"Shift"`, `"Ctrl"`, `"Alt"`, `"Meta"`.
+#[pyclass]
+struct InputSim {
+    inner: xa11y::InputSim,
+}
+
+#[pymethods]
+impl InputSim {
+    /// Left-click at `target` once.
+    fn click(&self, target: Bound<'_, PyAny>) -> PyResult<()> {
+        let pt = parse_target(&target)?;
+        self.inner.mouse().click(pt).map_err(to_py_err)
+    }
+
+    /// Left double-click at `target`.
+    fn double_click(&self, target: Bound<'_, PyAny>) -> PyResult<()> {
+        let pt = parse_target(&target)?;
+        self.inner.mouse().double_click(pt).map_err(to_py_err)
+    }
+
+    /// Right-click at `target`.
+    fn right_click(&self, target: Bound<'_, PyAny>) -> PyResult<()> {
+        let pt = parse_target(&target)?;
+        self.inner.mouse().right_click(pt).map_err(to_py_err)
+    }
+
+    /// Move the pointer to `target` without pressing any button.
+    fn move_to(&self, target: Bound<'_, PyAny>) -> PyResult<()> {
+        let pt = parse_target(&target)?;
+        self.inner.mouse().move_to(pt).map_err(to_py_err)
+    }
+
+    /// Left-drag from `start` to `end`. Default duration 150 ms.
+    fn drag(&self, start: Bound<'_, PyAny>, end: Bound<'_, PyAny>) -> PyResult<()> {
+        let from = parse_target(&start)?;
+        let to = parse_target(&end)?;
+        self.inner.mouse().drag(from, to).map_err(to_py_err)
+    }
+
+    /// Scroll at `target`. `dx` positive → scroll right, `dy` positive →
+    /// scroll content down.
+    #[pyo3(signature = (target, dx=0, dy=0))]
+    fn scroll(&self, target: Bound<'_, PyAny>, dx: i32, dy: i32) -> PyResult<()> {
+        let pt = parse_target(&target)?;
+        self.inner
+            .mouse()
+            .scroll(pt, xa11y::ScrollDelta::new(dx, dy))
+            .map_err(to_py_err)
+    }
+
+    /// Tap a key (press + release). See the class docstring for key names.
+    fn press(&self, key: &str) -> PyResult<()> {
+        let k = parse_key(key)?;
+        self.inner.keyboard().press(k).map_err(to_py_err)
+    }
+
+    /// Tap `key` while `held` (list of key names) are held.
+    #[pyo3(signature = (key, held=Vec::new()))]
+    fn chord(&self, key: &str, held: Vec<String>) -> PyResult<()> {
+        let k = parse_key(key)?;
+        let held: Result<Vec<_>, _> = held.iter().map(|s| parse_key(s)).collect();
+        self.inner.keyboard().chord(k, &held?).map_err(to_py_err)
+    }
+
+    /// Type literal text into the currently focused control.
+    fn type_text(&self, text: &str) -> PyResult<()> {
+        self.inner.keyboard().type_text(text).map_err(to_py_err)
+    }
+}
+
+/// Convert a Python target (`(int, int)` tuple or `Element`) to an
+/// [`xa11y::Point`]. Keeps the target-resolution cost explicit at the call
+/// site, matching the Rust [`IntoPoint`] contract.
+fn parse_target(target: &Bound<'_, PyAny>) -> PyResult<xa11y::Point> {
+    if let Ok(el) = target.downcast::<Element>() {
+        let element = el.borrow();
+        let (x, y, w, h) = element
+            .bounds_data
+            .ok_or_else(|| PyValueError::new_err("Element has no bounds"))?;
+        return Ok(xa11y::Point::new(x + (w as i32) / 2, y + (h as i32) / 2));
+    }
+    let tup: (i32, i32) = target
+        .extract()
+        .map_err(|_| PyTypeError::new_err("expected (int, int) tuple or Element for target"))?;
+    Ok(xa11y::Point::new(tup.0, tup.1))
+}
+
+/// Parse a key-name string into an [`xa11y::Key`]. Accepts:
+/// single chars (`"a"`, `"7"`), named modifiers (`"Shift"`, `"Ctrl"`,
+/// `"Alt"`, `"Meta"`), named keys (`"Enter"`, `"Tab"`, `"Escape"`,
+/// `"Backspace"`, `"Space"`, `"Delete"`, `"Insert"`, `"Home"`, `"End"`,
+/// `"PageUp"`, `"PageDown"`, `"ArrowUp/Down/Left/Right"`), and function
+/// keys `"F1"` through `"F24"`.
+fn parse_key(name: &str) -> PyResult<xa11y::Key> {
+    let k = match name {
+        "Shift" => xa11y::Key::Shift,
+        "Ctrl" | "Control" => xa11y::Key::Ctrl,
+        "Alt" | "Option" => xa11y::Key::Alt,
+        "Meta" | "Cmd" | "Command" | "Super" | "Win" => xa11y::Key::Meta,
+        "Enter" | "Return" => xa11y::Key::Enter,
+        "Escape" | "Esc" => xa11y::Key::Escape,
+        "Backspace" => xa11y::Key::Backspace,
+        "Tab" => xa11y::Key::Tab,
+        "Space" => xa11y::Key::Space,
+        "Delete" => xa11y::Key::Delete,
+        "Insert" => xa11y::Key::Insert,
+        "ArrowUp" | "Up" => xa11y::Key::ArrowUp,
+        "ArrowDown" | "Down" => xa11y::Key::ArrowDown,
+        "ArrowLeft" | "Left" => xa11y::Key::ArrowLeft,
+        "ArrowRight" | "Right" => xa11y::Key::ArrowRight,
+        "Home" => xa11y::Key::Home,
+        "End" => xa11y::Key::End,
+        "PageUp" => xa11y::Key::PageUp,
+        "PageDown" => xa11y::Key::PageDown,
+        s if s.starts_with('F') && s.len() >= 2 && s[1..].chars().all(|c| c.is_ascii_digit()) => {
+            let n: u8 = s[1..]
+                .parse()
+                .map_err(|_| PyValueError::new_err(format!("Invalid function key: {s}")))?;
+            xa11y::Key::F(n)
+        }
+        s if s.chars().count() == 1 => xa11y::Key::Char(s.chars().next().unwrap()),
+        _ => return Err(PyValueError::new_err(format!("Unknown key name: {name}"))),
+    };
+    Ok(k)
+}
+
+/// Construct an [`InputSim`] backed by the platform's native input path.
+#[pyfunction]
+fn input_sim() -> PyResult<InputSim> {
+    let sim = xa11y::input_sim().map_err(to_py_err)?;
+    Ok(InputSim { inner: sim })
+}
+
 // ── Module-level functions ──────────────────────────────────────────────────
 
 /// Create a top-level Locator.
@@ -976,6 +1117,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Element>()?;
     m.add_class::<Event>()?;
     m.add_class::<EventType>()?;
+    m.add_class::<InputSim>()?;
     m.add_class::<Locator>()?;
     m.add_class::<Rect>()?;
     m.add_class::<Subscription>()?;
@@ -1013,6 +1155,9 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Re-export as "locator" in Python
     let locator_fn_obj = m.getattr("locator_fn")?;
     m.setattr("locator", &locator_fn_obj)?;
+
+    // Input simulation factory
+    m.add_function(wrap_pyfunction!(input_sim, m)?)?;
 
     // CLI entry point
     m.add_function(wrap_pyfunction!(_cli_main, m)?)?;

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -57,6 +57,12 @@ fn to_py_err(e: xa11y::Error) -> PyErr {
         xa11y::Error::Platform { code, message } => {
             PlatformError::new_err(format!("Platform error ({code}): {message}"))
         }
+        xa11y::Error::NoElementBounds => {
+            PyValueError::new_err("Element has no bounds; cannot compute a screen point")
+        }
+        xa11y::Error::Unsupported { feature } => {
+            ActionNotSupportedError::new_err(format!("Unsupported: {feature}"))
+        }
     }
 }
 

--- a/xa11y-windows/Cargo.toml
+++ b/xa11y-windows/Cargo.toml
@@ -13,6 +13,8 @@ serde_json = { workspace = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = [
     "Win32_UI_Accessibility",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_Ole",

--- a/xa11y-windows/src/input.rs
+++ b/xa11y-windows/src/input.rs
@@ -1,0 +1,355 @@
+//! Windows input-simulation backend using `SendInput`.
+//!
+//! Implements [`xa11y_core::InputProvider`] with the Win32 `SendInput` API.
+//! Pointer motion uses absolute, virtual-desktop coordinates; text entry uses
+//! `KEYEVENTF_UNICODE` so it is keyboard-layout-independent; individual keys
+//! go through virtual-key codes so downstream apps see normal `WM_KEYDOWN`
+//! messages (and modifiers compose with `chord`).
+
+use std::sync::Mutex;
+
+use windows::Win32::Foundation::GetLastError;
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYBD_EVENT_FLAGS,
+    KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE, MOUSEEVENTF_ABSOLUTE,
+    MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN,
+    MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_MOVE, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP,
+    MOUSEEVENTF_VIRTUALDESK, MOUSEEVENTF_WHEEL, MOUSEINPUT, VIRTUAL_KEY, VK_0, VK_1, VK_2, VK_3,
+    VK_4, VK_5, VK_6, VK_7, VK_8, VK_9, VK_A, VK_B, VK_BACK, VK_C, VK_CONTROL, VK_D, VK_DELETE,
+    VK_DOWN, VK_E, VK_END, VK_ESCAPE, VK_F, VK_F1, VK_F10, VK_F11, VK_F12, VK_F13, VK_F14, VK_F15,
+    VK_F16, VK_F17, VK_F18, VK_F19, VK_F2, VK_F20, VK_F21, VK_F22, VK_F23, VK_F24, VK_F3, VK_F4,
+    VK_F5, VK_F6, VK_F7, VK_F8, VK_F9, VK_G, VK_H, VK_HOME, VK_I, VK_INSERT, VK_J, VK_K, VK_L,
+    VK_LEFT, VK_LWIN, VK_M, VK_MENU, VK_N, VK_NEXT, VK_O, VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4,
+    VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_COMMA, VK_OEM_MINUS, VK_OEM_PERIOD, VK_OEM_PLUS, VK_P,
+    VK_PRIOR, VK_Q, VK_R, VK_RETURN, VK_RIGHT, VK_S, VK_SHIFT, VK_SPACE, VK_T, VK_TAB, VK_U, VK_UP,
+    VK_V, VK_W, VK_X, VK_Y, VK_Z,
+};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
+};
+
+use xa11y_core::input::{InputProvider, Key, MouseButton, Point, ScrollDelta};
+use xa11y_core::{Error, Result};
+
+/// One notch of a physical mouse wheel. Matches Win32's `WHEEL_DELTA` macro.
+const WHEEL_DELTA: i32 = 120;
+
+/// `SendInput`-based [`InputProvider`] for Windows.
+///
+/// All calls serialize through an internal mutex so concurrent threads don't
+/// interleave pointer moves or key up/down pairs (Win32 event ordering is
+/// global to the desktop session).
+#[derive(Default)]
+pub struct WindowsInputProvider {
+    lock: Mutex<()>,
+}
+
+impl WindowsInputProvider {
+    pub fn new() -> Result<Self> {
+        Ok(Self::default())
+    }
+
+    fn send(&self, inputs: &[INPUT]) -> Result<()> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        let size = std::mem::size_of::<INPUT>() as i32;
+        // SAFETY: `inputs` is a valid slice and `size` matches `INPUT`.
+        let sent = unsafe { SendInput(inputs, size) };
+        if sent as usize != inputs.len() {
+            // SAFETY: GetLastError takes no args and is always safe to call.
+            let code = unsafe { GetLastError().0 } as i64;
+            return Err(Error::Platform {
+                code,
+                message: format!(
+                    "SendInput sent {sent}/{} events (GetLastError={code})",
+                    inputs.len()
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+fn mouse_input(flags: u32, dx: i32, dy: i32, data: i32) -> INPUT {
+    INPUT {
+        r#type: INPUT_MOUSE,
+        Anonymous: INPUT_0 {
+            mi: MOUSEINPUT {
+                dx,
+                dy,
+                mouseData: data as u32,
+                dwFlags: windows::Win32::UI::Input::KeyboardAndMouse::MOUSE_EVENT_FLAGS(flags),
+                time: 0,
+                dwExtraInfo: 0,
+            },
+        },
+    }
+}
+
+fn key_input(vk: VIRTUAL_KEY, flags: KEYBD_EVENT_FLAGS) -> INPUT {
+    INPUT {
+        r#type: INPUT_KEYBOARD,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: vk,
+                wScan: 0,
+                dwFlags: flags,
+                time: 0,
+                dwExtraInfo: 0,
+            },
+        },
+    }
+}
+
+fn unicode_input(code_unit: u16, key_up: bool) -> INPUT {
+    let mut flags = KEYEVENTF_UNICODE;
+    if key_up {
+        flags |= KEYEVENTF_KEYUP;
+    }
+    INPUT {
+        r#type: INPUT_KEYBOARD,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: VIRTUAL_KEY(0),
+                wScan: code_unit,
+                dwFlags: flags,
+                time: 0,
+                dwExtraInfo: 0,
+            },
+        },
+    }
+}
+
+/// Normalize a physical screen pixel to the 0..=65535 absolute coordinate
+/// range expected by `SendInput` with `MOUSEEVENTF_VIRTUALDESK`.
+fn to_absolute(x: i32, y: i32) -> (i32, i32) {
+    // SAFETY: GetSystemMetrics takes a constant and returns i32; always safe.
+    let vx = unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) };
+    let vy = unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) };
+    let vw = unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) }.max(1);
+    let vh = unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) }.max(1);
+    // +vw/2 / vw biases toward the logical centre of each pixel (Microsoft's
+    // documented formula for normalised absolute mouse coordinates).
+    let ax = (((x - vx) as i64 * 65535 + (vw as i64 / 2)) / vw as i64) as i32;
+    let ay = (((y - vy) as i64 * 65535 + (vh as i64 / 2)) / vh as i64) as i32;
+    (ax, ay)
+}
+
+/// Map a named [`Key`] to its Win32 virtual-key code. Returns the VK plus a
+/// bool indicating whether the key should be marked extended (arrow keys,
+/// navigation cluster, Right Alt/Ctrl, etc.).
+fn vk_for(key: &Key) -> Result<(VIRTUAL_KEY, bool)> {
+    let v = match key {
+        Key::Shift => (VK_SHIFT, false),
+        Key::Ctrl => (VK_CONTROL, false),
+        Key::Alt => (VK_MENU, false),
+        Key::Meta => (VK_LWIN, true),
+        Key::Enter => (VK_RETURN, false),
+        Key::Escape => (VK_ESCAPE, false),
+        Key::Backspace => (VK_BACK, false),
+        Key::Tab => (VK_TAB, false),
+        Key::Space => (VK_SPACE, false),
+        Key::Delete => (VK_DELETE, true),
+        Key::Insert => (VK_INSERT, true),
+        Key::ArrowUp => (VK_UP, true),
+        Key::ArrowDown => (VK_DOWN, true),
+        Key::ArrowLeft => (VK_LEFT, true),
+        Key::ArrowRight => (VK_RIGHT, true),
+        Key::Home => (VK_HOME, true),
+        Key::End => (VK_END, true),
+        Key::PageUp => (VK_PRIOR, true),
+        Key::PageDown => (VK_NEXT, true),
+        Key::F(n) => {
+            let vk = match n {
+                1 => VK_F1,
+                2 => VK_F2,
+                3 => VK_F3,
+                4 => VK_F4,
+                5 => VK_F5,
+                6 => VK_F6,
+                7 => VK_F7,
+                8 => VK_F8,
+                9 => VK_F9,
+                10 => VK_F10,
+                11 => VK_F11,
+                12 => VK_F12,
+                13 => VK_F13,
+                14 => VK_F14,
+                15 => VK_F15,
+                16 => VK_F16,
+                17 => VK_F17,
+                18 => VK_F18,
+                19 => VK_F19,
+                20 => VK_F20,
+                21 => VK_F21,
+                22 => VK_F22,
+                23 => VK_F23,
+                24 => VK_F24,
+                _ => {
+                    return Err(Error::InvalidActionData {
+                        message: format!("F{n} is out of range (1..=24)"),
+                    });
+                }
+            };
+            (vk, false)
+        }
+        Key::Char(c) => (vk_for_char(*c)?, false),
+    };
+    Ok(v)
+}
+
+/// Map a `Key::Char` value to a virtual-key code assuming a US layout for
+/// symbols. The [`Key`] contract guarantees `c` is not ASCII uppercase, so we
+/// only need to handle lowercase letters, digits, and common OEM punctuation.
+fn vk_for_char(c: char) -> Result<VIRTUAL_KEY> {
+    let vk = match c {
+        'a' => VK_A,
+        'b' => VK_B,
+        'c' => VK_C,
+        'd' => VK_D,
+        'e' => VK_E,
+        'f' => VK_F,
+        'g' => VK_G,
+        'h' => VK_H,
+        'i' => VK_I,
+        'j' => VK_J,
+        'k' => VK_K,
+        'l' => VK_L,
+        'm' => VK_M,
+        'n' => VK_N,
+        'o' => VK_O,
+        'p' => VK_P,
+        'q' => VK_Q,
+        'r' => VK_R,
+        's' => VK_S,
+        't' => VK_T,
+        'u' => VK_U,
+        'v' => VK_V,
+        'w' => VK_W,
+        'x' => VK_X,
+        'y' => VK_Y,
+        'z' => VK_Z,
+        '0' => VK_0,
+        '1' => VK_1,
+        '2' => VK_2,
+        '3' => VK_3,
+        '4' => VK_4,
+        '5' => VK_5,
+        '6' => VK_6,
+        '7' => VK_7,
+        '8' => VK_8,
+        '9' => VK_9,
+        ';' => VK_OEM_1,
+        '/' => VK_OEM_2,
+        '`' => VK_OEM_3,
+        '[' => VK_OEM_4,
+        '\\' => VK_OEM_5,
+        ']' => VK_OEM_6,
+        '\'' => VK_OEM_7,
+        ',' => VK_OEM_COMMA,
+        '.' => VK_OEM_PERIOD,
+        '-' => VK_OEM_MINUS,
+        '=' => VK_OEM_PLUS,
+        _ => {
+            return Err(Error::Unsupported {
+                feature: format!(
+                    "Key::Char('{c}') has no Win32 virtual-key mapping; \
+                     use Keyboard::type_text for arbitrary characters"
+                ),
+            });
+        }
+    };
+    Ok(vk)
+}
+
+fn button_down_up(button: MouseButton) -> (u32, u32) {
+    match button {
+        MouseButton::Left => (MOUSEEVENTF_LEFTDOWN.0, MOUSEEVENTF_LEFTUP.0),
+        MouseButton::Right => (MOUSEEVENTF_RIGHTDOWN.0, MOUSEEVENTF_RIGHTUP.0),
+        MouseButton::Middle => (MOUSEEVENTF_MIDDLEDOWN.0, MOUSEEVENTF_MIDDLEUP.0),
+    }
+}
+
+impl InputProvider for WindowsInputProvider {
+    fn pointer_move(&self, to: Point) -> Result<()> {
+        let (ax, ay) = to_absolute(to.x, to.y);
+        let input = mouse_input(
+            MOUSEEVENTF_MOVE.0 | MOUSEEVENTF_ABSOLUTE.0 | MOUSEEVENTF_VIRTUALDESK.0,
+            ax,
+            ay,
+            0,
+        );
+        self.send(&[input])
+    }
+
+    fn pointer_down(&self, button: MouseButton) -> Result<()> {
+        let (down, _) = button_down_up(button);
+        self.send(&[mouse_input(down, 0, 0, 0)])
+    }
+
+    fn pointer_up(&self, button: MouseButton) -> Result<()> {
+        let (_, up) = button_down_up(button);
+        self.send(&[mouse_input(up, 0, 0, 0)])
+    }
+
+    fn pointer_click(&self, at: Point, button: MouseButton, count: u32) -> Result<()> {
+        if count == 0 {
+            return Ok(());
+        }
+        self.pointer_move(at)?;
+        let (down, up) = button_down_up(button);
+        // Batch each press/release into one SendInput call so the system
+        // bookkeeps the click-count (double/triple click) for us when the
+        // calls arrive within the OS double-click time.
+        for _ in 0..count {
+            self.send(&[mouse_input(down, 0, 0, 0), mouse_input(up, 0, 0, 0)])?;
+        }
+        Ok(())
+    }
+
+    fn pointer_scroll(&self, at: Point, delta: ScrollDelta) -> Result<()> {
+        self.pointer_move(at)?;
+        let step = WHEEL_DELTA;
+        if delta.dy != 0 {
+            // `Input.dy > 0` means scroll content down per module docs, which
+            // maps to a *positive* wheel delta on Win32 (wheel rolled forward).
+            self.send(&[mouse_input(MOUSEEVENTF_WHEEL.0, 0, 0, delta.dy * step)])?;
+        }
+        if delta.dx != 0 {
+            self.send(&[mouse_input(MOUSEEVENTF_HWHEEL.0, 0, 0, delta.dx * step)])?;
+        }
+        Ok(())
+    }
+
+    fn key_down(&self, key: &Key) -> Result<()> {
+        let (vk, extended) = vk_for(key)?;
+        let mut flags = KEYBD_EVENT_FLAGS(0);
+        if extended {
+            flags |= KEYEVENTF_EXTENDEDKEY;
+        }
+        self.send(&[key_input(vk, flags)])
+    }
+
+    fn key_up(&self, key: &Key) -> Result<()> {
+        let (vk, extended) = vk_for(key)?;
+        let mut flags = KEYEVENTF_KEYUP;
+        if extended {
+            flags |= KEYEVENTF_EXTENDEDKEY;
+        }
+        self.send(&[key_input(vk, flags)])
+    }
+
+    fn type_text(&self, text: &str) -> Result<()> {
+        // Use KEYEVENTF_UNICODE so case/shift/IME behaviour is produced by
+        // the OS text-input path rather than by synthesising shift chords
+        // against whatever keyboard layout happens to be active.
+        let mut inputs: Vec<INPUT> = Vec::with_capacity(text.len() * 2);
+        for code_unit in text.encode_utf16() {
+            inputs.push(unicode_input(code_unit, false));
+            inputs.push(unicode_input(code_unit, true));
+        }
+        if inputs.is_empty() {
+            return Ok(());
+        }
+        self.send(&inputs)
+    }
+}

--- a/xa11y-windows/src/lib.rs
+++ b/xa11y-windows/src/lib.rs
@@ -6,8 +6,12 @@
 mod splice;
 
 #[cfg(target_os = "windows")]
+mod input;
+#[cfg(target_os = "windows")]
 mod uia;
 
+#[cfg(target_os = "windows")]
+pub use input::WindowsInputProvider;
 #[cfg(target_os = "windows")]
 pub use uia::WindowsProvider;
 
@@ -15,7 +19,7 @@ pub use uia::WindowsProvider;
 mod stub;
 
 #[cfg(not(target_os = "windows"))]
-pub use stub::WindowsProvider;
+pub use stub::{WindowsInputProvider, WindowsProvider};
 
 #[cfg(test)]
 mod tests {

--- a/xa11y-windows/src/lib.rs
+++ b/xa11y-windows/src/lib.rs
@@ -10,10 +10,14 @@ mod input;
 #[cfg(target_os = "windows")]
 mod uia;
 
+mod screenshot;
+
 #[cfg(target_os = "windows")]
 pub use input::WindowsInputProvider;
 #[cfg(target_os = "windows")]
 pub use uia::WindowsProvider;
+
+pub use screenshot::WindowsScreenshot;
 
 #[cfg(not(target_os = "windows"))]
 mod stub;

--- a/xa11y-windows/src/screenshot.rs
+++ b/xa11y-windows/src/screenshot.rs
@@ -1,0 +1,26 @@
+//! Windows screen capture — stub for this spike.
+//!
+//! A real implementation would use `Windows.Graphics.Capture` (UWP, DWM-aware,
+//! works on composited desktops) or GDI `BitBlt` (simpler, but breaks with
+//! per-monitor DPI and hardware-accelerated windows). Tracked as follow-up.
+
+use xa11y_core::{Error, Rect, Result, Screenshot, ScreenshotProvider};
+
+pub struct WindowsScreenshot;
+
+impl WindowsScreenshot {
+    pub fn new() -> Result<Self> {
+        Err(Error::Unsupported {
+            feature: "screenshot on Windows (not yet implemented)".into(),
+        })
+    }
+}
+
+impl ScreenshotProvider for WindowsScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        unreachable!()
+    }
+    fn capture_region(&self, _: Rect) -> Result<Screenshot> {
+        unreachable!()
+    }
+}

--- a/xa11y-windows/src/stub.rs
+++ b/xa11y-windows/src/stub.rs
@@ -1,5 +1,6 @@
 //! Stub backend for non-Windows platforms (allows compilation on all targets).
 
+use xa11y_core::input::{InputProvider, Key, MouseButton, Point, ScrollDelta};
 use xa11y_core::{ElementData, Error, Provider, Result, Subscription};
 
 #[derive(Default)]
@@ -11,6 +12,45 @@ impl WindowsProvider {
             code: -1,
             message: "Windows backend only available on Windows".to_string(),
         })
+    }
+}
+
+#[derive(Default)]
+pub struct WindowsInputProvider;
+
+impl WindowsInputProvider {
+    pub fn new() -> Result<Self> {
+        Err(Error::Platform {
+            code: -1,
+            message: "Windows input backend only available on Windows".to_string(),
+        })
+    }
+}
+
+impl InputProvider for WindowsInputProvider {
+    fn pointer_move(&self, _: Point) -> Result<()> {
+        unreachable!()
+    }
+    fn pointer_down(&self, _: MouseButton) -> Result<()> {
+        unreachable!()
+    }
+    fn pointer_up(&self, _: MouseButton) -> Result<()> {
+        unreachable!()
+    }
+    fn pointer_click(&self, _: Point, _: MouseButton, _: u32) -> Result<()> {
+        unreachable!()
+    }
+    fn pointer_scroll(&self, _: Point, _: ScrollDelta) -> Result<()> {
+        unreachable!()
+    }
+    fn key_down(&self, _: &Key) -> Result<()> {
+        unreachable!()
+    }
+    fn key_up(&self, _: &Key) -> Result<()> {
+        unreachable!()
+    }
+    fn type_text(&self, _: &str) -> Result<()> {
+        unreachable!()
     }
 }
 

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -25,6 +25,13 @@ pub use xa11y_core::{
     Rect, Result, Role, StateFlag, StateSet, Subscription, SubscriptionIter, Toggled,
 };
 
+// Re-export input simulation surface.
+pub use xa11y_core::input;
+pub use xa11y_core::{
+    anchor_point, point_for, Anchor, ClickOptions, ClickTarget, DragOptions, InputProvider,
+    InputSim, IntoPoint, Key, Keyboard, Mouse, MouseButton, Point, ScrollDelta,
+};
+
 // Implementation details used by platform backends and Python bindings.
 #[doc(hidden)]
 pub use xa11y_core::{CancelHandle, EventReceiver, Provider, RecvStatus, Selector};
@@ -72,6 +79,40 @@ pub fn provider() -> Result<Arc<dyn Provider>> {
 #[cfg(feature = "testing")]
 pub fn create_provider() -> Result<Arc<dyn Provider>> {
     create_provider_boxed().map(Arc::from)
+}
+
+/// Build an [`InputSim`] backed by the platform's native input-synthesis API
+/// (CGEvent on macOS, SendInput on Windows, XTest on X11). Returns
+/// [`Error::Unsupported`] on a Wayland-only Linux session and
+/// [`Error::Platform`] on any other platform we don't ship a backend for.
+///
+/// `InputSim` is cheap to clone — construct one and share it.
+pub fn input_sim() -> Result<InputSim> {
+    #[cfg(target_os = "macos")]
+    {
+        let backend = xa11y_macos::MacOSInputProvider::new()?;
+        Ok(InputSim::new(Arc::new(backend)))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let backend = xa11y_windows::WindowsInputProvider::new()?;
+        Ok(InputSim::new(Arc::new(backend)))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let backend = xa11y_linux::LinuxInputProvider::new()?;
+        Ok(InputSim::new(Arc::new(backend)))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        Err(Error::Platform {
+            code: -1,
+            message: format!(
+                "Input simulation not available on platform: {}",
+                std::env::consts::OS
+            ),
+        })
+    }
 }
 
 fn create_provider_boxed() -> Result<Box<dyn Provider>> {

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -32,6 +32,10 @@ pub use xa11y_core::{
     InputSim, IntoPoint, Key, Keyboard, Mouse, MouseButton, Point, ScrollDelta,
 };
 
+// Re-export screenshot surface.
+pub use xa11y_core::screenshot;
+pub use xa11y_core::{Screenshot, ScreenshotProvider, Screenshotter};
+
 // Implementation details used by platform backends and Python bindings.
 #[doc(hidden)]
 pub use xa11y_core::{CancelHandle, EventReceiver, Provider, RecvStatus, Selector};
@@ -109,6 +113,45 @@ pub fn input_sim() -> Result<InputSim> {
             code: -1,
             message: format!(
                 "Input simulation not available on platform: {}",
+                std::env::consts::OS
+            ),
+        })
+    }
+}
+
+/// Build a [`Screenshotter`] backed by the platform's native capture API
+/// (ScreenCaptureKit on macOS, X11 `GetImage` or xdg-desktop-portal on Linux,
+/// stubbed on Windows).
+///
+/// Returns:
+/// - [`Error::PermissionDenied`] on macOS if Screen Recording permission
+///   hasn't been granted (or on Linux if the Wayland portal denies consent).
+/// - [`Error::Unsupported`] on Linux if neither `DISPLAY` nor `WAYLAND_DISPLAY`
+///   is set, and on Windows until a backend ships.
+///
+/// `Screenshotter` is cheap to clone — construct one and share it.
+pub fn screenshotter() -> Result<Screenshotter> {
+    #[cfg(target_os = "macos")]
+    {
+        let backend = xa11y_macos::MacOSScreenshot::new()?;
+        Ok(Screenshotter::new(Arc::new(backend)))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let backend = xa11y_windows::WindowsScreenshot::new()?;
+        Ok(Screenshotter::new(Arc::new(backend)))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let backend = xa11y_linux::LinuxScreenshot::new()?;
+        Ok(Screenshotter::new(Arc::new(backend)))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        Err(Error::Platform {
+            code: -1,
+            message: format!(
+                "Screenshot not available on platform: {}",
                 std::env::consts::OS
             ),
         })

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -14,6 +14,7 @@
 //! are reached from submodule tests via `use crate::integ as h;`.
 
 pub mod actions;
+pub mod screenshot;
 pub mod tree;
 
 #[cfg(target_os = "macos")]

--- a/xa11y/tests/integ/screenshot.rs
+++ b/xa11y/tests/integ/screenshot.rs
@@ -1,0 +1,74 @@
+//! Screenshot integration tests — capture pixels from the running test app
+//! and verify the PNG round-trips through the decoder at the expected size.
+
+#[cfg(test)]
+mod tests {
+    use crate::integ as h;
+
+    #[test]
+    #[ignore]
+    fn capture_full_screen_yields_nonempty_png() {
+        let shot = xa11y::screenshotter()
+            .expect("screenshotter construction")
+            .capture()
+            .expect("full-screen capture");
+        assert!(shot.width > 0 && shot.height > 0, "empty capture dims");
+        assert_eq!(
+            shot.pixels.len(),
+            (shot.width as usize) * (shot.height as usize) * 4
+        );
+
+        let bytes = shot.to_png().expect("PNG encode");
+        assert!(bytes.len() > 100, "PNG unexpectedly small");
+        assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n", "missing PNG signature");
+    }
+
+    #[test]
+    #[ignore]
+    fn capture_element_matches_bounds_at_scale() {
+        let app = h::app_root();
+        // Any element with on-screen bounds works; Submit is a well-known
+        // named button in the AccessKit test app.
+        let button = h::named(&app, "Submit");
+
+        // In headless CI (--headless winit), the test app has no on-screen
+        // bounds. Skip the assertion part in that case — the full-screen
+        // test in this module still validates the core pipeline.
+        let Some(bounds) = button.bounds else {
+            eprintln!("skipping: element has no bounds (likely headless)");
+            return;
+        };
+        if bounds.width == 0 || bounds.height == 0 {
+            eprintln!("skipping: element bounds are zero-sized");
+            return;
+        }
+
+        let shot = xa11y::screenshotter()
+            .expect("screenshotter construction")
+            .capture_element(&button)
+            .expect("element capture");
+
+        assert!(shot.scale > 0.0);
+        let expected_w = (bounds.width as f32 * shot.scale).round() as u32;
+        let expected_h = (bounds.height as f32 * shot.scale).round() as u32;
+        // Allow 1px slack for rounding on fractional scale factors.
+        assert!(
+            (shot.width as i64 - expected_w as i64).abs() <= 1,
+            "width {} not within 1 of expected {} (scale {})",
+            shot.width,
+            expected_w,
+            shot.scale
+        );
+        assert!(
+            (shot.height as i64 - expected_h as i64).abs() <= 1,
+            "height {} not within 1 of expected {} (scale {})",
+            shot.height,
+            expected_h,
+            shot.scale
+        );
+
+        // Round-trip through PNG.
+        let bytes = shot.to_png().expect("PNG encode");
+        assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+    }
+}


### PR DESCRIPTION
## Summary

Two new capabilities, each on its own surface, kept fully decoupled from the a11y `Provider` trait:

- **Input simulation** (`xa11y::input_sim()`): synthesised pointer + keyboard events. `InputProvider` trait in `xa11y-core` with backends in `xa11y-{macos,linux,windows}`. CGEvent on macOS, SendInput on Windows, XTest on X11 (Wayland returns `Error::Unsupported`).
- **Screenshot** (`xa11y::screenshotter()`): pixel capture returning RGBA8 at physical resolution with a scale factor. `ScreenshotProvider` trait in `xa11y-core`. ScreenCaptureKit on macOS (CGDisplay* is obsoleted on 15+), X11 `GetImage` + `xdg-desktop-portal.Screenshot` on Linux, stub on Windows.

Both surfaces follow the same pattern: trait in core, backend structs in platform crates, thin wrapper type (`InputSim` / `Screenshotter`) holding an `Arc<dyn ...Provider>`. Neither surface calls into the a11y tree and the a11y tree never falls back to either — per tenet 1 (no silent fallbacks).

## Notable notes

- **macOS screenshot switched to ScreenCaptureKit.** `CGDisplayCreateImage[ForRect]` are hard-unavailable on the macOS 15+ SDK; the new `safe_cg_capture_rgba` wrapper uses `SCScreenshotManager` with a dispatch-semaphore sync-over-async. `exception_safe.m` now builds with `-fobjc-arc` so `__block NSError *` captures in completion handlers retain correctly (without ARC the captured error was autoreleased before the outer thread read it, causing SIGSEGV). Existing CF retain/release calls are ARC-safe.
- **Linux Wayland** uses the portal's `Screenshot` method, which returns a PNG file URI; we decode back to RGBA and crop client-side for region captures. Portal UX means the first call per session may prompt.
- **No auto-raise** on element capture — occluded elements return whatever pixels are at their screen bounds, matching Playwright's behaviour.
- Integration tests are `#[ignore]`'d and run via `cargo xtask test-integ` per CLAUDE.md.

## Test plan
- [ ] `cargo xtask check` — fmt, lint, unit tests, macOS FFI exception-safety, bindings parity (verified locally on macOS)
- [ ] macOS integ tests — `cargo xtask test-integ` including the new `capture_full_screen_yields_nonempty_png` and `capture_element_matches_bounds_at_scale` tests
- [ ] Linux integ tests via Finch — `cargo xtask test-integ-container`
- [ ] Windows CI — confirm stub returns `Error::Unsupported` cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)