### PR TITLE
fix(windows): use tree-walking for descendants + raw view for FindAllBuildCache (fixes #168, #177)

### DIFF
--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -11,7 +11,7 @@ use windows::Win32::System::Variant::VARIANT;
 use windows::Win32::UI::Accessibility::*;
 
 use xa11y_core::{
-    selector::{matches_simple, Selector},
+    selector::{matches_simple, Combinator, Selector, SelectorSegment},
     CancelHandle, ElementData, Error, Event, EventKind, EventReceiver, Provider, Rect, Result,
     Role, StateFlag, StateSet, Subscription, Toggled,
 };
@@ -596,6 +596,76 @@ impl Provider for WindowsProvider {
             }
         }
         Ok(None)
+    }
+
+    /// Override the default `narrow_multi_segment` so that the Descendant
+    /// combinator uses `find_elements_in_tree` (tree-walking via `get_children`)
+    /// rather than `self.find_elements` (which would invoke `find_all_subtree`).
+    ///
+    /// `find_all_subtree` calls `FindAllBuildCache(TreeScope_Subtree)` with no
+    /// fallback. When the candidate element is a UIA *fragment element* (not the
+    /// HWND fragment root — e.g. a Qt QFormLayout virtual group), that COM call
+    /// can return an incomplete array, silently missing virtual child elements.
+    /// By routing through `get_children` → `uia_children`, we get the
+    /// `RawViewWalker` fallback that recovers those missing children.
+    fn narrow_multi_segment(
+        &self,
+        mut candidates: Vec<ElementData>,
+        segments: &[SelectorSegment],
+        max_depth: u32,
+        limit: Option<usize>,
+    ) -> Result<Vec<ElementData>> {
+        for segment in segments {
+            let mut next_candidates = Vec::new();
+            for candidate in &candidates {
+                match segment.combinator {
+                    Combinator::Child => {
+                        let children = self.get_children(Some(candidate))?;
+                        for child in children {
+                            if matches_simple(&child, &segment.simple) {
+                                next_candidates.push(child);
+                            }
+                        }
+                    }
+                    Combinator::Descendant => {
+                        // Use tree-walking so uia_children's RawViewWalker fallback
+                        // is available for UIA fragment elements (issue #168).
+                        let sub_selector = Selector {
+                            segments: vec![SelectorSegment {
+                                combinator: Combinator::Root,
+                                simple: segment.simple.clone(),
+                            }],
+                        };
+                        let mut sub_results = xa11y_core::selector::find_elements_in_tree(
+                            |el| self.get_children(el),
+                            Some(candidate),
+                            &sub_selector,
+                            None,
+                            Some(max_depth),
+                        )?;
+                        next_candidates.append(&mut sub_results);
+                    }
+                    Combinator::Root => unreachable!(),
+                }
+            }
+            let mut seen = std::collections::HashSet::new();
+            next_candidates.retain(|e| seen.insert(e.handle));
+            candidates = next_candidates;
+        }
+
+        if let Some(nth) = segments.last().and_then(|s| s.simple.nth) {
+            if nth <= candidates.len() {
+                candidates = vec![candidates.remove(nth - 1)];
+            } else {
+                candidates.clear();
+            }
+        }
+
+        if let Some(limit) = limit {
+            candidates.truncate(limit);
+        }
+
+        Ok(candidates)
     }
 
     fn find_elements(

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -205,33 +205,21 @@ impl WindowsProvider {
     }
 
     /// Get direct UIA children of an element with properties pre-fetched.
-    /// Tries FindAllBuildCache first (works with AccessKit fragment roots),
-    /// falls back to RawViewWalker + BuildUpdatedCache for native elements.
+    /// batch_request uses raw view (TrueCondition), so FindAllBuildCache sees
+    /// all elements including virtual/fragment elements.
     fn uia_children(&self, element: &IUIAutomationElement) -> Vec<IUIAutomationElement> {
-        // Try FindAllBuildCache(Children) first — works with AccessKit virtual elements
-        if let Ok(true_cond) = unsafe { self.automation.CreateTrueCondition() } {
-            if let Ok(arr) = unsafe {
-                element.FindAllBuildCache(TreeScope_Children, &true_cond, &self.batch_request)
-            } {
-                let count = uia_len(&arr);
-                if count > 0 {
-                    return (0..count).filter_map(|i| uia_get(&arr, i)).collect();
-                }
-            }
+        let true_cond = match unsafe { self.automation.CreateTrueCondition() } {
+            Ok(c) => c,
+            Err(_) => return Vec::new(),
+        };
+        match unsafe {
+            element.FindAllBuildCache(TreeScope_Children, &true_cond, &self.batch_request)
+        } {
+            Ok(arr) => (0..uia_len(&arr))
+                .filter_map(|i| uia_get(&arr, i))
+                .collect(),
+            Err(_) => Vec::new(),
         }
-
-        // Fall back to RawViewWalker if FindAll found nothing
-        let mut children = Vec::new();
-        if let Ok(walker) = unsafe { self.automation.RawViewWalker() } {
-            let mut child = unsafe { walker.GetFirstChildElement(element) }.ok();
-            while let Some(ref child_el) = child {
-                // Populate snapshot so build_element_data can use Cached* accessors
-                let cached = self.populate_cache(child_el);
-                children.push(cached.as_ref().unwrap_or(child_el).clone());
-                child = unsafe { walker.GetNextSiblingElement(child_el) }.ok();
-            }
-        }
-        children
     }
 
     /// Fetch the entire subtree with all properties pre-fetched in one COM call.
@@ -406,6 +394,13 @@ fn create_batch_request(automation: &IUIAutomation) -> Result<IUIAutomationCache
             message: format!("AddProperty({:?}) failed: {e}", prop),
         })?;
     }
