### PR TITLE
docs: read version from Cargo.toml instead of hardcoding it

### DIFF
--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -6,7 +6,8 @@ import { resolve } from "node:path";
 
 const cargoToml = readFileSync(resolve("../../Cargo.toml"), "utf-8");
 const verMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
-const version = verMatch ? `v${verMatch[1]}` : "v0.7.0";
+if (!verMatch) throw new Error("Could not find version in Cargo.toml");
+const version = `v${verMatch[1]}`;
 ---
 
 <!doctype html>

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -6,7 +6,7 @@ import { resolve } from "node:path";
 
 const cargoToml = readFileSync(resolve("../../Cargo.toml"), "utf-8");
 const verMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
-const version = verMatch ? `v${verMatch[1].replace(/\.\d+$/, "")}` : "v0.7";
+const version = verMatch ? `v${verMatch[1]}` : "v0.7.0";
 ---
 
 <!doctype html>

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -1,6 +1,12 @@
 ---
 // Custom landing page — Graphite theme with lime accent
 // Overrides the Starlight splash page for the root URL
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const cargoToml = readFileSync(resolve("../../Cargo.toml"), "utf-8");
+const verMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
+const version = verMatch ? `v${verMatch[1].replace(/\.\d+$/, "")}` : "v0.7";
 ---
 
 <!doctype html>
@@ -292,7 +298,7 @@
 <body>
 
 <header class="topbar">
-  <a class="brand" href="/"><span class="glyph">x</span> xa11y <span class="ver">v0.6</span></a>
+  <a class="brand" href="/"><span class="glyph">x</span> xa11y <span class="ver">{version}</span></a>
   <nav class="nav">
     <a href="/guides/quick-start/">quick start</a>
     <a href="/guides/overview/">overview</a>
@@ -407,7 +413,7 @@
 
 <footer>
   <div>
-    <div class="brand" style="margin-bottom:12px;"><span class="glyph">x</span> xa11y <span class="ver">v0.6</span></div>
+    <div class="brand" style="margin-bottom:12px;"><span class="glyph">x</span> xa11y <span class="ver">{version}</span></div>
     <div style="color:var(--ink-muted); font-size:13px; line-height:1.55; max-width:34ch;">
       A unified API for accessibility trees on macOS, Windows and Linux. MIT-licensed, built in the open.
     </div>


### PR DESCRIPTION
The landing page showed v0.6 while the crate is at 0.7. Replace both
hardcoded v0.6 strings with a build-time read of the workspace
Cargo.toml so the displayed version always tracks the crate version.

https://claude.ai/code/session_016xd9i7Y5nWRM2vmqYtcQvJ