### PR TITLE
ci(release-notes): bubble up Models errors, add manual rerun workflow

### DIFF
--- a/.github/scripts/generate-release-notes.mjs
+++ b/.github/scripts/generate-release-notes.mjs
@@ -13,7 +13,7 @@ import { argv, env, exit, stderr, stdout } from "node:process";
 // Authenticates with the workflow's GITHUB_TOKEN — no separate API key needed.
 // See: https://docs.github.com/en/github-models/prototyping-with-ai-models
 const GITHUB_MODELS_URL = "https://models.github.ai/inference/chat/completions";
-const MODEL_ID = "openai/gpt-4o";
+const MODEL_ID = "openai/gpt-5-mini";
 
 const TOOL_DEFINITION = {
   type: "function",
@@ -212,6 +212,7 @@ async function invokeGithubModels(inputText, repoName, token) {
     },
   };
 
+  stderr.write(`POST ${GITHUB_MODELS_URL} (model=${MODEL_ID})\n`);
   const resp = await fetch(GITHUB_MODELS_URL, {
     method: "POST",
     headers: {
@@ -225,8 +226,26 @@ async function invokeGithubModels(inputText, repoName, token) {
 
   if (!resp.ok) {
     const detail = await resp.text();
+    // Surface status, rate-limit headers, and response body as separate
+    // stderr lines so the workflow log shows them even when the thrown
+    // Error message gets truncated or its newlines collapsed.
+    stderr.write(`GitHub Models error: ${resp.status} ${resp.statusText}\n`);
+    const interesting = [
+      "x-ratelimit-limit",
+      "x-ratelimit-remaining",
+      "x-ratelimit-reset",
+      "x-ratelimit-resource",
+      "retry-after",
+      "x-request-id",
+      "www-authenticate",
+    ];
+    for (const name of interesting) {
+      const value = resp.headers.get(name);
+      if (value) stderr.write(`  ${name}: ${value}\n`);
+    }
+    stderr.write(`Response body:\n${detail || "(empty)"}\n`);
     throw new Error(
-      `GitHub Models request failed: ${resp.status} ${resp.statusText}\n${detail}`,
+      `GitHub Models request failed: ${resp.status} ${resp.statusText} — ${detail.slice(0, 500) || "(empty body)"}`,
     );
   }
 

--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -1,0 +1,88 @@
+name: Update release notes
+
+# Re-run the LLM release-note generator against an existing tag and
+# overwrite that release's notes. Useful when the generator failed during
+# the publish workflow (e.g. GitHub Models 403/429) and the release got
+# created with the plain git-log fallback.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag of the release to update (e.g. v0.7.0)"
+        required: true
+        type: string
+      since:
+        description: "Override the previous tag for the diff range (optional)"
+        required: false
+        type: string
+      dry_run:
+        description: "Render notes only, do not edit the release"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  update:
+    name: Regenerate notes for ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      models: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need full history + tags so the script can resolve the previous
+          # tag and walk the commit range.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Verify tag exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${{ inputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::Release ${{ inputs.tag }} not found in this repo." >&2
+            exit 1
+          fi
+
+      - name: Generate release notes (LLM)
+        id: notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          NOTES_FILE="$RUNNER_TEMP/release_notes.md"
+          ARGS=("${{ inputs.tag }}")
+          if [ -n "${{ inputs.since }}" ]; then
+            ARGS+=(--since "${{ inputs.since }}")
+          fi
+          # No git-log fallback here on purpose: this workflow exists to
+          # *fix* a bad release, so a silent fallback to the same plain
+          # log we are trying to replace would defeat the point. Fail
+          # loudly instead and let the operator re-run after diagnosing.
+          node .github/scripts/generate-release-notes.mjs "${ARGS[@]}" > "$NOTES_FILE"
+          echo "notes-file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+          echo "----- release notes -----"
+          cat "$NOTES_FILE"
+          echo "-------------------------"
+
+      - name: Update GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ inputs.tag }}" \
+            --notes-file "${{ steps.notes.outputs.notes-file }}"
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run — release ${{ inputs.tag }} not modified." >&2


### PR DESCRIPTION
## Summary

- v0.7.0 shipped with plain git-log notes because the GitHub Models call returned 403 and the thrown `Error` swallowed the response body. The script now logs status, rate-limit headers, and the full response body to stderr before throwing, so the next failure is diagnosable from the workflow log alone.
- New `update-release-notes.yml` workflow (`workflow_dispatch`, inputs: `tag`, optional `since`, `dry_run`) regenerates notes for an existing release and overwrites them via `gh release edit`. Deliberately no git-log fallback — this workflow exists to fix a bad release, so silent fallback would defeat the point.
- Switched the model from `openai/gpt-4o` (High rate-limit class, ~50 req/day) to `openai/gpt-5-mini` (lower class, newer generation, native tool calling) to reduce throttling risk.

## Note on the underlying 403

A 403 (not 429) from `models.github.ai` typically means GitHub Models access isn't enabled at the org/account level. The model swap won't fix that — but with the improved logging, the next run will print the exact reason in the workflow log, and the manual workflow lets us regenerate v0.7.0's notes once Models access is sorted.

## Test plan

- [ ] Once merged, run `Update release notes` workflow with `tag=v0.7.0` and `dry_run=true` to confirm the script reaches Models and (if 403 persists) prints the real error body.
- [ ] If access is in order, re-run with `dry_run=false` to overwrite v0.7.0's notes.
- [ ] Confirm the next real publish run uses `openai/gpt-5-mini` and emits structured notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)