### PR TITLE
ci: drop noisy PR-comment diagnostics from JS integration jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,12 +468,6 @@ jobs:
     name: JS integration (Linux)
     runs-on: ubuntu-latest
     needs: js
-    permissions:
-      contents: read
-      # Needed so the "Post diagnostics to PR on failure" step can write
-      # a comment. No-op on runs from forks (GITHUB_TOKEN is read-only).
-      pull-requests: write
-      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -517,55 +511,11 @@ jobs:
         id: js_integ
         run: ./scripts/run_js_tests.sh
 
-      # Surface diagnostics as a PR comment on failure, so that reviewers
-      # (and assistants like Claude Code) can read the actual error output
-      # without needing access to the raw run logs.
-      - name: Post diagnostics to PR on failure
-        if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const jsDir = 'xa11y-js';
-            const sections = [];
-            const diag = path.join(jsDir, '.failure-diagnostics.log');
-            if (fs.existsSync(diag)) {
-              sections.push('### Diagnostic dump\n\n```\n' + fs.readFileSync(diag, 'utf8') + '\n```');
-            }
-            const appLog = path.join(jsDir, '.xa11y-test-app.log');
-            if (fs.existsSync(appLog)) {
-              sections.push('### xa11y-test-app stdout/stderr\n\n```\n' + fs.readFileSync(appLog, 'utf8') + '\n```');
-            }
-            const nodeLog = path.join(jsDir, '.node-test-output.log');
-            if (fs.existsSync(nodeLog)) {
-              const content = fs.readFileSync(nodeLog, 'utf8');
-              const tail = content.split('\n').slice(-200).join('\n');
-              sections.push('### node --test output (tail)\n\n```\n' + tail + '\n```');
-            }
-            if (sections.length === 0) {
-              sections.push('_No diagnostic files were produced — the failure happened before the test step could write them._');
-            }
-            const body =
-              '### JS integration (Linux) failure — run ' + context.runId + '\n\n' +
-              sections.join('\n\n') +
-              '\n\n<sub>Posted automatically from `ci.yml` `js-integ` job.</sub>';
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
-
   # ── JS integration tests on macOS against the AccessKit test app ──
   js-integ-macos:
     name: JS integration (macOS)
     runs-on: macos-latest
     needs: js
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -608,52 +558,11 @@ jobs:
         id: js_integ
         run: ./scripts/run_js_tests.sh
 
-      - name: Post diagnostics to PR on failure
-        if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const jsDir = 'xa11y-js';
-            const sections = [];
-            const diag = path.join(jsDir, '.failure-diagnostics.log');
-            if (fs.existsSync(diag)) {
-              sections.push('### Diagnostic dump\n\n```\n' + fs.readFileSync(diag, 'utf8') + '\n```');
-            }
-            const appLog = path.join(jsDir, '.xa11y-test-app.log');
-            if (fs.existsSync(appLog)) {
-              sections.push('### xa11y-test-app stdout/stderr\n\n```\n' + fs.readFileSync(appLog, 'utf8') + '\n```');
-            }
-            const nodeLog = path.join(jsDir, '.node-test-output.log');
-            if (fs.existsSync(nodeLog)) {
-              const content = fs.readFileSync(nodeLog, 'utf8');
-              const tail = content.split('\n').slice(-200).join('\n');
-              sections.push('### node --test output (tail)\n\n```\n' + tail + '\n```');
-            }
-            if (sections.length === 0) {
-              sections.push('_No diagnostic files were produced — the failure happened before the test step could write them._');
-            }
-            const body =
-              '### JS integration (macOS) failure — run ' + context.runId + '\n\n' +
-              sections.join('\n\n') +
-              '\n\n<sub>Posted automatically from `ci.yml` `js-integ-macos` job.</sub>';
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
-
   # ── JS integration tests on Windows against the AccessKit test app ──
   js-integ-windows:
     name: JS integration (Windows)
     runs-on: windows-latest
     needs: js
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -687,52 +596,11 @@ jobs:
         shell: bash
         run: ./scripts/run_js_tests.sh
 
-      - name: Post diagnostics to PR on failure
-        if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const jsDir = 'xa11y-js';
-            const sections = [];
-            const diag = path.join(jsDir, '.failure-diagnostics.log');
-            if (fs.existsSync(diag)) {
-              sections.push('### Diagnostic dump\n\n```\n' + fs.readFileSync(diag, 'utf8') + '\n```');
-            }
-            const appLog = path.join(jsDir, '.xa11y-test-app.log');
-            if (fs.existsSync(appLog)) {
-              sections.push('### xa11y-test-app stdout/stderr\n\n```\n' + fs.readFileSync(appLog, 'utf8') + '\n```');
-            }
-            const nodeLog = path.join(jsDir, '.node-test-output.log');
-            if (fs.existsSync(nodeLog)) {
-              const content = fs.readFileSync(nodeLog, 'utf8');
-              const tail = content.split('\n').slice(-200).join('\n');
-              sections.push('### node --test output (tail)\n\n```\n' + tail + '\n```');
-            }
-            if (sections.length === 0) {
-              sections.push('_No diagnostic files were produced — the failure happened before the test step could write them._');
-            }
-            const body =
-              '### JS integration (Windows) failure — run ' + context.runId + '\n\n' +
-              sections.join('\n\n') +
-              '\n\n<sub>Posted automatically from `ci.yml` `js-integ-windows` job.</sub>';
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
-
   # ── Electron integration tests (Linux only; bug is Linux-specific) ──
   electron:
     name: Electron integration (Linux)
     runs-on: ubuntu-latest
     needs: js
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Removes the `Post diagnostics to PR on failure` step from the `js-integ`, `js-integ-macos`, and `js-integ-windows` jobs — it was posting a comment on every failing PR run and the noise outweighs the value.
- Drops the `pull-requests: write` / `issues: write` permission blocks those steps required (including the unused block on the `electron` job).

## Test plan
- [ ] CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)