### PR TITLE
docs(js): fill in JS API docstrings + fix generator parser bug

### DIFF
--- a/xa11y-js/scripts/patch-native-dts.mjs
+++ b/xa11y-js/scripts/patch-native-dts.mjs
@@ -8,6 +8,9 @@
 //      the Rust side can't express.
 //   2. Narrow `Element.checked: string | null` -> `CheckedState | null`.
 //   3. Narrow `Event.type: string` -> `EventTypeName`.
+//   4. Append a `;` to the napi-emitted `NativeSubscription` type alias
+//      (napi-rs omits terminators, which confuses the docs generator's
+//      multi-line type-alias parser).
 //
 // Each substitution is guarded: if a pattern stops matching (because napi
 // changed its output format), the script fails loudly so the drift is
@@ -60,6 +63,17 @@ const REPLACEMENTS = [
     name: 'Event.type -> EventTypeName',
     from: '  get type(): string\n',
     to: '  get type(): EventTypeName\n',
+  },
+  {
+    // napi-rs emits this line without a trailing `;`. The docs generator
+    // (docs/generate_js_api.py) uses `;` to terminate multi-line type
+    // aliases, so an unterminated alias silently swallows every later
+    // class declaration until it hits any line that happens to end in `;`.
+    // Appending the terminator here is a one-line fix that keeps the parser
+    // honest.
+    name: 'NativeSubscription type alias terminator',
+    from: 'export type NativeSubscription = _NativeSubscription\n',
+    to: 'export type NativeSubscription = _NativeSubscription;\n',
   },
 ];
 

--- a/xa11y-js/src/app.rs
+++ b/xa11y-js/src/app.rs
@@ -10,6 +10,11 @@ use crate::locator::Locator;
 use crate::map_err;
 use crate::subscription::NativeSubscription;
 
