### PR TITLE
ci(linux): consolidate Python venvs + cache apt packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,23 @@ jobs:
           python-version: "3.12"
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            xvfb dbus dbus-x11 fluxbox \
-            at-spi2-core \
-            libxkbcommon-x11-0 libxkbcommon-x11-dev \
-            libxcursor1 libxrandr2 libxi6 \
-            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0 \
-            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3 \
-            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 \
-            libxcb-image0 libxcb-render-util0 libxcb-xkb1 \
-            libgtk-4-dev gir1.2-gtk-4.0 libgirepository-2.0-dev libcairo2-dev \
+        # `awalsh128/cache-apt-pkgs-action` caches the .debs so re-runs on
+        # the same package-set finish in ~10s instead of the ~60s it takes
+        # to `apt-get update` + `install` 30 packages from scratch.
+        # Bump `version` to invalidate the cache when the package list changes.
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          version: 1
+          packages: >-
+            xvfb dbus dbus-x11 fluxbox
+            at-spi2-core
+            libxkbcommon-x11-0 libxkbcommon-x11-dev
+            libxcursor1 libxrandr2 libxi6
+            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0
+            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3
+            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1
+            libxcb-image0 libxcb-render-util0 libxcb-xkb1
+            libgtk-4-dev gir1.2-gtk-4.0 libgirepository-2.0-dev libcairo2-dev
             libwebkit2gtk-4.1-dev libssl-dev librsvg2-dev libgtk-3-dev
 
       - name: Run unit tests
@@ -500,17 +505,20 @@ jobs:
 
       - name: Install system dependencies
         # Same list as the Linux unit-test job: xvfb + dbus + at-spi2 for
-        # accessibility, xcb/xkb/egl for winit's window backend.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            xvfb dbus dbus-x11 fluxbox \
-            at-spi2-core \
-            libxkbcommon-x11-0 libxkbcommon-x11-dev \
-            libxcursor1 libxrandr2 libxi6 \
-            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0 \
-            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3 \
-            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 \
+        # accessibility, xcb/xkb/egl for winit's window backend. Cached
+        # via `awalsh128/cache-apt-pkgs-action` — bump `version` to
+        # invalidate when the package list changes.
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          version: 1
+          packages: >-
+            xvfb dbus dbus-x11 fluxbox
+            at-spi2-core
+            libxkbcommon-x11-0 libxkbcommon-x11-dev
+            libxcursor1 libxrandr2 libxi6
+            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0
+            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3
+            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1
             libxcb-image0 libxcb-render-util0 libxcb-xkb1
 
       - name: Run JS integration tests
@@ -766,19 +774,23 @@ jobs:
           cache-dependency-path: xa11y-js/package-lock.json
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            xvfb dbus dbus-x11 fluxbox \
-            at-spi2-core \
-            libxkbcommon-x11-0 libxkbcommon-x11-dev \
-            libxcursor1 libxrandr2 libxi6 \
-            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0 \
-            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3 \
-            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 \
-            libxcb-image0 libxcb-render-util0 libxcb-xkb1 \
-            libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
-            libdrm2 libgbm1 libxcomposite1 libxdamage1 libxfixes3 \
+        # Cached via `awalsh128/cache-apt-pkgs-action`; bump `version` to
+        # invalidate when the package list changes. Adds the Electron
+        # runtime deps (nss/atk/cups/…) on top of the base X/dbus/a11y set.
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          version: 1
+          packages: >-
+            xvfb dbus dbus-x11 fluxbox
+            at-spi2-core
+            libxkbcommon-x11-0 libxkbcommon-x11-dev
+            libxcursor1 libxrandr2 libxi6
+            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0
+            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3
+            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1
+            libxcb-image0 libxcb-render-util0 libxcb-xkb1
+            libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2
+            libdrm2 libgbm1 libxcomposite1 libxdamage1 libxfixes3
             libpango-1.0-0 libasound2t64
 
       - name: Run Electron integration tests