+
+    // Use raw view (TrueCondition) so FindAllBuildCache sees all UIA elements,
+    // including virtual/fragment elements from Qt, AccessKit, etc. that don't
+    // set IsControlElement=true and are silently excluded by the default
+    // Control View tree filter.
+    let raw_view = uia_call(|| unsafe { automation.CreateTrueCondition() })?;
+    uia_call(|| unsafe { request.SetTreeFilter(&raw_view) })?;
 
     Ok(request)
 }
@@ -602,12 +597,11 @@ impl Provider for WindowsProvider {
     /// combinator uses `find_elements_in_tree` (tree-walking via `get_children`)
     /// rather than `self.find_elements` (which would invoke `find_all_subtree`).
     ///
-    /// `find_all_subtree` calls `FindAllBuildCache(TreeScope_Subtree)` with no
-    /// fallback. When the candidate element is a UIA *fragment element* (not the
-    /// HWND fragment root — e.g. a Qt QFormLayout virtual group), that COM call
-    /// can return an incomplete array, silently missing virtual child elements.
-    /// By routing through `get_children` → `uia_children`, we get the
-    /// `RawViewWalker` fallback that recovers those missing children.
+    /// `find_all_subtree` calls `FindAllBuildCache(TreeScope_Subtree)`. When the
+    /// candidate element is a UIA *fragment element* (not the HWND fragment root
+    /// — e.g. a Qt QFormLayout virtual group), that call can return an incomplete
+    /// array due to provider-activation boundaries, regardless of the tree view
+    /// filter. Walking level-by-level via `get_children` avoids that problem.
     fn narrow_multi_segment(
         &self,
         mut candidates: Vec<ElementData>,
@@ -628,8 +622,8 @@ impl Provider for WindowsProvider {
                         }
                     }
                     Combinator::Descendant => {
-                        // Use tree-walking so uia_children's RawViewWalker fallback
-                        // is available for UIA fragment elements (issue #168).
+                        // Walk level-by-level to avoid provider-activation boundary
+                        // issues with FindAllBuildCache(Subtree) on fragment elements.
                         let sub_selector = Selector {
                             segments: vec![SelectorSegment {
                                 combinator: Combinator::Root,

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -857,6 +857,85 @@ fn locator_selector_getter() {
     assert_eq!(loc.selector(), "button > text_field");
 }
 
+// Regression test for issue #168: a descendant-combinator selector must find
+// elements nested inside virtual UIA fragment groups (e.g. Qt QFormLayout value
+// columns) that `FindAllBuildCache(TreeScope_Subtree)` may miss because it
+// returns nothing when rooted at a fragment element (not a fragment root).
+//
+// Tree: application > window > group["Outer"] > group["Inner"] > static_text["TestFarm"]
+// Selector: group[name="Outer"] static_text[name="TestFarm"]
+// The static_text is 2 hops deep from the outer group, so narrow_multi_segment
+// must recurse into children rather than relying solely on a single flat scan.
+#[test]
+fn locator_descendant_through_nested_groups() {
+    let children_map: Vec<Vec<usize>> = vec![
+        vec![1],  // 0: application
+        vec![2],  // 1: window
+        vec![3],  // 2: group "Outer"
+        vec![4],  // 3: group "Inner"
+        vec![],   // 4: static_text "TestFarm"
+    ];
+    let parent_map: Vec<Option<usize>> = vec![
+        None,
+        Some(0),
+        Some(1),
+        Some(2),
+        Some(3),
+    ];
+    let roles = [
+        Role::Application,
+        Role::Window,
+        Role::Group,
+        Role::Group,
+        Role::StaticText,
+    ];
+    let names = [
+        Some("Test App"),
+        Some("Window"),
+        Some("Outer"),
+        Some("Inner"),
+        Some("TestFarm"),
+    ];
+
+    let nodes: Vec<MockNode> = (0..5usize)
+        .map(|i| MockNode {
+            data: ElementData {
+                role: roles[i],
+                name: names[i].map(String::from),
+                value: None,
+                description: None,
+                bounds: None,
+                actions: vec![],
+                states: StateSet::default(),
+                numeric_value: None,
+                min_value: None,
+                max_value: None,
+                stable_id: None,
+                pid: Some(1234),
+                raw: std::collections::HashMap::new(),
+                handle: i as u64,
+            },
+            children: children_map[i].clone(),
+            parent: parent_map[i],
+        })
+        .collect();
+
+    let provider = Arc::new(MockProvider {
+        nodes,
+        last_action: std::sync::Mutex::new(None),
+    });
+    let app = App::by_name_with(provider as Arc<dyn Provider>, "Test App").unwrap();
+
+    let loc = app.locator(r#"group[name="Outer"] static_text[name="TestFarm"]"#);
+    assert!(
+        loc.exists().unwrap(),
+        "static_text nested inside two groups must be reachable via descendant combinator"
+    );
+    let el = loc.element().unwrap();
+    assert_eq!(el.role, Role::StaticText);
+    assert_eq!(el.name.as_deref(), Some("TestFarm"));
+}
+
 // ── Multi-app mock for system-root searches ──
 
 /// Build a mock with multiple apps at the top level.

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -869,19 +869,13 @@ fn locator_selector_getter() {
 #[test]
 fn locator_descendant_through_nested_groups() {
     let children_map: Vec<Vec<usize>> = vec![
-        vec![1],  // 0: application
-        vec![2],  // 1: window
-        vec![3],  // 2: group "Outer"
-        vec![4],  // 3: group "Inner"
-        vec![],   // 4: static_text "TestFarm"
+        vec![1], // 0: application
+        vec![2], // 1: window
+        vec![3], // 2: group "Outer"
+        vec![4], // 3: group "Inner"
+        vec![],  // 4: static_text "TestFarm"
     ];
-    let parent_map: Vec<Option<usize>> = vec![
-        None,
-        Some(0),
-        Some(1),
-        Some(2),
-        Some(3),
-    ];
+    let parent_map: Vec<Option<usize>> = vec![None, Some(0), Some(1), Some(2), Some(3)];
     let roles = [
         Role::Application,
         Role::Window,


### PR DESCRIPTION
## Summary

**Commit 1 (original #176 fix):** Override `narrow_multi_segment` in `WindowsProvider` to route the `Descendant` combinator through `find_elements_in_tree → get_children → uia_children` (walker path) instead of `find_all_subtree`. Fixes provider-activation boundary issue where `FindAllBuildCache(TreeScope_Subtree)` rooted at a UIA fragment element returns incomplete results.

**Commit 2 (root cause fix, closes #177):** Set `TrueCondition` as the `TreeFilter` on the shared `IUIAutomationCacheRequest` in `create_batch_request`. This propagates raw view to all `FindAllBuildCache` call sites so virtual/fragment UIA elements (Qt, AccessKit, etc.) that don't declare `IsControlElement=true` are no longer silently excluded by the default Control View filter. Removes the now-redundant `RawViewWalker` fallback from `uia_children`.

## Test plan

- [x] Added `locator_descendant_through_nested_groups` unit test
- [x] All 59 existing unit tests pass (`cargo test --package xa11y`)
- [x] `cargo build --package xa11y-windows` clean, no warnings

Fixes #168. Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)