+/// A running application — the entry point for accessibility queries.
+///
+/// Construct via {@link App.byName}, {@link App.byPid}, or {@link App.list}.
+/// An `App` is **not** an `Element` — it represents the application as a
+/// whole and provides {@link App.locator} to search its accessibility tree.
 #[napi]
 pub struct App {
     name: String,
@@ -42,6 +47,14 @@ pub struct AppLookupOptions {
 #[napi]
 impl App {
     /// Find an application by exact name.
+    ///
+    /// Pass `options.timeout` (ms) to poll the accessibility API until the
+    /// app appears. Useful when the app may not yet be registered (e.g.
+    /// just-launched). Only "not found" errors trigger a retry; permission
+    /// errors and the like fail fast.
+    ///
+    /// Rejects with `PermissionDeniedError` if accessibility is not enabled,
+    /// or `SelectorNotMatchedError` if no matching app is found.
     #[napi(ts_return_type = "Promise<App>")]
     pub fn by_name(name: String, options: Option<AppLookupOptions>) -> AsyncTask<FindByNameTask> {
         AsyncTask::new(FindByNameTask {
@@ -51,6 +64,8 @@ impl App {
     }
 
     /// Find an application by process ID.
+    ///
+    /// See {@link App.byName} for the `options.timeout` behaviour.
     #[napi(ts_return_type = "Promise<App>")]
     pub fn by_pid(pid: u32, options: Option<AppLookupOptions>) -> AsyncTask<FindByPidTask> {
         AsyncTask::new(FindByPidTask {
@@ -65,17 +80,24 @@ impl App {
         AsyncTask::new(ListAppsTask {})
     }
 
+    /// The application's human-readable name (e.g. `"Safari"`).
     #[napi(getter)]
     pub fn name(&self) -> String {
         self.name.clone()
     }
 
+    /// The application's process ID, or `null` if the platform does not
+    /// expose one for this app.
     #[napi(getter)]
     pub fn pid(&self) -> Option<u32> {
         self.pid
     }
 
-    /// Create a [`Locator`] scoped to this application's accessibility tree.
+    /// Create a `Locator` scoped to this application's accessibility tree.
+    ///
+    /// The locator re-resolves `selector` on every operation, so it always
+    /// targets the current UI state — see the `Locator` class for the full
+    /// API.
     #[napi]
     pub fn locator(&self, selector: String) -> Locator {
         Locator::from_inner(xa11y::Locator::new(

--- a/xa11y-js/src/element.rs
+++ b/xa11y-js/src/element.rs
@@ -8,6 +8,16 @@ use crate::map_err;
 use crate::subscription::NativeSubscription;
 use crate::types::{toggled_to_str, Rect};
 
+/// A snapshot of a node in the accessibility tree.
+///
+/// Property getters (`role`, `name`, `value`, state flags, etc.) are
+/// synchronous — they read the snapshot data captured when the element
+/// was fetched. Navigation methods (`children()`, `parent()`) are async
+/// and re-query the provider on every call, so you always see the latest
+/// tree state.
+///
+/// Elements are cheap to pass around; they share the provider handle
+/// internally.
 #[napi]
 pub struct Element {
     pub(crate) data: xa11y::ElementData,
@@ -30,51 +40,67 @@ impl Element {
         self.data.role.to_snake_case().to_string()
     }
 
+    /// Human-readable name (title, label, or ARIA name).
     #[napi(getter)]
     pub fn name(&self) -> Option<String> {
         self.data.name.clone()
     }
 
+    /// Current value — text content for editable fields, stringified slider
+    /// position, etc. For numeric controls, prefer `numericValue`.
     #[napi(getter)]
     pub fn value(&self) -> Option<String> {
         self.data.value.clone()
     }
 
+    /// Supplementary description (tooltip text, ARIA description).
     #[napi(getter)]
     pub fn description(&self) -> Option<String> {
         self.data.description.clone()
     }
 
+    /// Numeric value for sliders, spin buttons, and progress indicators.
     #[napi(getter)]
     pub fn numeric_value(&self) -> Option<f64> {
         self.data.numeric_value
     }
 
+    /// Minimum numeric value for bounded controls (slider, spin button).
     #[napi(getter)]
     pub fn min_value(&self) -> Option<f64> {
         self.data.min_value
     }
 
+    /// Maximum numeric value for bounded controls (slider, spin button).
     #[napi(getter)]
     pub fn max_value(&self) -> Option<f64> {
         self.data.max_value
     }
 
+    /// Platform-assigned identifier that is stable across queries for the
+    /// same element. Not available on every platform / every widget.
     #[napi(getter)]
     pub fn stable_id(&self) -> Option<String> {
         self.data.stable_id.clone()
     }
 
+    /// Process ID of the owning application.
     #[napi(getter)]
     pub fn pid(&self) -> Option<u32> {
         self.data.pid
     }
 
+    /// Names of actions the element advertises (e.g. `["press", "focus"]`).
+    /// Use `Locator.performAction(name)` to invoke a custom action, or the
+    /// named convenience methods (`press`, `toggle`, etc.) for the common
+    /// ones.
     #[napi(getter)]
     pub fn actions(&self) -> Vec<String> {
         self.data.actions.clone()
     }
 
+    /// Screen-coordinate bounding rectangle, or `null` for virtual /
+    /// off-screen elements that do not have a physical position.
     #[napi(getter)]
     pub fn bounds(&self) -> Option<Rect> {
         self.data.bounds.map(Into::into)
@@ -98,21 +124,26 @@ impl Element {
         serde_json::Value::Object(map)
     }
 
+    /// `true` if the element is interactive (not greyed out or disabled).
     #[napi(getter)]
     pub fn enabled(&self) -> bool {
         self.data.states.enabled
     }
 
+    /// `true` if the element is currently rendered on screen (not hidden,
+    /// not clipped off the viewport).
     #[napi(getter)]
     pub fn visible(&self) -> bool {
         self.data.states.visible
     }
 
+    /// `true` if the element currently has keyboard focus.
     #[napi(getter)]
     pub fn focused(&self) -> bool {
         self.data.states.focused
     }
 
+    /// Tri-state checked value for checkboxes, toggle buttons, and menu items:
     /// `"on"`, `"off"`, `"mixed"`, or `null` if the element is not toggleable.
     #[napi(getter)]
     pub fn checked(&self) -> Option<String> {
@@ -122,36 +153,48 @@ impl Element {
             .map(|t| toggled_to_str(t).to_string())
     }
 
+    /// `true` if the element is selected (list item, tab, row).
     #[napi(getter)]
     pub fn selected(&self) -> bool {
         self.data.states.selected
     }
 
+    /// `true` / `false` for expandable elements (disclosures, menus, tree
+    /// items); `null` if the element is not expandable.
     #[napi(getter)]
     pub fn expanded(&self) -> Option<bool> {
         self.data.states.expanded
     }
 
+    /// `true` if the element accepts text editing (text field, text area,
+    /// rich-text region).
     #[napi(getter)]
     pub fn editable(&self) -> bool {
         self.data.states.editable
     }
 
+    /// `true` if the element can receive keyboard focus (distinct from
+    /// `focused`, which reports the current state).
     #[napi(getter)]
     pub fn focusable(&self) -> bool {
         self.data.states.focusable
     }
 
+    /// `true` if the element is a modal dialog that blocks interaction with
+    /// the rest of the app.
     #[napi(getter)]
     pub fn modal(&self) -> bool {
         self.data.states.modal
     }
 
+    /// `true` for form fields that are marked required.
     #[napi(getter)]
     pub fn required(&self) -> bool {
         self.data.states.required
     }
 
+    /// `true` if the element is loading or otherwise indicating a busy
+    /// state (progress indicator, spinner region).
     #[napi(getter)]
     pub fn busy(&self) -> bool {
         self.data.states.busy

--- a/xa11y-js/src/input.rs
+++ b/xa11y-js/src/input.rs
@@ -11,11 +11,22 @@ use napi::Either;
 use crate::element::Element;
 use crate::map_err;
 
-/// Input-simulation façade. Constructed via the module-level `inputSim()`.
+/// Synthesises OS-level pointer and keyboard events.
 ///
-/// Methods return `Promise<void>` — platform input APIs are synchronous but
-/// can block briefly, so they run on the napi worker pool like the other
-/// provider-touching calls.
+/// Constructed via the module-level `inputSim()` function. Targets are
+/// either an `[x, y]` tuple in screen pixels, or an `Element` (centred on
+/// its bounds). Key values are strings: printable characters are literal
+/// (`"a"`, `"7"`, `";"`); named keys use their Pascal name (`"Enter"`,
+/// `"ArrowUp"`, `"F5"`); modifiers are `"Shift"`, `"Ctrl"`, `"Alt"`,
+/// `"Meta"`.
+///
+/// Input simulation is distinct from the accessibility action layer —
+/// prefer `Locator.press` / `Locator.typeText` when the target exposes
+/// the semantic action. Use `InputSim` for gestures with no a11y
+/// equivalent (drag-and-drop, scroll wheels, global shortcuts).
+///
+/// Methods return `Promise<void>` — the underlying OS input APIs are
+/// synchronous but can block briefly, so they run on the napi worker pool.
 #[napi]
 pub struct InputSim {
     inner: xa11y::InputSim,
@@ -277,7 +288,11 @@ impl Task for KeyboardTask {
     }
 }
 
-/// Construct an [`InputSim`] backed by the platform's native input path.
+/// Construct an `InputSim` backed by the platform's native input path
+/// (CGEvent on macOS, SendInput on Windows, XTest on X11).
+///
+/// Throws `PlatformError` on a Wayland-only Linux session (no XTest
+/// available). `InputSim` is cheap to hold; construct one and reuse.
 #[napi(js_name = "inputSim")]
 #[allow(
     dead_code,

--- a/xa11y-js/src/locator.rs
+++ b/xa11y-js/src/locator.rs
@@ -7,6 +7,23 @@ use napi::bindgen_prelude::{AsyncTask, Env, Task};
 use crate::element::Element;
 use crate::map_err;
 
+/// A resilient element reference that re-queries on each interaction.
+///
+/// Locators never hold a live reference to a UI element. Instead, they
+/// store a selector and resolve it on demand, making them immune to
+/// staleness. Action methods (`press`, `typeText`, `toggle`, …) auto-wait
+/// for the element to appear (up to 5 seconds by default) before acting.
+///
+/// Locators are cheap to clone — the chaining methods (`child`, `descendant`,
+/// `nth`, `first`) return new locators rather than mutating in place.
+///
+/// @example
+/// ```ts
+/// const app = await App.byName('MyApp');
+/// const save = app.locator("button[name='Save']");
+/// await save.press();                  // auto-waits, then presses
+/// await save.waitEnabled(10);          // wait up to 10 seconds
+/// ```
 #[napi]
 pub struct Locator {
     inner: xa11y::Locator,
@@ -95,26 +112,43 @@ impl Locator {
     // ── Actions (each auto-waits, then performs the action) ────────────
 
     /// Click / invoke the matched element.
+    ///
+    /// Auto-waits for the element to exist before acting. For elements whose
+    /// primary activation is `toggle` or `select` (checkbox, tab, radio),
+    /// `press` dispatches to that semantic — there is no need to distinguish.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn press(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(self.inner.clone(), ActionKind::Press))
     }
+
+    /// Move keyboard focus to the matched element.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn focus(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(self.inner.clone(), ActionKind::Focus))
     }
+
+    /// Remove keyboard focus from the matched element.
+    ///
+    /// Not supported on Linux or Windows — on those platforms this rejects
+    /// with `ActionNotSupportedError`.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn blur(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(self.inner.clone(), ActionKind::Blur))
     }
+
+    /// Toggle a two- or three-state control (checkbox, switch, toggle button).
     #[napi(ts_return_type = "Promise<void>")]
     pub fn toggle(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(self.inner.clone(), ActionKind::Toggle))
     }
+
+    /// Expand a disclosure, menu, or tree item.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn expand(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(self.inner.clone(), ActionKind::Expand))
     }
+
+    /// Collapse a disclosure, menu, or tree item.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn collapse(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(
@@ -122,10 +156,14 @@ impl Locator {
             ActionKind::Collapse,
         ))
     }
+
+    /// Select the matched element (list item, tab, row).
     #[napi(js_name = "select", ts_return_type = "Promise<void>")]
     pub fn select_(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(self.inner.clone(), ActionKind::Select))
     }
+
+    /// Open the element's context menu.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn show_menu(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(
@@ -133,6 +171,11 @@ impl Locator {
             ActionKind::ShowMenu,
         ))
     }
+
+    /// Scroll the element into the visible area.
+    ///
+    /// No-op on macOS — the macOS accessibility API has no equivalent. Uses
+    /// `Component.ScrollTo` on Linux and `ScrollItemPattern` on Windows.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn scroll_into_view(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(
@@ -140,6 +183,8 @@ impl Locator {
             ActionKind::ScrollIntoView,
         ))
     }
+
+    /// Increment a numeric value (slider, spin button) by its platform step.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn increment(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(
@@ -147,6 +192,8 @@ impl Locator {
             ActionKind::Increment,
         ))
     }
+
+    /// Decrement a numeric value (slider, spin button) by its platform step.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn decrement(&self) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::nullary(
@@ -155,6 +202,8 @@ impl Locator {
         ))
     }
 
+    /// Set the text value of the matched element. Replaces the entire value
+    /// rather than inserting at the caret — use `typeText` for insertion.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn set_value(&self, value: String) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::with_text(
@@ -164,6 +213,7 @@ impl Locator {
         ))
     }
 