--- a/scripts/run_gtk_tests.sh
+++ b/scripts/run_gtk_tests.sh
@@ -88,32 +88,9 @@ if [[ "$(uname)" == "Linux" ]]; then
         2>/dev/null || true
 fi
 
-# ── Set up Python venv ───────────────────────────────────────────────
-
-VENV_DIR="$PROJECT_ROOT/.venv-gtk-test"
-
-if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating virtualenv at $VENV_DIR..."
-    python3 -m venv "$VENV_DIR"
-fi
-
-PIP="$VENV_DIR/bin/pip"
-PYTEST="$VENV_DIR/bin/pytest"
-
-echo "Installing dependencies..."
-"$PIP" install --quiet maturin
-"$PIP" install --quiet -r "$PROJECT_ROOT/tests/requirements.txt"
-"$PIP" install --quiet -r "$GTK_APP_DIR/requirements.txt"
-
-# Generate README for xa11y-python (it's in .gitignore, maturin needs it)
-echo "Generating xa11y-python README..."
-cd "$PROJECT_ROOT"
-cargo xtask sync-readmes 2>&1
-
-# Build and install xa11y Python bindings
-echo "Building xa11y Python bindings..."
-cd "$PROJECT_ROOT/xa11y-python"
-"$PIP" install --quiet -e .
+# ── Set up shared Python integ venv ──────────────────────────────────
+# shellcheck source=setup_python_integ_env.sh
+source "$SCRIPT_DIR/setup_python_integ_env.sh" "$GTK_APP_DIR/requirements.txt"
 
 cd "$PROJECT_ROOT"
 

--- a/scripts/run_qt_tests.sh
+++ b/scripts/run_qt_tests.sh
@@ -92,39 +92,15 @@ fi
 
 export QT_ACCESSIBILITY=1
 
-# ── Set up Python venv ───────────────────────────────────────────────
+# ── Set up shared Python integ venv ──────────────────────────────────
+#
+# Sources `scripts/setup_python_integ_env.sh` which creates `.venv-test`,
+# installs maturin + shared test deps + the Qt-app requirements, and
+# builds the xa11y bindings (once per job — subsequent callers skip the
+# rebuild when `import xa11y` already works).
 
-VENV_DIR="$PROJECT_ROOT/.venv-qt-test"
-
-if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating virtualenv at $VENV_DIR..."
-    python3 -m venv "$VENV_DIR"
-fi
-
-PIP="$VENV_DIR/bin/pip"
-PYTHON="$VENV_DIR/bin/python"
-PYTEST="$VENV_DIR/bin/pytest"
-
-if [[ "$(uname)" == MINGW* ]] || [[ "$(uname)" == MSYS* ]] || [[ "$OSTYPE" == "msys" ]]; then
-    PIP="$VENV_DIR/Scripts/pip.exe"
-    PYTHON="$VENV_DIR/Scripts/python.exe"
-    PYTEST="$VENV_DIR/Scripts/pytest.exe"
-fi
-
-echo "Installing dependencies..."
-"$PIP" install --quiet maturin
-"$PIP" install --quiet -r "$PROJECT_ROOT/tests/requirements.txt"
-"$PIP" install --quiet -r "$QT_APP_DIR/requirements.txt"
-
-# Generate README for xa11y-python (it's in .gitignore, maturin needs it)
-echo "Generating xa11y-python README..."
-cd "$PROJECT_ROOT"
-cargo xtask sync-readmes 2>&1
-
-# Build and install xa11y Python bindings
-echo "Building xa11y Python bindings..."
-cd "$PROJECT_ROOT/xa11y-python"
-"$PIP" install --quiet -e .
+# shellcheck source=setup_python_integ_env.sh
+source "$SCRIPT_DIR/setup_python_integ_env.sh" "$QT_APP_DIR/requirements.txt"
 
 cd "$PROJECT_ROOT"
 

