### PR TITLE
refactor(core): lift narrow_multi_segment to Provider trait default

### DIFF
--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -1,7 +1,7 @@
 use crate::element::ElementData;
 use crate::error::Result;
 use crate::event_provider::Subscription;
-use crate::selector::Selector;
+use crate::selector::{matches_simple, Combinator, Selector, SelectorSegment};
 
 /// Platform backend trait for accessibility tree access.
 ///
@@ -55,6 +55,66 @@ pub trait Provider: Send + Sync {
             limit,
             max_depth,
         )
+    }
+
+    /// Narrow candidates through remaining selector segments (Child/Descendant
+    /// combinators), deduplicate, apply final :nth and limit.
+    fn narrow_multi_segment(
+        &self,
+        mut candidates: Vec<ElementData>,
+        segments: &[SelectorSegment],
+        max_depth: u32,
+        limit: Option<usize>,
+    ) -> Result<Vec<ElementData>> {
+        for segment in segments {
+            let mut next_candidates = Vec::new();
+            for candidate in &candidates {
+                match segment.combinator {
+                    Combinator::Child => {
+                        let children = self.get_children(Some(candidate))?;
+                        for child in children {
+                            if matches_simple(&child, &segment.simple) {
+                                next_candidates.push(child);
+                            }
+                        }
+                    }
+                    Combinator::Descendant => {
+                        let sub_selector = Selector {
+                            segments: vec![SelectorSegment {
+                                combinator: Combinator::Root,
+                                simple: segment.simple.clone(),
+                            }],
+                        };
+                        let mut sub_results = self.find_elements(
+                            Some(candidate),
+                            &sub_selector,
+                            None,
+                            Some(max_depth),
+                        )?;
+                        next_candidates.append(&mut sub_results);
+                    }
+                    Combinator::Root => unreachable!(),
+                }
+            }
+            let mut seen = std::collections::HashSet::new();
+            next_candidates.retain(|e| seen.insert(e.handle));
+            candidates = next_candidates;
+        }
+
+        // Apply :nth on last segment
+        if let Some(nth) = segments.last().and_then(|s| s.simple.nth) {
+            if nth <= candidates.len() {
+                candidates = vec![candidates.remove(nth - 1)];
+            } else {
+                candidates.clear();
+            }
+        }
+
+        if let Some(limit) = limit {
+            candidates.truncate(limit);
+        }
+
+        Ok(candidates)
     }
 
     // ── Common actions ──────────────────────────────────────────────
@@ -150,6 +210,15 @@ impl<T: Provider + ?Sized> Provider for &T {
         max_depth: Option<u32>,
     ) -> Result<Vec<ElementData>> {
         (**self).find_elements(root, selector, limit, max_depth)
+    }
+    fn narrow_multi_segment(
+        &self,
+        candidates: Vec<ElementData>,
+        segments: &[SelectorSegment],
+        max_depth: u32,
+        limit: Option<usize>,
+    ) -> Result<Vec<ElementData>> {
+        (**self).narrow_multi_segment(candidates, segments, max_depth, limit)
     }
     fn press(&self, element: &ElementData) -> Result<()> {
         (**self).press(element)

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1721,7 +1721,6 @@ impl MacOSProvider {
         }
         results
     }
-
 }
 
 impl Provider for MacOSProvider {

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1037,7 +1037,7 @@ fn snake_to_ax_pascal(snake: &str) -> String {
 
 // ── Lightweight selector matching (no ElementData) ───────────────────────────
 
-use xa11y_core::selector::{match_op, Combinator, SimpleSelector};
+use xa11y_core::selector::{match_op, SimpleSelector};
 
 /// Test whether a raw AXElement matches a SimpleSelector, fetching only the
 /// attributes the selector actually inspects. This avoids building a full
@@ -1722,65 +1722,6 @@ impl MacOSProvider {
         results
     }
 
-    /// Narrow candidates through remaining selector segments (Child/Descendant
-    /// combinators), deduplicate, apply final :nth and limit.
-    fn narrow_multi_segment(
-        &self,
-        mut candidates: Vec<ElementData>,
-        segments: &[xa11y_core::selector::SelectorSegment],
-        max_depth: u32,
-        limit: Option<usize>,
-    ) -> Result<Vec<ElementData>> {
-        for segment in segments {
-            let mut next_candidates = Vec::new();
-            for candidate in &candidates {
-                match segment.combinator {
-                    Combinator::Child => {
-                        let children = self.get_children(Some(candidate))?;
-                        for child in children {
-                            if xa11y_core::selector::matches_simple(&child, &segment.simple) {
-                                next_candidates.push(child);
-                            }
-                        }
-                    }
-                    Combinator::Descendant => {
-                        let sub_selector = Selector {
-                            segments: vec![xa11y_core::selector::SelectorSegment {
-                                combinator: Combinator::Root,
-                                simple: segment.simple.clone(),
-                            }],
-                        };
-                        let mut sub_results = self.find_elements(
-                            Some(candidate),
-                            &sub_selector,
-                            None,
-                            Some(max_depth),
-                        )?;
-                        next_candidates.append(&mut sub_results);
-                    }
-                    Combinator::Root => unreachable!(),
-                }
-            }
-            let mut seen = HashSet::new();
-            next_candidates.retain(|e| seen.insert(e.handle));
-            candidates = next_candidates;
-        }
-
-        // Apply :nth on last segment
-        if let Some(nth) = segments.last().and_then(|s| s.simple.nth) {
-            if nth <= candidates.len() {
-                candidates = vec![candidates.remove(nth - 1)];
-            } else {
-                candidates.clear();
-            }
-        }
-
-        if let Some(limit) = limit {
-            candidates.truncate(limit);
-        }
-
-        Ok(candidates)
-    }
 }
 
 impl Provider for MacOSProvider {

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -227,7 +227,6 @@ impl WindowsProvider {
             root.FindAllBuildCache(TreeScope_Subtree, &true_cond, &self.batch_request)
         })
     }