+    /// Set the numeric value of the matched element (slider, spin button).
     #[napi(ts_return_type = "Promise<void>")]
     pub fn set_numeric_value(&self, value: f64) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::with_num(
@@ -173,6 +223,11 @@ impl Locator {
         ))
     }
 
+    /// Type `text` at the current caret position.
+    ///
+    /// Uses the platform accessibility API — never simulates keyboard events.
+    /// For synthesised keystrokes (global shortcuts, drag gestures), use the
+    /// `InputSim` surface instead.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn type_text(&self, text: String) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::with_text(
@@ -182,6 +237,8 @@ impl Locator {
         ))
     }
 
+    /// Select the text range from `start` to `end` (0-based character offsets).
+    /// Rejects with `InvalidActionDataError` if `start > end`.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn select_text(&self, start: u32, end: u32) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::with_range(
@@ -192,7 +249,11 @@ impl Locator {
         ))
     }
 
-    /// Perform an action by snake_case name.
+    /// Perform a custom action by its snake_case name.
+    ///
+    /// Use this for actions the element advertises in its `actions` list
+    /// that don't have a dedicated method. Rejects with
+    /// `ActionNotSupportedError` if the element does not advertise `action`.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn perform_action(&self, action: String) -> AsyncTask<ActionTask> {
         AsyncTask::new(ActionTask::with_text(
@@ -203,7 +264,14 @@ impl Locator {
     }
 
     // ── Waits ──────────────────────────────────────────────────────────
+    //
+    // Each wait polls the provider until its condition is satisfied or
+    // `timeoutSeconds` elapses (default: 5s). Waits that expect the element
+    // to be present resolve with the matched `Element`; waits that expect it
+    // to be gone resolve with `undefined`.
 
+    /// Wait for a matching element to become visible.
+    /// Rejects with `TimeoutError` if still hidden after `timeoutSeconds`.
     #[napi(
         ts_args_type = "timeoutSeconds?: number",
         ts_return_type = "Promise<Element>"
@@ -216,6 +284,8 @@ impl Locator {
         ))
     }
 
