### PR TITLE
feat(screenshot): cross-platform screenshot + Windows GDI impl + Wayland portal tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,10 +694,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -1028,6 +1062,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1425,6 +1469,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1777,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -2720,6 +2783,7 @@ dependencies = [
 name = "xa11y-core"
 version = "0.6.2"
 dependencies = [
+ "png",
  "serde",
  "serde_json",
  "strum",
@@ -2739,6 +2803,7 @@ dependencies = [
 name = "xa11y-linux"
 version = "0.6.2"
 dependencies = [
+ "png",
  "rayon",
  "serde_json",
  "x11rb",

--- a/Containerfile.wayland
+++ b/Containerfile.wayland
@@ -1,0 +1,23 @@
+FROM xa11y-base
+
+# Headless Wayland + xdg-desktop-portal for the Screenshot portal path.
+# We use sway (wlroots-based) as the compositor because it supports true
+# headless output (WLR_BACKENDS=headless) and pairs with xdg-desktop-portal-wlr,
+# which implements org.freedesktop.portal.Screenshot for wlroots compositors.
+#
+# GNOME/KDE portal backends assume a full desktop session and are not
+# reasonable inside a CI-sized container; wlr is the minimal working option.
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+        sway xdg-desktop-portal xdg-desktop-portal-wlr \
+        xdg-desktop-portal-gtk \
+        wayland-protocols libwayland-dev libwayland-client0 \
+        grim \
+        pipewire pipewire-pulse wireplumber \
+    && rm -rf /var/lib/apt/lists/*
+
+# sway expects /run/user/<uid> for XDG_RUNTIME_DIR; create it at image time
+# and rely on the script to chmod 700 and own it at container start-up.
+RUN mkdir -p /run/user/0 && chmod 700 /run/user/0

--- a/scripts/run_input_smoke.sh
+++ b/scripts/run_input_smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run the xa11y-linux input-smoke tests (XTest-driven) under Xvfb inside the
+# Linux integ container. Verifies the X11 input backend end-to-end.
+set -euo pipefail
+
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    exec dbus-run-session -- bash "$0" "$@"
+fi
+
+CLEANUP_PIDS=()
+cleanup() {
+    for pid in "${CLEANUP_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT
+
+Xvfb :99 -screen 0 1280x1024x24 -ac &
+CLEANUP_PIDS+=($!)
+sleep 1
+export DISPLAY=:99
+
+cd /xa11y
+cargo test -p xa11y-linux --test input_smoke -- --ignored --test-threads=1 --nocapture 2>&1

--- a/scripts/run_wayland_portal.sh
+++ b/scripts/run_wayland_portal.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Force unbuffered output — docker run otherwise batches diagnostic prints
+# from this wrapper with the `cargo test` output at the end.
+exec 1> >(stdbuf -o0 cat) 2>&1
+# Drive the Linux Wayland portal-Screenshot path end-to-end inside the
+# xa11y-wayland container:
+#   1. start a D-Bus session bus
+#   2. start sway (wlroots) with the headless backend
+#   3. start xdg-desktop-portal + xdg-desktop-portal-wlr
+#   4. run the xa11y-linux screenshot tests with WAYLAND_DISPLAY set and
+#      DISPLAY unset, forcing the portal code path
+#
+# The portal-wlr backend auto-approves screenshot requests for clients it
+# can identify, which is what we need in non-interactive CI. If consent is
+# asked for, the call will block forever — the harness applies a 30s
+# timeout to each `cargo test` to surface that case cleanly.
+set -euo pipefail
+
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    exec dbus-run-session -- bash "$0" "$@"
+fi
+
+export XDG_RUNTIME_DIR=/run/user/0
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+# Suppress the "can't start the accessibility bus" chatter from sway — it's
+# not relevant to the screenshot path.
+export NO_AT_BRIDGE=1
+export XDG_SESSION_TYPE=wayland
+export XDG_CURRENT_DESKTOP=sway
+
+CLEANUP_PIDS=()
+cleanup() {
+    for pid in "${CLEANUP_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT
+
+# 1. Start sway with the headless wlroots backend. A minimal config is
+# enough — we just need the compositor up so the wl_display socket exists.
+cat > /tmp/sway.conf <<'EOF'
+# Minimal headless sway config: no inputs, one virtual output.
+output HEADLESS-1 resolution 1280x1024 position 0,0
+EOF
+WLR_BACKENDS=headless \
+WLR_LIBINPUT_NO_DEVICES=1 \
+WLR_RENDERER=pixman \
+sway -c /tmp/sway.conf >/tmp/sway.log 2>&1 &
+CLEANUP_PIDS+=($!)
+
+# Wait for sway to create the Wayland socket.
+for _ in $(seq 1 30); do
+    if compgen -G "$XDG_RUNTIME_DIR/wayland-*" >/dev/null; then
+        break
+    fi
+    sleep 0.2
+done
+sock=$(ls "$XDG_RUNTIME_DIR"/wayland-* 2>/dev/null | head -1 || true)
+if [ -z "$sock" ]; then
+    echo "sway failed to create a Wayland socket. Log:" >&2
+    cat /tmp/sway.log >&2 || true
+    exit 1
+fi
+export WAYLAND_DISPLAY="$(basename "$sock")"
+unset DISPLAY
+echo "WAYLAND_DISPLAY=$WAYLAND_DISPLAY"
+
+# 1b. Start pipewire — xdg-desktop-portal-wlr will fail to expose its
+# Screenshot and ScreenCast interfaces if it can't talk to a pipewire core
+# (ScreenCast needs the pipewire graph; Screenshot init is gated on the
+# same startup path).
+pipewire >/tmp/pipewire.log 2>&1 &
+CLEANUP_PIDS+=($!)
+wireplumber >/tmp/wireplumber.log 2>&1 &
+CLEANUP_PIDS+=($!)
+# Wait briefly for pipewire to come up on the session bus.
+for _ in $(seq 1 25); do
+    if pw-cli info 0 >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.2
+done
+
+# 2. Start the portal infrastructure. xdg-desktop-portal-wlr exports the
+# Screenshot interface for wlroots compositors; xdg-desktop-portal is the
+# frontend that sits on the session bus.
+#
+# The portal frontend picks a backend based on XDG_CURRENT_DESKTOP and a
+# /usr/share/xdg-desktop-portal/portals/<name>.portal manifest. The wlr
+# package ships wlr.portal with UseIn=sway (amongst others), so setting
+# XDG_CURRENT_DESKTOP=sway above makes the frontend route screenshot
+# requests to xdg-desktop-portal-wlr.
+#
+# Ubuntu 24.04's shipped sway-portals.conf leaves Screenshot unbound in
+# practice (only ScreenCast gets routed to wlr). Write an explicit override
+# into a user-scoped config so Screenshot reaches the wlr backend too.
+mkdir -p /root/.config/xdg-desktop-portal
+cat > /root/.config/xdg-desktop-portal/sway-portals.conf <<'EOF'
+[preferred]
+default=wlr;gtk
+# Screenshot requires an Access portal (for consent UI) which wlr doesn't
+# implement — fall back to gtk for Access while keeping wlr for Screenshot
+# itself.
+org.freedesktop.impl.portal.Screenshot=wlr
+org.freedesktop.impl.portal.ScreenCast=wlr
+org.freedesktop.impl.portal.Access=gtk
+EOF
+/usr/libexec/xdg-desktop-portal-wlr -l TRACE >/tmp/portal-wlr.log 2>&1 &
+CLEANUP_PIDS+=($!)
+/usr/libexec/xdg-desktop-portal-gtk >/tmp/portal-gtk.log 2>&1 &
+CLEANUP_PIDS+=($!)
+/usr/libexec/xdg-desktop-portal -v >/tmp/portal.log 2>&1 &
+CLEANUP_PIDS+=($!)
+
+# xdg-desktop-portal registers its portal objects lazily as the impl
+# backends respond on the bus. In a container without a systemd user unit
+# or graphical session, the chain (pipewire → xdpw → xdp frontend) takes a
+# few seconds to stabilise. Sleep then introspect — a single check is more
+# reliable here than polling, which in practice races the build artefacts
+# being mmap'd.
+sleep 10
+echo "---Screenshot interface check---"
+if dbus-send --session --print-reply \
+     --dest=org.freedesktop.portal.Desktop \
+     /org/freedesktop/portal/desktop \
+     org.freedesktop.DBus.Introspectable.Introspect 2>&1 \
+     | grep -q 'org\.freedesktop\.portal\.Screenshot'; then
+    echo "OK: portal Screenshot interface is registered."
+else
+    echo "WARN: portal Screenshot interface not registered; test will fail."
+fi
+
+# Dump the logs on the way in so failures are self-explanatory.
+echo "---portal-wlr log---"
+tail -20 /tmp/portal-wlr.log 2>/dev/null || true
+echo "---portal log---"
+tail -20 /tmp/portal.log 2>/dev/null || true
+echo "---end logs---"
+
+echo "---portal interfaces at /org/freedesktop/portal/desktop---"
+dbus-send --session --print-reply --dest=org.freedesktop.portal.Desktop \
+    /org/freedesktop/portal/desktop \
+    org.freedesktop.DBus.Introspectable.Introspect 2>&1 \
+    | grep -E 'interface name|method name=' | head -40 || true
+echo "---end interfaces---"
+echo "---impl-side: does xdpw expose Screenshot impl?---"
+dbus-send --session --print-reply --dest=org.freedesktop.impl.portal.desktop.wlr \
+    /org/freedesktop/portal/desktop \
+    org.freedesktop.DBus.Introspectable.Introspect 2>&1 \
+    | grep -E 'interface name=' | head -20 || true
+echo "---end impl-side---"
+
+# 3. Build the workspace and launch the AccessKit test app so the
+# element-capture test has a live a11y tree to aim at. We enable AT-SPI2
+# on the bus first — same as run_integ_tests.sh does for X11.
+export NO_AT_BRIDGE=0
+export AT_SPI_CLIENT=true
+export ACCESSIBILITY_ENABLED=1
+if command -v /usr/libexec/at-spi-bus-launcher &>/dev/null; then
+    /usr/libexec/at-spi-bus-launcher --launch-immediately &
+    CLEANUP_PIDS+=($!)
+fi
+if command -v /usr/libexec/at-spi2-registryd &>/dev/null; then
+    /usr/libexec/at-spi2-registryd &
+    CLEANUP_PIDS+=($!)
+fi
+sleep 1
+dbus-send --session --print-reply --dest=org.a11y.Bus /org/a11y/bus \
+    org.freedesktop.DBus.Properties.Set \
+    string:org.a11y.Status string:IsEnabled variant:boolean:true \
+    2>/dev/null || true
+dbus-send --session --print-reply --dest=org.a11y.Bus /org/a11y/bus \
+    org.freedesktop.DBus.Properties.Set \
+    string:org.a11y.Status string:ScreenReaderEnabled variant:boolean:true \
+    2>/dev/null || true
+
+cd /xa11y
+echo "Building workspace..."
+cargo build --workspace --features xa11y/strict-roles >/tmp/build.log 2>&1
+
+echo "Launching xa11y-test-app..."
+./target/debug/xa11y-test-app --headless >/tmp/test-app.log 2>&1 &
+CLEANUP_PIDS+=($!)
+sleep 3
+
+set +e
+timeout 60 cargo test -p xa11y --test integ_test --features strict-roles \
+    -- --ignored --test-threads=1 --nocapture capture_
+rc=$?
+set -e
+
+echo "---portal-wlr log (final)---"
+tail -40 /tmp/portal-wlr.log 2>/dev/null || true
+echo "---portal log (final)---"
+tail -40 /tmp/portal.log 2>/dev/null || true
+echo "---sway log (final)---"
+tail -20 /tmp/sway.log 2>/dev/null || true
+echo "---end---"
+exit $rc

--- a/scripts/run_wayland_smoke.sh
+++ b/scripts/run_wayland_smoke.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run the xa11y-linux Wayland smoke tests (session-detection + portal branch
+# selection) inside the container. The detection tests just flip env vars;
+# the full portal path requires weston + xdg-desktop-portal which this script
+# does NOT start — that coverage lives in run_wayland_portal.sh.
+set -euo pipefail
+
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    exec dbus-run-session -- bash "$0" "$@"
+fi
+
+cd /xa11y
+cargo test -p xa11y-linux --test wayland_smoke -- --ignored --test-threads=1 --nocapture 2>&1

--- a/xa11y-core/Cargo.toml
+++ b/xa11y-core/Cargo.toml
@@ -13,6 +13,7 @@ strict-roles = []
 test-support = []
 
 [dependencies]
+png = "0.17"
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { version = "0.28", features = ["derive"] }

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod input;
 pub mod locator;
 pub mod provider;
 pub mod role;
+pub mod screenshot;
 pub mod selector;
 
 /// Shared in-memory mock Provider. Gated behind `test-support` so only the
@@ -29,6 +30,7 @@ pub use input::{
 pub use locator::Locator;
 pub use provider::Provider;
 pub use role::{unknown_role, Role};
+pub use screenshot::{Screenshot, ScreenshotProvider, Screenshotter};
 pub use selector::Selector;
 
 /// Maximum tree traversal depth for providers. Prevents stack overflow from

--- a/xa11y-core/src/screenshot.rs
+++ b/xa11y-core/src/screenshot.rs
@@ -1,0 +1,156 @@
+//! Screenshot capture: pixel-level snapshots of the screen or a region.
+//!
+//! Screenshot is **separate from** both the accessibility action layer
+//! ([`crate::Provider`]) and the input-synthesis layer ([`crate::InputProvider`]).
+//! Backends that only capture pixels do not know how to read the a11y tree,
+//! synthesise input, or raise/activate windows — they are pure pixel readers.
+//!
+//! # What you get
+//!
+//! [`Screenshotter`] returns a [`Screenshot`] carrying raw RGBA8 pixels in
+//! **physical** (device) pixels — the same resolution the compositor renders
+//! at. On HiDPI displays that means pixel dimensions exceed the logical bounds
+//! you passed in; [`Screenshot::scale`] records the ratio. Call
+//! [`Screenshot::to_png`] or [`Screenshot::save_png`] to encode.
+//!
+//! # No auto-raise
+//!
+//! Capturing an element that is occluded or off-screen returns whatever pixels
+//! are at those coordinates — the target window is **not** raised or
+//! activated. If you need the element in the foreground, do that explicitly
+//! before calling [`Screenshotter::capture_element`].
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::element::{Element, Rect};
+use crate::error::{Error, Result};
+
+/// Platform backend trait for screen capture.
+///
+/// Implementors snapshot pixels from a display or a sub-region. They must
+/// return **physical** (device) pixels — never downscaled to logical points —
+/// and report the scale factor alongside the pixel buffer.
+///
+/// # Errors
+///
+/// - [`Error::PermissionDenied`] when the OS denies the capture permission
+///   (e.g. macOS Screen Recording).
+/// - [`Error::Unsupported`] when the current session has no capture path
+///   (e.g. Linux with neither X11 DISPLAY nor a working Wayland portal).
+/// - [`Error::Platform`] for raw OS / FFI failures.
+pub trait ScreenshotProvider: Send + Sync {
+    /// Capture the primary display in full.
+    fn capture_full(&self) -> Result<Screenshot>;
+
+    /// Capture a sub-rectangle specified in logical screen coordinates
+    /// (the same coordinate space as [`Rect`] in `Element::bounds`).
+    fn capture_region(&self, rect: Rect) -> Result<Screenshot>;
+}
+
+/// A captured image: raw RGBA8 pixels plus dimensions and scale.
+///
+/// `width` and `height` are in **physical** pixels. `scale` is the ratio of
+/// physical to logical (1.0 on standard displays, 2.0 on typical Retina /
+/// 1.5/1.75/2.0 on common Windows/Linux HiDPI configurations). `pixels.len()`
+/// equals `width * height * 4`.
+#[derive(Debug, Clone)]
+pub struct Screenshot {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+    pub scale: f32,
+}
+
+impl Screenshot {
+    /// Encode as PNG and return the bytes.
+    pub fn to_png(&self) -> Result<Vec<u8>> {
+        let expected = (self.width as usize)
+            .checked_mul(self.height as usize)
+            .and_then(|n| n.checked_mul(4))
+            .ok_or_else(|| Error::Platform {
+                code: -1,
+                message: "screenshot dimensions overflow".into(),
+            })?;
+        if self.pixels.len() != expected {
+            return Err(Error::Platform {
+                code: -1,
+                message: format!(
+                    "screenshot pixel buffer size {} does not match {}x{} RGBA ({} bytes)",
+                    self.pixels.len(),
+                    self.width,
+                    self.height,
+                    expected
+                ),
+            });
+        }
+
+        let mut out = Vec::new();
+        {
+            let mut encoder = png::Encoder::new(&mut out, self.width, self.height);
+            encoder.set_color(png::ColorType::Rgba);
+            encoder.set_depth(png::BitDepth::Eight);
+            let mut writer = encoder.write_header().map_err(png_err)?;
+            writer.write_image_data(&self.pixels).map_err(png_err)?;
+        }
+        Ok(out)
+    }
+
+    /// Encode as PNG and write to `path`.
+    pub fn save_png(&self, path: impl AsRef<Path>) -> Result<()> {
+        let bytes = self.to_png()?;
+        std::fs::write(path, bytes).map_err(|e| Error::Platform {
+            code: e.raw_os_error().unwrap_or(-1) as i64,
+            message: format!("save_png: {e}"),
+        })
+    }
+}
+
+fn png_err(e: png::EncodingError) -> Error {
+    Error::Platform {
+        code: -1,
+        message: format!("png encode: {e}"),
+    }
+}
+
+/// Handle for capturing screenshots. Cheap to clone — shares a single backend.
+#[derive(Clone)]
+pub struct Screenshotter {
+    backend: Arc<dyn ScreenshotProvider>,
+}
+
+impl Screenshotter {
+    pub fn new(backend: Arc<dyn ScreenshotProvider>) -> Self {
+        Self { backend }
+    }
+
+    /// Access the underlying provider for composite sequences.
+    pub fn backend(&self) -> &Arc<dyn ScreenshotProvider> {
+        &self.backend
+    }
+
+    /// Capture the full primary display.
+    pub fn capture(&self) -> Result<Screenshot> {
+        self.backend.capture_full()
+    }
+
+    /// Capture an explicit sub-rectangle of the screen.
+    pub fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
+        self.backend.capture_region(rect)
+    }
+
+    /// Capture the pixels under an element's current bounds.
+    ///
+    /// Returns [`Error::NoElementBounds`] if the element reports no bounds.
+    /// The target window is **not** raised or activated — see module docs.
+    pub fn capture_element(&self, element: &Element) -> Result<Screenshot> {
+        let rect = element.bounds.ok_or(Error::NoElementBounds)?;
+        self.backend.capture_region(rect)
+    }
+}
+
+impl std::fmt::Debug for Screenshotter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Screenshotter").finish_non_exhaustive()
+    }
+}

--- a/xa11y-js/Cargo.lock
+++ b/xa11y-js/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -225,6 +237,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -359,10 +380,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -611,13 +651,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "napi"
 version = "3.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb7848c221fb7bb789e02f01875287ebb1e078b92a6566a34de01ef8806e7c2b"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "ctor",
  "futures",
  "napi-build",
@@ -717,6 +767,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,7 +868,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -893,6 +956,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1166,7 +1235,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1367,7 +1436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -1429,6 +1498,7 @@ dependencies = [
 name = "xa11y-core"
 version = "0.6.2"
 dependencies = [
+ "png",
  "serde",
  "serde_json",
  "strum",
@@ -1450,6 +1520,7 @@ dependencies = [
 name = "xa11y-linux"
 version = "0.6.2"
 dependencies = [
+ "png",
  "rayon",
  "serde_json",
  "x11rb",

--- a/xa11y-linux/Cargo.toml
+++ b/xa11y-linux/Cargo.toml
@@ -11,6 +11,7 @@ xa11y-core = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+png = "0.17"
 rayon = "1"
 zbus = { version = "5", default-features = false, features = ["async-io", "blocking-api"] }
 # X11 + XTest for the input-simulation backend. Wayland is intentionally not

--- a/xa11y-linux/src/lib.rs
+++ b/xa11y-linux/src/lib.rs
@@ -13,13 +13,19 @@ mod events;
 mod input;
 
 #[cfg(target_os = "linux")]
+mod screenshot;
+
+#[cfg(target_os = "linux")]
 pub use atspi::LinuxProvider;
 
 #[cfg(target_os = "linux")]
 pub use input::LinuxInputProvider;
 
+#[cfg(target_os = "linux")]
+pub use screenshot::LinuxScreenshot;
+
 #[cfg(not(target_os = "linux"))]
 mod stub;
 
 #[cfg(not(target_os = "linux"))]
-pub use stub::{LinuxInputProvider, LinuxProvider};
+pub use stub::{LinuxInputProvider, LinuxProvider, LinuxScreenshot};

--- a/xa11y-linux/src/screenshot.rs
+++ b/xa11y-linux/src/screenshot.rs
@@ -28,16 +28,20 @@ pub struct LinuxScreenshot {
     backend: Backend,
 }
 
+// Box the X11 variant's fields — `RustConnection` is large enough that the
+// enum would otherwise be dominated by the X11 case and clippy flags it as
+// `large_enum_variant`. The backend sits behind an `Arc` in `Screenshotter`,
+// so the extra indirection costs at most one allocation per process.
 enum Backend {
-    X11 {
-        conn: Mutex<RustConnection>,
-        root_width: u16,
-        root_height: u16,
-        root: u32,
-    },
-    Wayland {
-        conn: ZbusConnection,
-    },
+    X11(Box<X11Backend>),
+    Wayland { conn: ZbusConnection },
+}
+
+struct X11Backend {
+    conn: Mutex<RustConnection>,
+    root_width: u16,
+    root_height: u16,
+    root: u32,
 }
 
 impl LinuxScreenshot {
@@ -63,12 +67,12 @@ impl LinuxScreenshot {
             let root_width = screen.width_in_pixels;
             let root_height = screen.height_in_pixels;
             Ok(Self {
-                backend: Backend::X11 {
+                backend: Backend::X11(Box::new(X11Backend {
                     conn: Mutex::new(conn),
                     root,
                     root_width,
                     root_height,
-                },
+                })),
             })
         } else if wayland {
             let conn = ZbusConnection::session().map_err(|e| Error::Platform {
@@ -250,24 +254,16 @@ impl LinuxScreenshot {
 impl ScreenshotProvider for LinuxScreenshot {
     fn capture_full(&self) -> Result<Screenshot> {
         match &self.backend {
-            Backend::X11 {
-                conn,
-                root,
-                root_width,
-                root_height,
-            } => self.capture_x11(conn, *root, *root_width, *root_height, None),
+            Backend::X11(x) => self.capture_x11(&x.conn, x.root, x.root_width, x.root_height, None),
             Backend::Wayland { conn } => self.capture_wayland(conn, None),
         }
     }
 
     fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
         match &self.backend {
-            Backend::X11 {
-                conn,
-                root,
-                root_width,
-                root_height,
-            } => self.capture_x11(conn, *root, *root_width, *root_height, Some(rect)),
+            Backend::X11(x) => {
+                self.capture_x11(&x.conn, x.root, x.root_width, x.root_height, Some(rect))
+            }
             Backend::Wayland { conn } => self.capture_wayland(conn, Some(rect)),
         }
     }

--- a/xa11y-linux/src/screenshot.rs
+++ b/xa11y-linux/src/screenshot.rs
@@ -1,0 +1,350 @@
+//! Linux screen capture. X11 path uses `GetImage` on the root window; Wayland
+//! path uses `org.freedesktop.portal.Screenshot` (PNG file URI returned by
+//! xdg-desktop-portal, decoded back into RGBA).
+//!
+//! Wayland portal capture **prompts the user** for consent the first time per
+//! session (subsequent calls may be auto-approved depending on the portal
+//! implementation) and captures the full screen only — regions are cropped
+//! client-side from the full capture.
+//!
+//! Scale factor is reported as 1.0 on both paths: X11 has no canonical way to
+//! read the user's HiDPI scale from the wire protocol (it's in Xft.dpi / XRDB
+//! or the compositor), and the portal returns already-composited pixels.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{ConnectionExt as _, ImageFormat};
+use x11rb::rust_connection::RustConnection;
+use zbus::blocking::Connection as ZbusConnection;
+use zbus::blocking::Proxy;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
+
+use xa11y_core::{Error, Rect, Result, Screenshot, ScreenshotProvider};
+
+/// Choose the Linux screenshot backend based on session environment.
+pub struct LinuxScreenshot {
+    backend: Backend,
+}
+
+enum Backend {
+    X11 {
+        conn: Mutex<RustConnection>,
+        root_width: u16,
+        root_height: u16,
+        root: u32,
+    },
+    Wayland {
+        conn: ZbusConnection,
+    },
+}
+
+impl LinuxScreenshot {
+    pub fn new() -> Result<Self> {
+        let display_set = std::env::var_os("DISPLAY").is_some();
+        let wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+
+        if display_set {
+            let (conn, screen_num) =
+                RustConnection::connect(None).map_err(|e| Error::Platform {
+                    code: -1,
+                    message: format!("X11 connect: {e}"),
+                })?;
+            let screen = conn
+                .setup()
+                .roots
+                .get(screen_num)
+                .ok_or_else(|| Error::Platform {
+                    code: -1,
+                    message: "X server reported no screens".into(),
+                })?;
+            let root = screen.root;
+            let root_width = screen.width_in_pixels;
+            let root_height = screen.height_in_pixels;
+            Ok(Self {
+                backend: Backend::X11 {
+                    conn: Mutex::new(conn),
+                    root,
+                    root_width,
+                    root_height,
+                },
+            })
+        } else if wayland {
+            let conn = ZbusConnection::session().map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("session bus connect: {e}"),
+            })?;
+            Ok(Self {
+                backend: Backend::Wayland { conn },
+            })
+        } else {
+            Err(Error::Unsupported {
+                feature: "screenshot (no DISPLAY or WAYLAND_DISPLAY set)".into(),
+            })
+        }
+    }
+
+    fn capture_x11(
+        &self,
+        conn: &Mutex<RustConnection>,
+        root: u32,
+        root_w: u16,
+        root_h: u16,
+        rect: Option<Rect>,
+    ) -> Result<Screenshot> {
+        let (x, y, w, h) = match rect {
+            None => (0_i16, 0_i16, root_w, root_h),
+            Some(r) => {
+                let x = i16::try_from(r.x).map_err(|_| Error::Platform {
+                    code: -1,
+                    message: "rect x out of i16 range".into(),
+                })?;
+                let y = i16::try_from(r.y).map_err(|_| Error::Platform {
+                    code: -1,
+                    message: "rect y out of i16 range".into(),
+                })?;
+                let w = u16::try_from(r.width).map_err(|_| Error::Platform {
+                    code: -1,
+                    message: "rect width out of u16 range".into(),
+                })?;
+                let h = u16::try_from(r.height).map_err(|_| Error::Platform {
+                    code: -1,
+                    message: "rect height out of u16 range".into(),
+                })?;
+                (x, y, w, h)
+            }
+        };
+        if w == 0 || h == 0 {
+            return Err(Error::Platform {
+                code: -1,
+                message: "zero-sized capture rect".into(),
+            });
+        }
+
+        let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
+        let reply = guard
+            .get_image(ImageFormat::Z_PIXMAP, root, x, y, w, h, !0)
+            .map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("GetImage: {e}"),
+            })?
+            .reply()
+            .map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("GetImage reply: {e}"),
+            })?;
+
+        // Most modern X servers return Z_PIXMAP at 32 bpp for 24-bit visuals,
+        // with layout BGRX on little-endian. Detect and convert to RGBA.
+        let bpp = (reply.data.len() / (w as usize * h as usize)) as u32;
+        if bpp != 4 {
+            return Err(Error::Platform {
+                code: -1,
+                message: format!("unsupported X11 pixmap layout: {bpp} bytes/pixel (expected 4)"),
+            });
+        }
+
+        let mut rgba = Vec::with_capacity(reply.data.len());
+        for chunk in reply.data.chunks_exact(4) {
+            // X11 BGRX little-endian → RGBA
+            rgba.push(chunk[2]);
+            rgba.push(chunk[1]);
+            rgba.push(chunk[0]);
+            rgba.push(0xFF);
+        }
+
+        Ok(Screenshot {
+            width: w as u32,
+            height: h as u32,
+            pixels: rgba,
+            scale: 1.0,
+        })
+    }
+
+    fn capture_wayland(&self, conn: &ZbusConnection, rect: Option<Rect>) -> Result<Screenshot> {
+        let proxy = Proxy::new(
+            conn,
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+            "org.freedesktop.portal.Screenshot",
+        )
+        .map_err(|e| Error::Platform {
+            code: -1,
+            message: format!("portal Screenshot proxy: {e}"),
+        })?;
+
+        let mut options: HashMap<&str, Value> = HashMap::new();
+        options.insert("interactive", Value::Bool(false));
+        options.insert("modal", Value::Bool(false));
+
+        let request_path: OwnedObjectPath =
+            proxy
+                .call("Screenshot", &("", options))
+                .map_err(|e| Error::Platform {
+                    code: -1,
+                    message: format!("portal Screenshot call: {e}"),
+                })?;
+
+        let request = Proxy::new(
+            conn,
+            "org.freedesktop.portal.Desktop",
+            &request_path,
+            "org.freedesktop.portal.Request",
+        )
+        .map_err(|e| Error::Platform {
+            code: -1,
+            message: format!("portal Request proxy: {e}"),
+        })?;
+
+        // Block for Response(response: u, results: a{sv}). First signal wins.
+        let mut signals = request
+            .receive_signal("Response")
+            .map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("receive_signal: {e}"),
+            })?;
+        let msg = signals.next().ok_or_else(|| Error::Platform {
+            code: -1,
+            message: "portal Response signal channel closed".into(),
+        })?;
+        let (response, results): (u32, HashMap<String, OwnedValue>) =
+            msg.body().deserialize().map_err(|e| Error::Platform {
+                code: -1,
+                message: format!("portal Response deserialize: {e}"),
+            })?;
+        if response != 0 {
+            return Err(Error::PermissionDenied {
+                instructions: format!("xdg-desktop-portal Screenshot denied (response={response})"),
+            });
+        }
+        let uri_val = results.get("uri").ok_or_else(|| Error::Platform {
+            code: -1,
+            message: "portal Response missing 'uri' key".into(),
+        })?;
+        let uri: String = uri_val
+            .downcast_ref::<String>()
+            .map_err(|_| Error::Platform {
+                code: -1,
+                message: "portal Response 'uri' is not a string".into(),
+            })?;
+        let path = uri.strip_prefix("file://").ok_or_else(|| Error::Platform {
+            code: -1,
+            message: format!("portal URI not file://: {uri}"),
+        })?;
+        let bytes = std::fs::read(path).map_err(|e| Error::Platform {
+            code: e.raw_os_error().unwrap_or(-1) as i64,
+            message: format!("read portal PNG: {e}"),
+        })?;
+        // Best-effort cleanup of portal tmpfile.
+        let _ = std::fs::remove_file(path);
+
+        let shot = decode_png_to_rgba(&bytes)?;
+        match rect {
+            None => Ok(shot),
+            Some(r) => crop_rgba(shot, r),
+        }
+    }
+}
+
+impl ScreenshotProvider for LinuxScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        match &self.backend {
+            Backend::X11 {
+                conn,
+                root,
+                root_width,
+                root_height,
+            } => self.capture_x11(conn, *root, *root_width, *root_height, None),
+            Backend::Wayland { conn } => self.capture_wayland(conn, None),
+        }
+    }
+
+    fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
+        match &self.backend {
+            Backend::X11 {
+                conn,
+                root,
+                root_width,
+                root_height,
+            } => self.capture_x11(conn, *root, *root_width, *root_height, Some(rect)),
+            Backend::Wayland { conn } => self.capture_wayland(conn, Some(rect)),
+        }
+    }
+}
+
+fn decode_png_to_rgba(bytes: &[u8]) -> Result<Screenshot> {
+    let decoder = png::Decoder::new(bytes);
+    let mut reader = decoder.read_info().map_err(|e| Error::Platform {
+        code: -1,
+        message: format!("png decode header: {e}"),
+    })?;
+    let info = reader.info().clone();
+    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let frame = reader.next_frame(&mut buf).map_err(|e| Error::Platform {
+        code: -1,
+        message: format!("png decode frame: {e}"),
+    })?;
+    buf.truncate(frame.buffer_size());
+
+    let rgba = match (info.color_type, info.bit_depth) {
+        (png::ColorType::Rgba, png::BitDepth::Eight) => buf,
+        (png::ColorType::Rgb, png::BitDepth::Eight) => {
+            let mut out = Vec::with_capacity((info.width * info.height * 4) as usize);
+            for px in buf.chunks_exact(3) {
+                out.extend_from_slice(&[px[0], px[1], px[2], 0xFF]);
+            }
+            out
+        }
+        (ct, bd) => {
+            return Err(Error::Platform {
+                code: -1,
+                message: format!("unsupported portal PNG format: {ct:?} @ {bd:?}"),
+            });
+        }
+    };
+
+    Ok(Screenshot {
+        width: info.width,
+        height: info.height,
+        pixels: rgba,
+        scale: 1.0,
+    })
+}
+
+fn crop_rgba(shot: Screenshot, rect: Rect) -> Result<Screenshot> {
+    let Screenshot {
+        width: sw,
+        height: sh,
+        pixels,
+        scale,
+    } = shot;
+    let x = rect.x.max(0) as u32;
+    let y = rect.y.max(0) as u32;
+    if x >= sw || y >= sh {
+        return Err(Error::Platform {
+            code: -1,
+            message: "crop rect outside captured image".into(),
+        });
+    }
+    let w = rect.width.min(sw - x);
+    let h = rect.height.min(sh - y);
+    if w == 0 || h == 0 {
+        return Err(Error::Platform {
+            code: -1,
+            message: "crop rect has zero size".into(),
+        });
+    }
+    let mut out = Vec::with_capacity((w * h * 4) as usize);
+    for row in 0..h {
+        let start = ((y + row) * sw + x) as usize * 4;
+        let end = start + (w as usize) * 4;
+        out.extend_from_slice(&pixels[start..end]);
+    }
+    Ok(Screenshot {
+        width: w,
+        height: h,
+        pixels: out,
+        scale,
+    })
+}

--- a/xa11y-linux/src/stub.rs
+++ b/xa11y-linux/src/stub.rs
@@ -1,7 +1,9 @@
 //! Stub backend for non-Linux platforms (allows compilation on all targets).
 
 use xa11y_core::input::{InputProvider, Key, MouseButton, Point, ScrollDelta};
-use xa11y_core::{ElementData, Error, Provider, Result, Subscription};
+use xa11y_core::{
+    ElementData, Error, Provider, Rect, Result, Screenshot, ScreenshotProvider, Subscription,
+};
 
 #[derive(Default)]
 pub struct LinuxProvider;
@@ -47,6 +49,26 @@ impl InputProvider for LinuxInputProvider {
         unreachable!()
     }
     fn type_text(&self, _: &str) -> Result<()> {
+        unreachable!()
+    }
+}
+
+pub struct LinuxScreenshot;
+
+impl LinuxScreenshot {
+    pub fn new() -> Result<Self> {
+        Err(Error::Platform {
+            code: -1,
+            message: "Linux screenshot backend only available on Linux".to_string(),
+        })
+    }
+}
+
+impl ScreenshotProvider for LinuxScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        unreachable!()
+    }
+    fn capture_region(&self, _: Rect) -> Result<Screenshot> {
         unreachable!()
     }
 }

--- a/xa11y-linux/tests/wayland_smoke.rs
+++ b/xa11y-linux/tests/wayland_smoke.rs
@@ -1,0 +1,114 @@
+//! Wayland session-detection smoke tests for [`xa11y_linux`].
+//!
+//! These exercise the environment-variable logic that picks a backend without
+//! requiring a real Wayland compositor or `xdg-desktop-portal`:
+//!
+//! - Input sim on Wayland-only sessions returns `Error::Unsupported`
+//!   (per Tenet 1 — no silent fallback to keysym guessing or libei without an
+//!   explicit backend).
+//! - The screenshot provider construction picks the Wayland branch when only
+//!   `WAYLAND_DISPLAY` is set, and the X11 branch when `DISPLAY` is set.
+//!
+//! Runs in a single-threaded section so env mutations don't race. Marked
+//! `#[ignore]` so the normal unit-test pass doesn't flip env vars on a
+//! developer workstation.
+
+#![cfg(target_os = "linux")]
+
+use xa11y_core::Error;
+use xa11y_linux::{LinuxInputProvider, LinuxScreenshot};
+
+// The three tests below all mutate process-global env vars. To guarantee
+// single-threaded access even when the harness forgets `--test-threads=1`,
+// they share a Mutex and each test performs its own save/restore.
+use std::sync::Mutex;
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn scoped_env<F: FnOnce()>(display: Option<&str>, wayland: Option<&str>, f: F) {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev_display = std::env::var_os("DISPLAY");
+    let prev_wayland = std::env::var_os("WAYLAND_DISPLAY");
+    // SAFETY: env mutations are guarded by ENV_LOCK and restored below.
+    unsafe {
+        match display {
+            Some(v) => std::env::set_var("DISPLAY", v),
+            None => std::env::remove_var("DISPLAY"),
+        }
+        match wayland {
+            Some(v) => std::env::set_var("WAYLAND_DISPLAY", v),
+            None => std::env::remove_var("WAYLAND_DISPLAY"),
+        }
+    }
+    f();
+    unsafe {
+        match prev_display {
+            Some(v) => std::env::set_var("DISPLAY", v),
+            None => std::env::remove_var("DISPLAY"),
+        }
+        match prev_wayland {
+            Some(v) => std::env::set_var("WAYLAND_DISPLAY", v),
+            None => std::env::remove_var("WAYLAND_DISPLAY"),
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn input_provider_reports_unsupported_on_wayland_only_session() {
+    scoped_env(None, Some("wayland-0"), || {
+        match LinuxInputProvider::new() {
+            Err(Error::Unsupported { feature }) => {
+                assert!(
+                    feature.contains("Wayland") || feature.contains("input simulation"),
+                    "feature string should name the missing capability; got {feature:?}"
+                );
+            }
+            Err(other) => panic!("expected Error::Unsupported, got {other:?}"),
+            Ok(_) => panic!("expected Error::Unsupported, got Ok"),
+        }
+    });
+}
+
+#[test]
+#[ignore]
+fn input_provider_reports_unsupported_with_no_display() {
+    scoped_env(None, None, || match LinuxInputProvider::new() {
+        Err(Error::Unsupported { .. }) => {}
+        Err(other) => panic!("expected Error::Unsupported, got {other:?}"),
+        Ok(_) => panic!("expected Error::Unsupported, got Ok"),
+    });
+}
+
+#[test]
+#[ignore]
+fn screenshot_constructor_picks_wayland_branch() {
+    // Construction must succeed even when no portal is reachable yet — the
+    // error only shows up at capture time. This mirrors the X11 branch, where
+    // the X server connection is also lazy from the caller's perspective in
+    // that `new()` doesn't probe the portal RPC.
+    scoped_env(None, Some("wayland-0"), || {
+        // If the session bus isn't available inside the container, we surface
+        // Error::Platform; that's fine — we're testing that the *branch* was
+        // Wayland, not that the portal RPC succeeds.
+        match LinuxScreenshot::new() {
+            Ok(_) => {}
+            Err(Error::Platform { message, .. }) => {
+                assert!(
+                    message.contains("session bus"),
+                    "Wayland-branch error should come from session-bus connect, got {message:?}"
+                );
+            }
+            Err(other) => panic!("unexpected error from Wayland-branch constructor: {other:?}"),
+        }
+    });
+}
+
+#[test]
+#[ignore]
+fn screenshot_constructor_reports_unsupported_with_no_display() {
+    scoped_env(None, None, || match LinuxScreenshot::new() {
+        Err(Error::Unsupported { .. }) => {}
+        Err(other) => panic!("expected Error::Unsupported, got {other:?}"),
+        Ok(_) => panic!("expected Error::Unsupported, got Ok"),
+    });
+}

--- a/xa11y-macos/build.rs
+++ b/xa11y-macos/build.rs
@@ -6,10 +6,13 @@ fn main() {
         cc::Build::new()
             .file("src/exception_safe.m")
             .flag("-fobjc-exceptions")
+            .flag("-fobjc-arc")
             .flag("-fmodules")
             .compile("exception_safe");
 
         println!("cargo:rustc-link-lib=framework=ApplicationServices");
+        println!("cargo:rustc-link-lib=framework=CoreGraphics");
         println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=ScreenCaptureKit");
     }
 }

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1267,7 +1267,7 @@ impl MacOSProvider {
     /// CGWindowListCopyWindowInfo. Without this permission, the list
     /// contains only system chrome (layer != 0). With it, app windows
     /// (layer 0) are included.
-    fn has_screen_recording_permission() -> bool {
+    pub(crate) fn has_screen_recording_permission() -> bool {
         let info = unsafe { safe_cg_window_list_copy(0, 0) };
         if info.is_null() {
             return false;

--- a/xa11y-macos/src/exception_safe.m
+++ b/xa11y-macos/src/exception_safe.m
@@ -6,7 +6,11 @@
 // aborts on foreign exceptions in extern "C" functions.
 
 #import <ApplicationServices/ApplicationServices.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
+#import <ScreenCaptureKit/ScreenCaptureKit.h>
+#include <stdlib.h>
+#include <string.h>
 
 // ── Attribute Access ─────────────────────────────────────────────────────────
 
@@ -351,6 +355,171 @@ CFTypeRef safe_ax_value_create_cf_range(CFIndex location, CFIndex length) {
         return AXValueCreate(kAXValueCFRangeType, &range);
     } @catch (NSException *e) {
         return NULL;
+    }
+}
+
+// ── Screen Capture (ScreenCaptureKit) ────────────────────────────────────────
+
+// Capture the primary display (or a sub-rect in logical screen points) into an
+// RGBA8 buffer. The buffer is malloc'd and ownership transfers to the caller,
+// who must free it via `safe_cg_free_pixels`.
+//
+// Uses ScreenCaptureKit's SCScreenshotManager. CGDisplayCreateImage family was
+// obsoleted in macOS 15.0; SCK is the only supported path forward.
+//
+// `use_rect`: 0 = full display, non-zero = use rect_x/y/w/h (logical points,
+//   in global screen space — same coords as Element.bounds).
+// `out_pixels`: on success, points to `(*out_width) * (*out_height) * 4` bytes
+//   of RGBA8888 data (R, G, B, A per pixel; row-major; tightly packed).
+// `out_scale`: ratio of physical image pixels to logical input points
+//   (1.0 on standard displays, 2.0 on typical Retina).
+//
+// Returns 0 on success; negative value on failure:
+//   -1  SCShareableContent query failed / no displays
+//   -2  SCScreenshotManager returned no image
+//   -3  pixel buffer allocation failed
+//   -4  bitmap context creation failed
+//   -5  requested rect has zero / negative dimensions
+//   -9999 ObjC exception
+int safe_cg_capture_rgba(
+    int use_rect,
+    double rect_x, double rect_y, double rect_w, double rect_h,
+    uint8_t **out_pixels,
+    uint32_t *out_width,
+    uint32_t *out_height,
+    double *out_scale
+) {
+    @try {
+        if (out_pixels) *out_pixels = NULL;
+        if (out_width) *out_width = 0;
+        if (out_height) *out_height = 0;
+        if (out_scale) *out_scale = 1.0;
+
+        if (use_rect && (rect_w <= 0.0 || rect_h <= 0.0)) {
+            return -5;
+        }
+
+        // Step 1: fetch shareable content (async → sync via semaphore).
+        __block SCShareableContent *content = nil;
+        __block NSError *contentError = nil;
+        dispatch_semaphore_t sem1 = dispatch_semaphore_create(0);
+        [SCShareableContent getShareableContentWithCompletionHandler:
+            ^(SCShareableContent *c, NSError *e) {
+                content = c;
+                contentError = e;
+                dispatch_semaphore_signal(sem1);
+            }];
+        dispatch_semaphore_wait(sem1, DISPATCH_TIME_FOREVER);
+        if (content == nil || content.displays.count == 0) {
+            if (contentError) {
+                NSLog(@"xa11y SCShareableContent error: %@", contentError);
+            }
+            return -1;
+        }
+
+        SCDisplay *display = content.displays[0];
+        CGRect logical_bounds = display.frame;
+        double disp_scale = (logical_bounds.size.width > 0.0)
+            ? ((double)display.width / (double)logical_bounds.size.width)
+            : 1.0;
+
+        // Step 2: build the capture configuration.
+        double src_x = use_rect ? rect_x : logical_bounds.origin.x;
+        double src_y = use_rect ? rect_y : logical_bounds.origin.y;
+        double src_w = use_rect ? rect_w : logical_bounds.size.width;
+        double src_h = use_rect ? rect_h : logical_bounds.size.height;
+
+        size_t phys_w = (size_t)(src_w * disp_scale + 0.5);
+        size_t phys_h = (size_t)(src_h * disp_scale + 0.5);
+        if (phys_w == 0 || phys_h == 0) return -5;
+
+        SCContentFilter *filter = [[SCContentFilter alloc]
+            initWithDisplay:display excludingWindows:@[]];
+        SCStreamConfiguration *config = [[SCStreamConfiguration alloc] init];
+        config.width = phys_w;
+        config.height = phys_h;
+        config.pixelFormat = 'BGRA';   // kCVPixelFormatType_32BGRA
+        config.colorSpaceName = kCGColorSpaceSRGB;
+        config.showsCursor = NO;
+        if (use_rect) {
+            // SCK sourceRect is in the display's local (logical) coordinates.
+            config.sourceRect = CGRectMake(
+                src_x - logical_bounds.origin.x,
+                src_y - logical_bounds.origin.y,
+                src_w, src_h
+            );
+            config.destinationRect = CGRectMake(0, 0, (CGFloat)phys_w, (CGFloat)phys_h);
+        }
+
+        // Step 3: capture one image (async → sync via semaphore).
+        __block CGImageRef image = NULL;
+        __block NSError *captureError = nil;
+        dispatch_semaphore_t sem2 = dispatch_semaphore_create(0);
+        [SCScreenshotManager
+            captureImageWithFilter:filter
+                    configuration:config
+                completionHandler:^(CGImageRef img, NSError *e) {
+                    captureError = e;
+                    if (img) {
+                        image = CGImageRetain(img);
+                    }
+                    dispatch_semaphore_signal(sem2);
+                }];
+        dispatch_semaphore_wait(sem2, DISPATCH_TIME_FOREVER);
+        if (image == NULL) {
+            if (captureError) {
+                NSLog(@"xa11y SCScreenshotManager error: %@", captureError);
+            }
+            return -2;
+        }
+
+        size_t w = CGImageGetWidth(image);
+        size_t h = CGImageGetHeight(image);
+        if (w == 0 || h == 0) {
+            CGImageRelease(image);
+            return -2;
+        }
+
+        // Step 4: blit into a fresh RGBA8 buffer.
+        size_t row_bytes = w * 4;
+        size_t buf_size = row_bytes * h;
+        uint8_t *buf = (uint8_t *)malloc(buf_size);
+        if (buf == NULL) {
+            CGImageRelease(image);
+            return -3;
+        }
+        memset(buf, 0, buf_size);
+
+        CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+        // RGBA8888 big-endian — R, G, B, A in memory order.
+        CGContextRef ctx = CGBitmapContextCreate(
+            buf, w, h, 8, row_bytes, cs,
+            kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big
+        );
+        CGColorSpaceRelease(cs);
+        if (ctx == NULL) {
+            free(buf);
+            CGImageRelease(image);
+            return -4;
+        }
+        CGContextDrawImage(ctx, CGRectMake(0, 0, (CGFloat)w, (CGFloat)h), image);
+        CGContextRelease(ctx);
+        CGImageRelease(image);
+
+        *out_pixels = buf;
+        *out_width = (uint32_t)w;
+        *out_height = (uint32_t)h;
+        *out_scale = disp_scale;
+        return 0;
+    } @catch (NSException *e) {
+        return -9999;
+    }
+}
+
+// Release a buffer returned from `safe_cg_capture_rgba`.
+void safe_cg_free_pixels(uint8_t *pixels) {
+    if (pixels != NULL) {
+        free(pixels);
     }
 }
 

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -4,11 +4,15 @@
 mod ax;
 #[cfg(target_os = "macos")]
 mod input;
+#[cfg(target_os = "macos")]
+mod screenshot;
 
 #[cfg(target_os = "macos")]
 pub use ax::MacOSProvider;
 #[cfg(target_os = "macos")]
 pub use input::MacOSInputProvider;
+#[cfg(target_os = "macos")]
+pub use screenshot::MacOSScreenshot;
 
 #[cfg(not(target_os = "macos"))]
 mod stub {
@@ -35,6 +39,26 @@ mod stub {
                 code: -1,
                 message: "macOS input backend only available on macOS".to_string(),
             })
+        }
+    }
+
+    pub struct MacOSScreenshot;
+
+    impl MacOSScreenshot {
+        pub fn new() -> Result<Self> {
+            Err(Error::Platform {
+                code: -1,
+                message: "macOS screenshot backend only available on macOS".to_string(),
+            })
+        }
+    }
+
+    impl ScreenshotProvider for MacOSScreenshot {
+        fn capture_full(&self) -> Result<Screenshot> {
+            unreachable!()
+        }
+        fn capture_region(&self, _: Rect) -> Result<Screenshot> {
+            unreachable!()
         }
     }
 
@@ -127,7 +151,7 @@ mod stub {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub use stub::{MacOSInputProvider, MacOSProvider};
+pub use stub::{MacOSInputProvider, MacOSProvider, MacOSScreenshot};
 
 #[cfg(test)]
 mod tests {

--- a/xa11y-macos/src/screenshot.rs
+++ b/xa11y-macos/src/screenshot.rs
@@ -1,0 +1,144 @@
+//! macOS screen capture backend via CGDisplayCreateImage.
+//!
+//! Returns physical (device) pixels as RGBA8. Requires the Screen Recording
+//! TCC permission — checked at construction time, same as `MacOSProvider`.
+
+use xa11y_core::{Error, Rect, Result, Screenshot, ScreenshotProvider};
+
+use crate::ax::MacOSProvider;
+
+extern "C" {
+    fn safe_cg_capture_rgba(
+        use_rect: i32,
+        rect_x: f64,
+        rect_y: f64,
+        rect_w: f64,
+        rect_h: f64,
+        out_pixels: *mut *mut u8,
+        out_width: *mut u32,
+        out_height: *mut u32,
+        out_scale: *mut f64,
+    ) -> i32;
+    fn safe_cg_free_pixels(pixels: *mut u8);
+}
+
+pub struct MacOSScreenshot;
+
+impl MacOSScreenshot {
+    pub fn new() -> Result<Self> {
+        if !MacOSProvider::has_screen_recording_permission() {
+            return Err(Error::PermissionDenied {
+                instructions: "Enable Screen Recording in System Settings → Privacy & Security → \
+                 Screen & System Audio Recording."
+                    .to_string(),
+            });
+        }
+        Ok(Self)
+    }
+
+    fn capture(&self, rect: Option<Rect>) -> Result<Screenshot> {
+        let (use_rect, rx, ry, rw, rh) = match rect {
+            Some(r) => (
+                1_i32,
+                f64::from(r.x),
+                f64::from(r.y),
+                f64::from(r.width),
+                f64::from(r.height),
+            ),
+            None => (0, 0.0, 0.0, 0.0, 0.0),
+        };
+
+        let mut pixels: *mut u8 = std::ptr::null_mut();
+        let mut width: u32 = 0;
+        let mut height: u32 = 0;
+        let mut scale: f64 = 1.0;
+
+        let rc = unsafe {
+            safe_cg_capture_rgba(
+                use_rect,
+                rx,
+                ry,
+                rw,
+                rh,
+                &mut pixels,
+                &mut width,
+                &mut height,
+                &mut scale,
+            )
+        };
+
+        if rc != 0 || pixels.is_null() {
+            // -1: SCShareableContent query failed / returned no displays —
+            // typically means the Screen Recording TCC grant is missing for
+            // this binary. macOS 15+ silently denies without prompting once
+            // a "no" decision is cached.
+            let err = match rc {
+                -1 => Error::PermissionDenied {
+                    instructions: "ScreenCaptureKit could not enumerate displays. Enable Screen \
+                                   Recording for this binary in System Settings → Privacy & \
+                                   Security → Screen & System Audio Recording."
+                        .to_string(),
+                },
+                -2 => Error::Platform {
+                    code: -2,
+                    message: "SCScreenshotManager returned no image".into(),
+                },
+                -3 => Error::Platform {
+                    code: -3,
+                    message: "pixel buffer allocation failed".into(),
+                },
+                -4 => Error::Platform {
+                    code: -4,
+                    message: "bitmap context creation failed".into(),
+                },
+                -5 => Error::Platform {
+                    code: -5,
+                    message: "requested rect has zero/negative dimensions".into(),
+                },
+                -9999 => Error::Platform {
+                    code: -9999,
+                    message: "ObjC exception during capture".into(),
+                },
+                other => Error::Platform {
+                    code: i64::from(other),
+                    message: format!("SCK capture failed with code {other}"),
+                },
+            };
+            return Err(err);
+        }
+        if width == 0 || height == 0 {
+            unsafe { safe_cg_free_pixels(pixels) };
+            return Err(Error::Platform {
+                code: -2,
+                message: "captured image has zero dimensions".into(),
+            });
+        }
+
+        let size = (width as usize)
+            .checked_mul(height as usize)
+            .and_then(|n| n.checked_mul(4))
+            .ok_or_else(|| Error::Platform {
+                code: -1,
+                message: "screenshot dimensions overflow".into(),
+            })?;
+        let pixels_vec = unsafe { std::slice::from_raw_parts(pixels, size) }.to_vec();
+        unsafe { safe_cg_free_pixels(pixels) };
+
+        Ok(Screenshot {
+            width,
+            height,
+            pixels: pixels_vec,
+            scale: scale as f32,
+        })
+    }
+}
+
+impl ScreenshotProvider for MacOSScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        self.capture(None)
+    }
+
+    fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
+        self.capture(Some(rect))
+    }
+}

--- a/xa11y-python/Cargo.lock
+++ b/xa11y-python/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -216,6 +228,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -319,10 +340,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -494,6 +534,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +580,19 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -684,7 +747,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -772,6 +835,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1042,7 +1111,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1243,7 +1312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -1305,6 +1374,7 @@ dependencies = [
 name = "xa11y-core"
 version = "0.6.2"
 dependencies = [
+ "png",
  "serde",
  "serde_json",
  "strum",
@@ -1315,6 +1385,7 @@ dependencies = [
 name = "xa11y-linux"
 version = "0.6.2"
 dependencies = [
+ "png",
  "rayon",
  "serde_json",
  "x11rb",

--- a/xa11y-windows/Cargo.toml
+++ b/xa11y-windows/Cargo.toml
@@ -23,6 +23,7 @@ windows = { version = "0.62", features = [
     "Win32_Graphics_Gdi",
     "Win32_System_Threading",
     "Win32_System_ProcessStatus",
+    "Win32_UI_HiDpi",
 ] }
 # Needed by the `#[implement]` macro, whose generated code references
 # `::windows_core::*` paths directly rather than going through the `windows`

--- a/xa11y-windows/src/lib.rs
+++ b/xa11y-windows/src/lib.rs
@@ -10,10 +10,14 @@ mod input;
 #[cfg(target_os = "windows")]
 mod uia;
 
+mod screenshot;
+
 #[cfg(target_os = "windows")]
 pub use input::WindowsInputProvider;
 #[cfg(target_os = "windows")]
 pub use uia::WindowsProvider;
+
+pub use screenshot::WindowsScreenshot;
 
 #[cfg(not(target_os = "windows"))]
 mod stub;

--- a/xa11y-windows/src/screenshot.rs
+++ b/xa11y-windows/src/screenshot.rs
@@ -1,0 +1,26 @@
+//! Windows screen capture — stub for this spike.
+//!
+//! A real implementation would use `Windows.Graphics.Capture` (UWP, DWM-aware,
+//! works on composited desktops) or GDI `BitBlt` (simpler, but breaks with
+//! per-monitor DPI and hardware-accelerated windows). Tracked as follow-up.
+
+use xa11y_core::{Error, Rect, Result, Screenshot, ScreenshotProvider};
+
+pub struct WindowsScreenshot;
+
+impl WindowsScreenshot {
+    pub fn new() -> Result<Self> {
+        Err(Error::Unsupported {
+            feature: "screenshot on Windows (not yet implemented)".into(),
+        })
+    }
+}
+
+impl ScreenshotProvider for WindowsScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        unreachable!()
+    }
+    fn capture_region(&self, _: Rect) -> Result<Screenshot> {
+        unreachable!()
+    }
+}

--- a/xa11y-windows/src/screenshot.rs
+++ b/xa11y-windows/src/screenshot.rs
@@ -1,26 +1,272 @@
-//! Windows screen capture — stub for this spike.
+//! Windows screen capture using GDI `BitBlt` against the virtual-desktop DC.
 //!
-//! A real implementation would use `Windows.Graphics.Capture` (UWP, DWM-aware,
-//! works on composited desktops) or GDI `BitBlt` (simpler, but breaks with
-//! per-monitor DPI and hardware-accelerated windows). Tracked as follow-up.
+//! We chose GDI over `Windows.Graphics.Capture` (WinRT) because the latter
+//! requires async plumbing and a message pump even for a single snapshot, and
+//! over DXGI Desktop Duplication because that API is per-adapter and adds a
+//! D3D dependency for what is otherwise a one-shot pixel read. `BitBlt` is
+//! synchronous, has no extra dependencies, and matches the model the other
+//! backends in this crate use (direct OS calls, no framework wrapper).
+//!
+//! # DPI
+//!
+//! The process is switched to Per-Monitor-V2 DPI awareness on first
+//! [`WindowsScreenshot::new`] so the captured coordinates match the physical
+//! pixels UIA reports for element bounds. If a higher awareness has already
+//! been set (for example by a host application), the call is a no-op and we
+//! keep the existing awareness — we never downgrade.
+//!
+//! `Screenshot::scale` is reported as 1.0 because with Per-Monitor-V2
+//! awareness the bounds we take in are already physical pixels, so no
+//! further upscaling is needed. Multi-monitor setups with mixed DPI still
+//! work: the virtual desktop spans all monitors, and `BitBlt` composites
+//! through DWM at each monitor's native DPI.
+//!
+//! # Active session required
+//!
+//! `BitBlt` against the desktop DC only works when the calling process's
+//! window station has a usable interactive desktop — i.e. a logged-in,
+//! *connected* session. Disconnected RDP sessions, Session 0 services, and
+//! other non-interactive contexts return `ERROR_INVALID_HANDLE` from
+//! `BitBlt` even though `GetDC(NULL)` succeeded. When we detect that error
+//! code we surface it as [`Error::Unsupported`] so callers can distinguish
+//! "no desktop to capture" from a real platform failure.
 
 use xa11y_core::{Error, Rect, Result, Screenshot, ScreenshotProvider};
 
 pub struct WindowsScreenshot;
 
+#[cfg(not(target_os = "windows"))]
 impl WindowsScreenshot {
     pub fn new() -> Result<Self> {
-        Err(Error::Unsupported {
-            feature: "screenshot on Windows (not yet implemented)".into(),
+        Err(Error::Platform {
+            code: -1,
+            message: "Windows screenshot backend only available on Windows".into(),
         })
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 impl ScreenshotProvider for WindowsScreenshot {
     fn capture_full(&self) -> Result<Screenshot> {
         unreachable!()
     }
     fn capture_region(&self, _: Rect) -> Result<Screenshot> {
         unreachable!()
+    }
+}
+
+#[cfg(target_os = "windows")]
+use windows::Win32::Graphics::Gdi::{
+    BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC, GetDIBits,
+    ReleaseDC, SelectObject, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HBITMAP, HDC,
+    HGDIOBJ, SRCCOPY,
+};
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::HiDpi::{
+    SetProcessDpiAwarenessContext, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+};
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
+};
+
+#[cfg(target_os = "windows")]
+impl WindowsScreenshot {
+    pub fn new() -> Result<Self> {
+        // Best-effort: succeeds on first call, returns ERROR_ACCESS_DENIED on
+        // subsequent calls (or if the awareness is pinned by manifest). Either
+        // outcome is fine — we only care that awareness is at least
+        // Per-Monitor-V2 before we read pixels.
+        unsafe {
+            let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+        }
+        Ok(Self)
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl ScreenshotProvider for WindowsScreenshot {
+    fn capture_full(&self) -> Result<Screenshot> {
+        let vx = unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) };
+        let vy = unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) };
+        let vw = unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) };
+        let vh = unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) };
+        if vw <= 0 || vh <= 0 {
+            return Err(Error::Platform {
+                code: -1,
+                message: format!("virtual screen has non-positive size: {vw}x{vh}"),
+            });
+        }
+        capture_rect(vx, vy, vw, vh)
+    }
+
+    fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
+        if rect.width == 0 || rect.height == 0 {
+            return Err(Error::Platform {
+                code: -1,
+                message: "zero-sized capture rect".into(),
+            });
+        }
+        let w = i32::try_from(rect.width).map_err(|_| Error::Platform {
+            code: -1,
+            message: "rect width out of i32 range".into(),
+        })?;
+        let h = i32::try_from(rect.height).map_err(|_| Error::Platform {
+            code: -1,
+            message: "rect height out of i32 range".into(),
+        })?;
+        capture_rect(rect.x, rect.y, w, h)
+    }
+}
+
+/// BitBlt a rectangle of the virtual desktop into an RGBA8 `Screenshot`.
+///
+/// `x`/`y` are virtual-screen coordinates (may be negative on multi-monitor
+/// setups); `w`/`h` are positive pixel dimensions.
+#[cfg(target_os = "windows")]
+fn capture_rect(x: i32, y: i32, w: i32, h: i32) -> Result<Screenshot> {
+    let width = w as u32;
+    let height = h as u32;
+
+    let screen_dc = unsafe { GetDC(None) };
+    if screen_dc.is_invalid() {
+        return Err(platform("GetDC(NULL) returned an invalid DC"));
+    }
+    let _guard_screen = ScreenDc(screen_dc);
+
+    let mem_dc = unsafe { CreateCompatibleDC(Some(screen_dc)) };
+    if mem_dc.is_invalid() {
+        return Err(platform("CreateCompatibleDC failed"));
+    }
+    let _guard_mem = MemDc(mem_dc);
+
+    let bitmap = unsafe { CreateCompatibleBitmap(screen_dc, w, h) };
+    if bitmap.is_invalid() {
+        return Err(platform("CreateCompatibleBitmap failed"));
+    }
+    let _guard_bmp = BmpGuard(bitmap);
+
+    let prev = unsafe { SelectObject(mem_dc, HGDIOBJ(bitmap.0)) };
+
+    unsafe {
+        BitBlt(mem_dc, 0, 0, w, h, Some(screen_dc), x, y, SRCCOPY).map_err(|e| {
+            let code = e.code().0;
+            // HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE) — what BitBlt actually
+            // returns on disconnected / non-interactive sessions. Surface as
+            // Unsupported so tests can skip gracefully rather than panic.
+            if code == 0x8007_0006_u32 as i32 {
+                Error::Unsupported {
+                    feature: "screen capture (no active desktop session; \
+                              reconnect the user session and retry)"
+                        .into(),
+                }
+            } else {
+                Error::Platform {
+                    code: -1,
+                    message: format!("BitBlt: {e}"),
+                }
+            }
+        })?;
+    }
+
+    // Request top-down BGRA (negative height ⇒ top-down DIB). We later swap
+    // blue/red in place to get RGBA.
+    let mut header = BITMAPINFO {
+        bmiHeader: BITMAPINFOHEADER {
+            biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+            biWidth: w,
+            biHeight: -h,
+            biPlanes: 1,
+            biBitCount: 32,
+            biCompression: BI_RGB.0,
+            biSizeImage: 0,
+            biXPelsPerMeter: 0,
+            biYPelsPerMeter: 0,
+            biClrUsed: 0,
+            biClrImportant: 0,
+        },
+        bmiColors: Default::default(),
+    };
+
+    let byte_len = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|n| n.checked_mul(4))
+        .ok_or_else(|| platform("screenshot dimensions overflow"))?;
+    let mut pixels = vec![0u8; byte_len];
+
+    let scanned = unsafe {
+        GetDIBits(
+            mem_dc,
+            bitmap,
+            0,
+            height,
+            Some(pixels.as_mut_ptr().cast()),
+            &mut header,
+            DIB_RGB_COLORS,
+        )
+    };
+    if scanned == 0 {
+        return Err(platform("GetDIBits returned 0 scanlines"));
+    }
+
+    // Restore the original bitmap before the guards run so Windows doesn't
+    // delete a selected object (GDI leaks otherwise). The guards then free
+    // the bitmap/memory DC/screen DC in the right order.
+    let _ = unsafe { SelectObject(mem_dc, prev) };
+
+    // BGRA → RGBA, in place.
+    for px in pixels.chunks_exact_mut(4) {
+        px.swap(0, 2);
+        px[3] = 0xFF;
+    }
+
+    Ok(Screenshot {
+        width,
+        height,
+        pixels,
+        scale: 1.0,
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn platform(msg: &str) -> Error {
+    Error::Platform {
+        code: -1,
+        message: msg.into(),
+    }
+}
+
+// RAII guards so every exit path releases GDI handles.
+
+#[cfg(target_os = "windows")]
+struct ScreenDc(HDC);
+#[cfg(target_os = "windows")]
+impl Drop for ScreenDc {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = ReleaseDC(None, self.0);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct MemDc(HDC);
+#[cfg(target_os = "windows")]
+impl Drop for MemDc {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = DeleteDC(self.0);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct BmpGuard(HBITMAP);
+#[cfg(target_os = "windows")]
+impl Drop for BmpGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = DeleteObject(HGDIOBJ(self.0 .0));
+        }
     }
 }

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -32,6 +32,10 @@ pub use xa11y_core::{
     InputSim, IntoPoint, Key, Keyboard, Mouse, MouseButton, Point, ScrollDelta,
 };
 
+// Re-export screenshot surface.
+pub use xa11y_core::screenshot;
+pub use xa11y_core::{Screenshot, ScreenshotProvider, Screenshotter};
+
 // Implementation details used by platform backends and Python bindings.
 #[doc(hidden)]
 pub use xa11y_core::{CancelHandle, EventReceiver, Provider, RecvStatus, Selector};
@@ -109,6 +113,45 @@ pub fn input_sim() -> Result<InputSim> {
             code: -1,
             message: format!(
                 "Input simulation not available on platform: {}",
+                std::env::consts::OS
+            ),
+        })
+    }
+}
+
+/// Build a [`Screenshotter`] backed by the platform's native capture API
+/// (ScreenCaptureKit on macOS, X11 `GetImage` or xdg-desktop-portal on Linux,
+/// stubbed on Windows).
+///
+/// Returns:
+/// - [`Error::PermissionDenied`] on macOS if Screen Recording permission
+///   hasn't been granted (or on Linux if the Wayland portal denies consent).
+/// - [`Error::Unsupported`] on Linux if neither `DISPLAY` nor `WAYLAND_DISPLAY`
+///   is set, and on Windows until a backend ships.
+///
+/// `Screenshotter` is cheap to clone — construct one and share it.
+pub fn screenshotter() -> Result<Screenshotter> {
+    #[cfg(target_os = "macos")]
+    {
+        let backend = xa11y_macos::MacOSScreenshot::new()?;
+        Ok(Screenshotter::new(Arc::new(backend)))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let backend = xa11y_windows::WindowsScreenshot::new()?;
+        Ok(Screenshotter::new(Arc::new(backend)))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let backend = xa11y_linux::LinuxScreenshot::new()?;
+        Ok(Screenshotter::new(Arc::new(backend)))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        Err(Error::Platform {
+            code: -1,
+            message: format!(
+                "Screenshot not available on platform: {}",
                 std::env::consts::OS
             ),
         })

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -14,6 +14,7 @@
 //! are reached from submodule tests via `use crate::integ as h;`.
 
 pub mod actions;
+pub mod screenshot;
 pub mod tree;
 
 #[cfg(target_os = "macos")]

--- a/xa11y/tests/integ/screenshot.rs
+++ b/xa11y/tests/integ/screenshot.rs
@@ -1,0 +1,74 @@
+//! Screenshot integration tests — capture pixels from the running test app
+//! and verify the PNG round-trips through the decoder at the expected size.
+
+#[cfg(test)]
+mod tests {
+    use crate::integ as h;
+
+    #[test]
+    #[ignore]
+    fn capture_full_screen_yields_nonempty_png() {
+        let shot = xa11y::screenshotter()
+            .expect("screenshotter construction")
+            .capture()
+            .expect("full-screen capture");
+        assert!(shot.width > 0 && shot.height > 0, "empty capture dims");
+        assert_eq!(
+            shot.pixels.len(),
+            (shot.width as usize) * (shot.height as usize) * 4
+        );
+
+        let bytes = shot.to_png().expect("PNG encode");
+        assert!(bytes.len() > 100, "PNG unexpectedly small");
+        assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n", "missing PNG signature");
+    }
+
+    #[test]
+    #[ignore]
+    fn capture_element_matches_bounds_at_scale() {
+        let app = h::app_root();
+        // Any element with on-screen bounds works; Submit is a well-known
+        // named button in the AccessKit test app.
+        let button = h::named(&app, "Submit");
+
+        // In headless CI (--headless winit), the test app has no on-screen
+        // bounds. Skip the assertion part in that case — the full-screen
+        // test in this module still validates the core pipeline.
+        let Some(bounds) = button.bounds else {
+            eprintln!("skipping: element has no bounds (likely headless)");
+            return;
+        };
+        if bounds.width == 0 || bounds.height == 0 {
+            eprintln!("skipping: element bounds are zero-sized");
+            return;
+        }
+
+        let shot = xa11y::screenshotter()
+            .expect("screenshotter construction")
+            .capture_element(&button)
+            .expect("element capture");
+
+        assert!(shot.scale > 0.0);
+        let expected_w = (bounds.width as f32 * shot.scale).round() as u32;
+        let expected_h = (bounds.height as f32 * shot.scale).round() as u32;
+        // Allow 1px slack for rounding on fractional scale factors.
+        assert!(
+            (shot.width as i64 - expected_w as i64).abs() <= 1,
+            "width {} not within 1 of expected {} (scale {})",
+            shot.width,
+            expected_w,
+            shot.scale
+        );
+        assert!(
+            (shot.height as i64 - expected_h as i64).abs() <= 1,
+            "height {} not within 1 of expected {} (scale {})",
+            shot.height,
+            expected_h,
+            shot.scale
+        );
+
+        // Round-trip through PNG.
+        let bytes = shot.to_png().expect("PNG encode");
+        assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+    }
+}

--- a/xa11y/tests/integ/screenshot.rs
+++ b/xa11y/tests/integ/screenshot.rs
@@ -8,10 +8,20 @@ mod tests {
     #[test]
     #[ignore]
     fn capture_full_screen_yields_nonempty_png() {
-        let shot = xa11y::screenshotter()
+        let shot = match xa11y::screenshotter()
             .expect("screenshotter construction")
             .capture()
-            .expect("full-screen capture");
+        {
+            Ok(s) => s,
+            // Disconnected RDP sessions / non-interactive CI jobs can't capture
+            // the desktop; the backend surfaces that as Unsupported. Skip
+            // rather than fail — the construction path is still exercised.
+            Err(xa11y::Error::Unsupported { feature }) => {
+                eprintln!("skipping: {feature}");
+                return;
+            }
+            Err(e) => panic!("full-screen capture: {e}"),
+        };
         assert!(shot.width > 0 && shot.height > 0, "empty capture dims");
         assert_eq!(
             shot.pixels.len(),
@@ -43,10 +53,17 @@ mod tests {
             return;
         }
 
-        let shot = xa11y::screenshotter()
+        let shot = match xa11y::screenshotter()
             .expect("screenshotter construction")
             .capture_element(&button)
-            .expect("element capture");
+        {
+            Ok(s) => s,
+            Err(xa11y::Error::Unsupported { feature }) => {
+                eprintln!("skipping: {feature}");
+                return;
+            }
+            Err(e) => panic!("element capture: {e}"),
+        };
 
         assert!(shot.scale > 0.0);
         let expected_w = (bounds.width as f32 * shot.scale).round() as u32;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,7 +16,9 @@ COMMANDS:
     test-js             Build and unit-test JS (Node) bindings
     test-js-integ       Run JS integration tests against the AccessKit test app
     test-integ          Run integration tests (delegates to scripts/)
-    test-integ-container  Run Linux integration tests in container
+    test-integ-container  Run Linux X11 integration tests in container
+    test-integ-wayland-container  Run Linux Wayland portal tests in container
+    test-integ-input-smoke-container  Run Linux XTest input smoke in container
     test-qt             Run Qt (PySide6) integration tests
     test-gtk            Run GTK4 integration tests
     test-cocoa          Run Cocoa/AppKit integration tests (macOS only)
@@ -47,6 +49,8 @@ fn main() -> ExitCode {
         "test-js-integ" => do_test_js_integ(),
         "test-integ" => do_test_integ(rest),
         "test-integ-container" => do_test_integ_container(rest),
+        "test-integ-wayland-container" => do_test_integ_wayland_container(),
+        "test-integ-input-smoke-container" => do_test_integ_input_smoke_container(),
         "test-qt" => do_test_qt(),
         "test-gtk" => do_test_gtk(),
         "test-cocoa" => do_test_cocoa(),
@@ -273,6 +277,70 @@ fn do_test_integ_container(args: &[String]) -> bool {
     let mut cmd_args = vec!["scripts/run_integ_container.sh"];
     cmd_args.extend(&str_args);
     run_in("bash", &cmd_args, &root)
+}
+
+fn do_test_integ_wayland_container() -> bool {
+    heading("Wayland portal screenshot tests (container)");
+    let root = project_root();
+    // Build the Wayland container image (extends xa11y-base with sway +
+    // xdg-desktop-portal + pipewire) if it isn't already present.
+    let img_exists = std::process::Command::new("docker")
+        .args(["image", "inspect", "xa11y-wayland"])
+        .current_dir(&root)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !img_exists
+        && !run_in(
+            "docker",
+            &[
+                "build",
+                "-t",
+                "xa11y-wayland",
+                "-f",
+                "Containerfile.wayland",
+                ".",
+            ],
+            &root,
+        )
+    {
+        return false;
+    }
+    run_in(
+        "docker",
+        &[
+            "run",
+            "--rm",
+            "-v",
+            &format!("{}:/xa11y", root.display()),
+            "-v",
+            "xa11y-cargo-cache:/xa11y/target",
+            "xa11y-wayland",
+            "bash",
+            "/xa11y/scripts/run_wayland_portal.sh",
+        ],
+        &root,
+    )
+}
+
+fn do_test_integ_input_smoke_container() -> bool {
+    heading("Linux X11 input smoke (container)");
+    let root = project_root();
+    run_in(
+        "docker",
+        &[
+            "run",
+            "--rm",
+            "-v",
+            &format!("{}:/xa11y", root.display()),
+            "-v",
+            "xa11y-cargo-cache:/xa11y/target",
+            "xa11y-base",
+            "bash",
+            "/xa11y/scripts/run_input_smoke.sh",
+        ],
+        &root,
+    )
 }
 
 fn do_test_qt() -> bool {


### PR DESCRIPTION
Supersedes #146 now that input-sim (#131) has merged to main — this PR carries the remaining screenshot work plus the Windows implementation and the Wayland portal test harness.

## Summary

- **Cross-platform `Screenshotter`** (unchanged from #146's `b6027c3`): `ScreenshotProvider` trait in `xa11y-core`; ScreenCaptureKit on macOS; X11 `GetImage` + `org.freedesktop.portal.Screenshot` on Linux; previously a stub on Windows.
- **Windows: real implementation**, GDI `BitBlt` against the virtual-desktop DC, sets Per-Monitor-V2 DPI awareness at construction. Disconnected RDP / Session 0 contexts (where `BitBlt` returns `ERROR_INVALID_HANDLE`) are surfaced as `Error::Unsupported` so tests skip cleanly.
- **Linux Wayland test harness**: new `Containerfile.wayland` (sway + pipewire + `xdg-desktop-portal-{wlr,gtk}`) and `scripts/run_wayland_portal.sh` drive the portal Screenshot path end-to-end in CI.
- **Linux input smoke runner**: `scripts/run_input_smoke.sh` exercises the XTest backend under Xvfb.
- **Wayland session-detection smoke tests**: `xa11y-linux/tests/wayland_smoke.rs` (4 tests, no compositor needed).
- Clippy fix for `large_enum_variant` on the Linux `Backend` enum.
- `xtask` adds `test-integ-wayland-container` and `test-integ-input-smoke-container`.

## Verified

| Env | Result |
|---|---|
| Windows host unit tests | all green |
| Windows screenshot integ | skips cleanly on disconnected session |
| Linux X11 container integ | 101/101 |
| Linux X11 screenshot integ | 2/2 |
| Linux X11 input smoke | 3/3 |
| Linux Wayland env-detection smoke | 4/4 |
| Linux Wayland portal screenshot integ | 2/2 (full-screen + element) |
| Clippy on Windows & Linux | clean |

macOS tests were not run locally here — the macOS screenshot path is the original #146 content and was verified on Mac by the previous author. My additions don't touch macOS code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)