### PR TITLE
ci(release-notes): swap to gpt-4o-mini, allow MODEL_ID override

### DIFF
--- a/.github/scripts/generate-release-notes.mjs
+++ b/.github/scripts/generate-release-notes.mjs
@@ -13,7 +13,13 @@ import { argv, env, exit, stderr, stdout } from "node:process";
 // Authenticates with the workflow's GITHUB_TOKEN — no separate API key needed.
 // See: https://docs.github.com/en/github-models/prototyping-with-ai-models
 const GITHUB_MODELS_URL = "https://models.github.ai/inference/chat/completions";
-const MODEL_ID = "openai/gpt-5-mini";
+// Defaults to openai/gpt-4o-mini: long-standing on GitHub Models, Low
+// rate-limit tier (150 req/day, 8K in / 4K out on free), native tool
+// calling. Override via MODEL_ID env var to try alternatives without a
+// code change. Note: the catalog at models.github.ai/catalog/models
+// lists more models than the inference endpoint actually serves on the
+// free tier — a slug being in the catalog is not a guarantee.
+const MODEL_ID = env.MODEL_ID || "openai/gpt-4o-mini";
 
 // Per-commit caps. Kept tight because the GitHub Models free tier has
 // strict per-request input caps (e.g. 4000 tokens for gpt-5-mini), and


### PR DESCRIPTION
## Summary

The batching rerun on v0.7.0 (after #159 landed) gave a clean diagnostic:

\`\`\`
400 Bad Request — {"code":"unavailable_model","message":"Unavailable model: gpt-5-mini"}
\`\`\`

\`gpt-5-mini\` is listed in the GitHub Models catalog but isn't actually served on the inference endpoint for this account. Swap to \`openai/gpt-4o-mini\`:

- Long-standing on GitHub Models since launch — known-good slug.
- **Low** rate-limit tier on free: 15 req/min, 150 req/day, 8K in / 4K out.
- Native OpenAI-style tool calls.
- 8K input cap is well above our ~2K-token batch budget.

Also wire \`MODEL_ID\` through the environment so future swaps don't need a code change, and leave a comment noting the catalog-vs-inference availability mismatch.

## Test plan

- [ ] Re-run \`Update release notes\` on \`v0.7.0\`. Expect 4 batches to all succeed and the release to be overwritten with structured notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)