+    /// Wait for a matching element to exist in the tree (may not be visible).
+    /// Rejects with `TimeoutError` if no match appears within `timeoutSeconds`.
     #[napi(
         ts_args_type = "timeoutSeconds?: number",
         ts_return_type = "Promise<Element>"
@@ -228,6 +298,7 @@ impl Locator {
         ))
     }
 
+    /// Wait for the matching element to be removed from the tree.
     #[napi(
         ts_args_type = "timeoutSeconds?: number",
         ts_return_type = "Promise<void>"
@@ -240,6 +311,7 @@ impl Locator {
         ))
     }
 
+    /// Wait for the matching element to become enabled (interactive).
     #[napi(
         ts_args_type = "timeoutSeconds?: number",
         ts_return_type = "Promise<Element>"
@@ -252,6 +324,7 @@ impl Locator {
         ))
     }
 
+    /// Wait for the matching element to be hidden or removed.
     #[napi(
         ts_args_type = "timeoutSeconds?: number",
         ts_return_type = "Promise<void>"
@@ -264,6 +337,7 @@ impl Locator {
         ))
     }
 
+    /// Wait for the matching element to become disabled (non-interactive).
     #[napi(
         ts_args_type = "timeoutSeconds?: number",
         ts_return_type = "Promise<Element>"