-
 }
 
 // ── Safe UIA helpers ────────────────────────────────────────────────────────

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -11,7 +11,7 @@ use windows::Win32::System::Variant::VARIANT;
 use windows::Win32::UI::Accessibility::*;
 
 use xa11y_core::{
-    selector::{matches_simple, Combinator, Selector, SelectorSegment},
+    selector::{matches_simple, Selector},
     CancelHandle, ElementData, Error, Event, EventKind, EventReceiver, Provider, Rect, Result,
     Role, StateFlag, StateSet, Subscription, Toggled,
 };
@@ -228,64 +228,6 @@ impl WindowsProvider {
         })
     }
 
-    /// Narrow phase-1 candidates through subsequent selector segments.
-    fn narrow_multi_segment(
-        &self,
-        mut candidates: Vec<ElementData>,
-        segments: &[SelectorSegment],
-        max_depth: u32,
-        limit: Option<usize>,
-    ) -> Result<Vec<ElementData>> {
-        for segment in segments {
-            let mut next_candidates = Vec::new();
-            for candidate in &candidates {
-                match segment.combinator {
-                    Combinator::Child => {
-                        let children = self.get_children(Some(candidate))?;
-                        for child in children {
-                            if matches_simple(&child, &segment.simple) {
-                                next_candidates.push(child);
-                            }
-                        }
-                    }
-                    Combinator::Descendant => {
-                        let sub_selector = Selector {
-                            segments: vec![SelectorSegment {
-                                combinator: Combinator::Root,
-                                simple: segment.simple.clone(),
-                            }],
-                        };
-                        let mut sub_results = self.find_elements(
-                            Some(candidate),
-                            &sub_selector,
-                            None,
-                            Some(max_depth),
-                        )?;
-                        next_candidates.append(&mut sub_results);
-                    }
-                    Combinator::Root => unreachable!(),
-                }
-            }
-            let mut seen = HashSet::new();
-            next_candidates.retain(|e| seen.insert(e.handle));
-            candidates = next_candidates;
-        }
-
-        // Apply :nth on last segment
-        if let Some(nth) = segments.last().and_then(|s| s.simple.nth) {
-            if nth <= candidates.len() {
-                candidates = vec![candidates.remove(nth - 1)];
-            } else {
-                candidates.clear();
-            }
-        }
-
-        if let Some(limit) = limit {
-            candidates.truncate(limit);
-        }
-
-        Ok(candidates)
-    }
 }
 
 // ── Safe UIA helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The macOS (`xa11y-macos/src/ax.rs`) and Windows (`xa11y-windows/src/uia.rs`) providers each carried a **byte-identical copy** of `narrow_multi_segment` (modulo three import-path differences). The method only uses `Provider` trait methods (`get_children`, `find_elements`) and core selector types, so it belongs on the trait itself.
- Moved to `xa11y-core/src/provider.rs` as a default method on `Provider`. The existing `impl<T: Provider + ?Sized> Provider for &T` forwarder was updated to match the file's existing convention of explicitly forwarding every method.
- Net **−48 lines** across 3 files. No behavior change.

Linux (`xa11y-linux/src/atspi.rs`) already uses the default `find_elements` path from core and never had a local `narrow_multi_segment`, so it is unaffected.

## Test plan

- [x] `cargo xtask check` — fmt, clippy, unit tests, bindings-parity, macos-ffi all green locally
- [ ] CI: Linux clippy + tests
- [ ] CI: Windows clippy + tests (the Windows deletion is symmetric with the macOS one — mechanical, same function body)
- [ ] CI: Python / JS bindings — `narrow_multi_segment` is an internal helper, not part of the public surface mirrored into bindings
- [ ] CI: integration tests on all three platforms (the call sites in each provider's `find_elements` continue to call `self.narrow_multi_segment(...)`, now resolving to the trait default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)