### PR TITLE
fix(linux): propagate AccessibilityNotEnabled through locator recursion

### DIFF
--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1161,26 +1161,41 @@ impl LinuxProvider {
             self.check_chromium_a11y_enabled(parent, None)?;
         }
 
-        // Process each child subtree in parallel: check match + recurse
-        let per_child: Vec<Vec<AccessibleRef>> = to_search
+        // Process each child subtree in parallel: check match + recurse.
+        // We deliberately swallow transient sibling errors here — a single
+        // flaky D-Bus call on one child shouldn't fail the whole locator
+        // query (the rest of this file is similarly tolerant via
+        // `unwrap_or_default()`). But `AccessibilityNotEnabled` is *not* a
+        // transient error: it's the signal that a Chromium renderer bridge
+        // isn't initialised, and callers need to see it. So we propagate
+        // that variant specifically and keep tolerating everything else.
+        let per_child: Vec<(Vec<AccessibleRef>, Option<Error>)> = to_search
             .par_iter()
             .map(|child| {
                 let mut child_results = Vec::new();
                 if self.matches_ref(child, simple) {
                     child_results.push(child.clone());
                 }
-                if let Ok(sub) =
-                    self.collect_matching_refs(child, simple, depth + 1, max_depth, limit)
-                {
-                    child_results.extend(sub);
+                match self.collect_matching_refs(child, simple, depth + 1, max_depth, limit) {
+                    Ok(sub) => {
+                        child_results.extend(sub);
+                        (child_results, None)
+                    }
+                    Err(e @ Error::AccessibilityNotEnabled { .. }) => (Vec::new(), Some(e)),
+                    Err(_) => (child_results, None),
                 }
-                child_results
             })
             .collect();
 
-        // Merge results, respecting limit
+        // Merge results, respecting limit. The first AccessibilityNotEnabled
+        // error seen wins — any child subtree raising it means the whole
+        // query is untrustworthy, so surface it rather than return partial
+        // data.
         let mut results = Vec::new();
-        for batch in per_child {
+        for (batch, maybe_err) in per_child {
+            if let Some(err) = maybe_err {
+                return Err(err);
+            }
             for r in batch {
                 results.push(r);
                 if let Some(limit) = limit {


### PR DESCRIPTION
## Summary

The Electron integ test \`without flag: locator query raises AccessibilityNotEnabledError\` has been failing on main since #131 merged. `app.locator(...)` against a Chromium/Electron app launched without \`--force-renderer-accessibility\` was returning an empty list instead of surfacing the error, so callers couldn't tell the difference between "no match" and "renderer bridge disabled".

## Root cause

`collect_matching_refs` in \`xa11y-linux/src/atspi.rs\` swallowed every error from its recursive calls via \`if let Ok(sub) = ...\`. That was intentional for transient sibling failures (the rest of the file similarly tolerates flaky D-Bus calls via \`unwrap_or_default()\`), but it also hid \`Error::AccessibilityNotEnabled\` — which is raised deep in the recursion (at the frame-with-no-children level) and needs to propagate all the way back to the caller.

The first-level test (\`window.children()\`) was unaffected because it goes through \`get_children\` which raises the error directly without a recursive layer in between.

## Fix

Propagate the \`AccessibilityNotEnabled\` variant specifically; keep swallowing other errors so one flaky D-Bus sibling doesn't fail the whole locator query. First child to raise wins — an untrustworthy tree shouldn't return partial results.

## Verified

- \`cargo test -p xa11y-linux --lib\` — 30/30 pass
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- The Electron integ test will confirm end-to-end in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)