@@ -276,6 +350,7 @@ impl Locator {
         ))
     }
 
+    /// Wait for the matching element to receive keyboard focus.
     #[napi(
         ts_args_type = "timeoutSeconds?: number",
         ts_return_type = "Promise<Element>"
@@ -288,6 +363,7 @@ impl Locator {
         ))
     }
 
+    /// Wait for the matching element to lose keyboard focus.
     #[napi(
         ts_args_type = "timeoutSeconds?: number",
         ts_return_type = "Promise<Element>"

--- a/xa11y-js/src/screenshot.rs
+++ b/xa11y-js/src/screenshot.rs
@@ -32,16 +32,20 @@ impl Screenshot {
 
 #[napi]
 impl Screenshot {
+    /// Image width in physical pixels.
     #[napi(getter)]
     pub fn width(&self) -> u32 {
         self.inner.width
     }
 
+    /// Image height in physical pixels.
     #[napi(getter)]
     pub fn height(&self) -> u32 {
         self.inner.height
     }
 
+    /// Physical-to-logical pixel ratio (1.0 on standard displays, 2.0 on
+    /// typical Retina, 1.5 / 1.75 / 2.0 on common Windows / Linux HiDPI).
     #[napi(getter)]
     pub fn scale(&self) -> f64 {
         self.inner.scale as f64

--- a/xa11y-js/src/subscription.rs
+++ b/xa11y-js/src/subscription.rs
@@ -26,6 +26,12 @@ use crate::types::{event_kind_to_str, state_flag_to_str};
 
 // ── Event ──────────────────────────────────────────────────────────────────
 
+/// An accessibility event delivered to a `Subscription`.
+///
+/// Events are emitted from the source application — focus changes, value
+/// edits, window lifecycle, structural updates. Attach a listener via
+/// `subscription.on(type, handler)` or await one with
+/// `subscription.waitForEvent(type, opts)`.
 #[napi]
 pub struct Event {
     kind: String,
@@ -82,11 +88,13 @@ impl Event {
         self.state_value
     }
 
+    /// Name of the application that emitted this event.
     #[napi(getter)]
     pub fn app_name(&self) -> String {
         self.app_name.clone()
     }
 
+    /// Process ID of the application that emitted this event.
     #[napi(getter)]
     pub fn app_pid(&self) -> u32 {
         self.app_pid

--- a/xa11y-js/src/types.rs
+++ b/xa11y-js/src/types.rs
@@ -1,12 +1,20 @@
 //! Small plain-data types exposed to JS: `Rect`, `EventKind`, etc.
 
-/// A bounding rectangle in screen coordinates (pixels).
+/// A bounding rectangle in screen coordinates.
+///
+/// Coordinates use the platform's native coordinate space: points on macOS,
+/// physical pixels on Windows and Linux. Origin is the top-left of the
+/// primary display; negative `x` / `y` are valid on multi-monitor setups.
 #[napi(object)]
 #[derive(Clone)]
 pub struct Rect {
+    /// Left edge, in screen coordinates.
     pub x: i32,
+    /// Top edge, in screen coordinates.
     pub y: i32,
+    /// Width in screen-coordinate units.
     pub width: i32,
+    /// Height in screen-coordinate units.
     pub height: i32,
 }
 


### PR DESCRIPTION
The JS API reference page was thin — most methods had no docstrings, and entire classes were missing.

## Root causes

1. **Thin docstrings in `xa11y-js/src/*.rs`.** napi-rs propagates Rust `///` comments into JSDoc in `native.d.ts`, but many symbols (every Element getter, every Locator wait, most action methods, class-level docs for App/Element/Locator/Event) had no doc comment at all.
2. **Latent parser bug in `docs/generate_js_api.py`.** The multi-line type-alias parser terminates on `;`, but napi-rs emits `export type NativeSubscription = _NativeSubscription` with no semicolon. Result: the parser silently slurped every subsequent class declaration into the type-alias "definition" until it hit any line ending in `;`. App, Element, Event, InputSim, and usually Locator/Screenshot all vanished from the rendered output — the baseline run detected only **1 class** out of 7.

## Fix

- **Generator:** patch `xa11y-js/scripts/patch-native-dts.mjs` to append a `;` to the napi-emitted `NativeSubscription` alias. One-line fix, closes the parser loophole.
- **Source docstrings:** add `///` comments (matching the Python `_native.pyi` stubs where the language parallels) across:
  - `App`: class-level doc, `name`/`pid` getters, richer `byName`/`byPid`/`locator` docs.
  - `Element`: class-level doc plus docs for 17+ getters (`name`, `value`, `description`, `numeric_value`, `min_value`, `max_value`, `stable_id`, `pid`, `actions`, `bounds`, and every state flag).
  - `Locator`: class-level doc with example; docs for `focus`/`blur`/`toggle`/`expand`/`collapse`/`select`/`show_menu`/`scroll_into_view`/`increment`/`decrement`/`set_value`/`set_numeric_value`/`type_text`/`select_text`/`perform_action`; docs for all 8 `wait_*` methods.
  - `Event`: class-level doc, `app_name`/`app_pid` getters.
  - `InputSim`: expanded class-level doc covering targets / key strings / when to use vs the a11y action layer.
  - `Rect`: class-level doc covering coordinate space, field-level docs.
  - `Screenshot`: `width`/`height`/`scale` getter docs.
  - `inputSim()` function: fuller doc on platform backing + Wayland caveat.

## Result

Regenerating `javascript.mdx` goes from **4 classes** detected to **8** (App, Element, Event, InputSim, Locator, Screenshot, AppLookupOptions, Rect), with every public method carrying a description.

## Test plan
- [x] `cargo check` + `cargo clippy -- -D warnings` pass on `xa11y-js`
- [x] `npx napi build` still succeeds; patched `native.d.ts` has the `;` terminator
- [x] `python docs/generate_js_api.py` reports 8 classes, 2 functions, 3 type aliases, 9 error classes
- [x] `npx astro build` passes cleanly (11 pages, including the regenerated `/api/javascript/`)
- [ ] Visual spot-check of the rendered `/api/javascript/` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)