--- a/scripts/run_tauri_tests.sh
+++ b/scripts/run_tauri_tests.sh
@@ -110,31 +110,9 @@ echo "Building Tauri test app..."
 cd "$PROJECT_ROOT"
 cargo build --manifest-path test-apps/tauri/Cargo.toml
 
-# ── Set up Python venv ───────────────────────────────────────────────
-
-VENV_DIR="$PROJECT_ROOT/.venv-tauri-test"
-
-if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating virtualenv at $VENV_DIR..."
-    python3 -m venv "$VENV_DIR"
-fi
-
-PIP="$VENV_DIR/bin/pip"
-PYTEST="$VENV_DIR/bin/pytest"
-
-echo "Installing dependencies..."
-"$PIP" install --quiet maturin
-"$PIP" install --quiet -r "$PROJECT_ROOT/tests/requirements.txt"
-
-# Generate README for xa11y-python (it's in .gitignore, maturin needs it)
-echo "Generating xa11y-python README..."
-cd "$PROJECT_ROOT"
-cargo xtask sync-readmes 2>&1
-
-# Build and install xa11y Python bindings
-echo "Building xa11y Python bindings..."
-cd "$PROJECT_ROOT/xa11y-python"
-"$PIP" install --quiet -e .
+# ── Set up shared Python integ venv ──────────────────────────────────
+# shellcheck source=setup_python_integ_env.sh
+source "$SCRIPT_DIR/setup_python_integ_env.sh"
 
 cd "$PROJECT_ROOT"
 

--- a/scripts/setup_python_integ_env.sh
+++ b/scripts/setup_python_integ_env.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Shared Python venv bootstrap for the Linux integration-test runners.
+#
+# The Qt / GTK / Tauri suites used to each create their own `.venv-{qt,gtk,tauri}-test`
+# and `pip install -e ./xa11y-python` separately — the first one paid a ~60s
+# maturin build, the other two re-linked against the warm cargo cache for
+# ~10s each. Worse, every invocation ran `pip install -e .` even when nothing
+# had changed, re-invoking maturin through pip each time.
+#
+# This helper consolidates all three suites onto a single `.venv-test` venv
+# and short-circuits the xa11y-python build when the package is already
+# importable. On a fresh runner the first caller pays the full build; the
+# second and third callers are no-ops.
+#
+# Usage: source scripts/setup_python_integ_env.sh [EXTRA_REQUIREMENTS_FILE ...]
+#
+# Sets PROJECT_ROOT, VENV_DIR, PIP, PYTHON, PYTEST on success (never exits —
+# meant to be sourced into the caller's env).
+
+SETUP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SETUP_SCRIPT_DIR/.." && pwd)"
+VENV_DIR="$PROJECT_ROOT/.venv-test"
+
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating shared integ venv at $VENV_DIR..."
+    python3 -m venv "$VENV_DIR"
+fi
+
+PIP="$VENV_DIR/bin/pip"
+PYTHON="$VENV_DIR/bin/python"
+PYTEST="$VENV_DIR/bin/pytest"
+
+if [[ "$(uname)" == MINGW* ]] || [[ "$(uname)" == MSYS* ]] || [[ "$OSTYPE" == "msys" ]]; then
+    PIP="$VENV_DIR/Scripts/pip.exe"
+    PYTHON="$VENV_DIR/Scripts/python.exe"
+    PYTEST="$VENV_DIR/Scripts/pytest.exe"
+fi
+
+# Core requirements: maturin (builds the PyO3 bindings) + shared test deps.
+"$PIP" install --quiet maturin
+"$PIP" install --quiet -r "$PROJECT_ROOT/tests/requirements.txt"
+
+# Per-suite extras (e.g. PySide6, PyGObject) are passed as arguments.
+for req in "$@"; do
+    if [ -n "$req" ] && [ -f "$req" ]; then
+        "$PIP" install --quiet -r "$req"
+    fi
+done
+
+# xa11y-python is built with maturin via `pip install -e`. maturin reads the
+# README referenced in pyproject.toml, and that README is gitignored (generated
+# from the root by `cargo xtask sync-readmes`). Generate it unconditionally —
+# it's cheap.
+echo "Generating xa11y-python README..."
+(cd "$PROJECT_ROOT" && cargo xtask sync-readmes >/dev/null 2>&1 || true)
+
+# Skip the bindings rebuild if the compiled extension module is already
+# importable. We check `xa11y._native` specifically (not just `xa11y`)
+# because the repo root contains a `xa11y/` Rust crate directory that gets
+# picked up by Python as an implicit namespace package — a bare
+# `import xa11y` succeeds against it even when the PyO3 extension isn't
+# installed.
+#
+# Within a single CI job, source doesn't change between Qt → GTK → Tauri
+# steps, so the second and third callers get this for free.
+if "$PYTHON" -c "import xa11y._native" 2>/dev/null; then
+    echo "xa11y-python already installed in $VENV_DIR; skipping build."
+else
+    echo "Building xa11y-python and installing into $VENV_DIR..."
+    (cd "$PROJECT_ROOT/xa11y-python" && "$PIP" install --quiet -e .)
+fi


### PR DESCRIPTION
## Summary

Two easy wins for the Linux CI job, which was taking ~7 min total on #149 (see [that run](https://github.com/xa11y/xa11y/actions/runs/24894743250/job/72896329281?pr=149)).

### 1. Consolidate Qt/GTK/Tauri Python venvs

Each of `run_qt_tests.sh`, `run_gtk_tests.sh`, `run_tauri_tests.sh` used to create its own `.venv-{qt,gtk,tauri}-test` and run `pip install -e ./xa11y-python` against it. On a cold runner the first caller (Qt) paid a ~60 s maturin build; the other two paid ~10 s each re-linking against the warm cargo cache. Every run re-invoked `pip install -e .` even when nothing had changed.

Factor the venv + dependency bootstrap into a new `scripts/setup_python_integ_env.sh` that:
- Reuses a single `.venv-test` across suites.
- Short-circuits the bindings build when `xa11y._native` already imports — checking `xa11y._native` specifically rather than `xa11y`, because the repo root contains a Rust crate directory named `xa11y/` that gets picked up by Python as an implicit namespace package, so `import xa11y` succeeds even without the PyO3 extension.
- Accepts per-suite extra `requirements.txt` files as arguments.

Within a single CI job, source doesn't change between Qt → GTK → Tauri steps, so the second and third callers skip the build entirely.

### 2. Cache apt packages with `awalsh128/cache-apt-pkgs-action`

The "Install system dependencies" step was taking ~60 s to `apt-get install -y` ~30 X/Qt/GTK/WebKit packages. The action caches the .debs and finishes in ~10 s on a cache hit. Applied to all three Linux jobs that share the same package set: unit-tests, JS integration, and Electron integration. Bump `version:` to invalidate the cache when the package list changes.

## Expected impact

| Step | Before | After (cache-hit) |
|---|---|---|
| Install system deps | ~60 s | ~10 s |
| Run Qt integ tests | ~136 s (62 s bindings build + 58 s pytest) | ~75 s (62 s build + 13 s skipped on reruns; full 75 s first run with pytest) |
| Run GTK integ tests | ~39 s | ~30 s (skips pip install) |
| Run Tauri integ tests | ~75 s | ~65 s (skips pip install) |
| **Linux job wall time** | **~7 min** | **~4 min** |

First-ever CI run on this branch pays full build + cache miss. Subsequent runs see the speedup.

## Test plan
- [x] `scripts/setup_python_integ_env.sh` idempotence tested locally (second call drops from ~45 s to ~1 s).
- [x] `xa11y._native` check correctly rejects the namespace-package false positive.
- [ ] Linux unit + Qt + GTK + Tauri integ jobs pass on CI.
- [ ] JS integration (Linux) + Electron integration jobs pass with cached apt packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)