### PR TITLE
Add JS Element action methods

### DIFF
--- a/xa11y-js/Cargo.lock
+++ b/xa11y-js/Cargo.lock
@@ -159,15 +159,21 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blocking"
@@ -203,6 +209,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "concurrent-queue"
@@ -353,6 +365,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +433,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -642,6 +672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,7 +706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb7848c221fb7bb789e02f01875287ebb1e078b92a6566a34de01ef8806e7c2b"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "ctor",
  "futures",
  "napi-build",
@@ -722,6 +761,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,11 +819,11 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -837,6 +888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,7 +925,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1000,6 +1057,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1235,7 +1298,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1436,7 +1499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -1467,6 +1530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,7 +1557,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xa11y"
-version = "0.6.2"
+version = "0.7.1"
 dependencies = [
  "serde_json",
  "xa11y-core",
@@ -1496,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-core"
-version = "0.6.2"
+version = "0.7.1"
 dependencies = [
  "png",
  "serde",
@@ -1507,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-js"
-version = "0.6.2"
+version = "0.7.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -1518,19 +1590,21 @@ dependencies = [
 
 [[package]]
 name = "xa11y-linux"
-version = "0.6.2"
+version = "0.7.1"
 dependencies = [
+ "evdev",
  "png",
  "rayon",
  "serde_json",
  "x11rb",
  "xa11y-core",
+ "xkbcommon",
  "zbus",
 ]
 
 [[package]]
 name = "xa11y-macos"
-version = "0.6.2"
+version = "0.7.1"
 dependencies = [
  "cc",
  "core-foundation",
@@ -1541,13 +1615,30 @@ dependencies = [
 
 [[package]]
 name = "xa11y-windows"
-version = "0.6.2"
+version = "0.7.1"
 dependencies = [
  "serde_json",
  "windows",
  "windows-core",
  "xa11y-core",
 ]
+
+[[package]]
+name = "xkbcommon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a974f48060a14e95705c01f24ad9c3345022f4d97441b8a36beb7ed5c4a02d"
+dependencies = [
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "zbus"

--- a/xa11y-js/__test__/unit/element-actions.test.js
+++ b/xa11y-js/__test__/unit/element-actions.test.js
@@ -1,0 +1,142 @@
+// Element action invocation — verifies snapshot Element methods delegate to
+// the stored provider and ElementData without going back through Locator.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { _makeTestActionProbe } = require('../../index.js');
+
+async function elementFor(probe, selector) {
+  return await probe.locator().descendant(selector).element();
+}
+
+async function assertElementAction({ selector, invoke, expected }) {
+  const probe = _makeTestActionProbe();
+  const el = await elementFor(probe, selector);
+
+  await invoke(el);
+
+  assert.deepEqual(probe.actions(), [expected]);
+}
+
+test('Element.press() delegates to provider press', async () => {
+  await assertElementAction({
+    selector: 'button[name="Back"]',
+    invoke: (el) => el.press(),
+    expected: [3, 'press', null],
+  });
+});
+
+test('Element.focus() delegates to provider focus', async () => {
+  await assertElementAction({
+    selector: 'button[name="Back"]',
+    invoke: (el) => el.focus(),
+    expected: [3, 'focus', null],
+  });
+});
+
+test('Element.toggle() delegates to provider toggle', async () => {
+  await assertElementAction({
+    selector: 'check_box[name="Agree"]',
+    invoke: (el) => el.toggle(),
+    expected: [7, 'toggle', null],
+  });
+});
+
+test('Element.expand() delegates to provider expand', async () => {
+  await assertElementAction({
+    selector: 'list[name="Items"]',
+    invoke: (el) => el.expand(),
+    expected: [10, 'expand', null],
+  });
+});
+
+test('Element.collapse() delegates to provider collapse', async () => {
+  await assertElementAction({
+    selector: 'list[name="Items"]',
+    invoke: (el) => el.collapse(),
+    expected: [10, 'collapse', null],
+  });
+});
+
+test('Element.select() delegates to provider select', async () => {
+  await assertElementAction({
+    selector: 'list_item[name="Item 1"]',
+    invoke: (el) => el.select(),
+    expected: [11, 'select', null],
+  });
+});
+
+test('Element.showMenu() delegates to provider show_menu', async () => {
+  await assertElementAction({
+    selector: 'button[name="Back"]',
+    invoke: (el) => el.showMenu(),
+    expected: [3, 'show_menu', null],
+  });
+});
+
+test('Element.scrollIntoView() delegates to provider scroll_into_view', async () => {
+  await assertElementAction({
+    selector: 'button[name="Back"]',
+    invoke: (el) => el.scrollIntoView(),
+    expected: [3, 'scroll_into_view', null],
+  });
+});
+
+test('Element.increment() delegates to provider increment', async () => {
+  await assertElementAction({
+    selector: 'slider[name="Volume"]',
+    invoke: (el) => el.increment(),
+    expected: [8, 'increment', null],
+  });
+});
+
+test('Element.decrement() delegates to provider decrement', async () => {
+  await assertElementAction({
+    selector: 'slider[name="Volume"]',
+    invoke: (el) => el.decrement(),
+    expected: [8, 'decrement', null],
+  });
+});
+
+test('Element.setValue() delegates value payload', async () => {
+  await assertElementAction({
+    selector: 'text_field[name="Search"]',
+    invoke: (el) => el.setValue('world'),
+    expected: [6, 'set_value', 'world'],
+  });
+});
+
+test('Element.setNumericValue() delegates numeric payload', async () => {
+  await assertElementAction({
+    selector: 'slider[name="Volume"]',
+    invoke: (el) => el.setNumericValue(42),
+    expected: [8, 'set_numeric_value', '42'],
+  });
+});
+
+test('Element.typeText() delegates text payload', async () => {
+  await assertElementAction({
+    selector: 'text_field[name="Search"]',
+    invoke: (el) => el.typeText('abc'),
+    expected: [6, 'type_text', 'abc'],
+  });
+});
+
+test('Element.selectText() delegates text range payload', async () => {
+  await assertElementAction({
+    selector: 'text_field[name="Search"]',
+    invoke: (el) => el.selectText(1, 3),
+    expected: [6, 'set_text_selection', '1..3'],
+  });
+});
+
+test('Element.performAction() delegates arbitrary action names', async () => {
+  await assertElementAction({
+    selector: 'button[name="Back"]',
+    invoke: (el) => el.performAction('raise'),
+    expected: [3, 'raise', null],
+  });
+});

--- a/xa11y-js/index.d.ts
+++ b/xa11y-js/index.d.ts
@@ -30,6 +30,7 @@ export {
   inputSim,
   locator,
   _makeTestLocator,
+  _makeTestActionProbe,
 } from './native.js';
 
 // Forward the narrowed types from native.d.ts.

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -507,6 +507,7 @@ module.exports = {
 
   // @internal -- used by unit tests
   _makeTestLocator: native._makeTestLocator,
+  _makeTestActionProbe: native._makeTestActionProbe,
   _makeDisconnectedSubscription: native._makeDisconnectedSubscription,
   _Subscription: Subscription,
 };

--- a/xa11y-js/src/element.rs
+++ b/xa11y-js/src/element.rs
@@ -91,7 +91,7 @@ impl Element {
     }
 
     /// Names of actions the element advertises (e.g. `["press", "focus"]`).
-    /// Use `Locator.performAction(name)` to invoke a custom action, or the
+    /// Use `Element.performAction(name)` to invoke a custom action, or the
     /// named convenience methods (`press`, `toggle`, etc.) for the common
     /// ones.
     #[napi(getter)]
@@ -228,9 +228,326 @@ impl Element {
             provider: self.provider.clone(),
         })
     }
+
+    // ── Actions ────────────────────────────────────────────────────────
+
+    /// Click / invoke this element via the accessibility action layer.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn press(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::Press,
+        ))
+    }
+
+    /// Move keyboard focus to this element.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn focus(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::Focus,
+        ))
+    }
+
+    /// Toggle a two- or three-state control.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn toggle(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::Toggle,
+        ))
+    }
+
+    /// Expand a disclosure, menu, or tree item.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn expand(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::Expand,
+        ))
+    }
+
+    /// Collapse a disclosure, menu, or tree item.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn collapse(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::Collapse,
+        ))
+    }
+
+    /// Select this element (list item, tab, row).
+    #[napi(js_name = "select", ts_return_type = "Promise<void>")]
+    pub fn select_(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::Select,
+        ))
+    }
+
+    /// Open this element's context menu.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn show_menu(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::ShowMenu,
+        ))
+    }
+
+    /// Scroll this element into the visible area.
+    ///
+    /// No-op on macOS — the macOS accessibility API has no equivalent. Uses
+    /// `Component.ScrollTo` on Linux and `ScrollItemPattern` on Windows.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn scroll_into_view(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::ScrollIntoView,
+        ))
+    }
+
+    /// Increment a numeric value (slider, spin button) by its platform step.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn increment(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::Increment,
+        ))
+    }
+
+    /// Decrement a numeric value (slider, spin button) by its platform step.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn decrement(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::Decrement,
+        ))
+    }
+
+    /// Set the text value of this element. Replaces the entire value rather
+    /// than inserting at the caret — use `typeText` for insertion.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn set_value(&self, value: String) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_text(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::SetValue,
+            value,
+        ))
+    }
+
+    /// Set the numeric value of this element (slider, spin button).
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn set_numeric_value(&self, value: f64) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_num(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::SetNumericValue,
+            value,
+        ))
+    }
+
+    /// Type `text` at the current caret position.
+    ///
+    /// Uses the platform accessibility API — never simulates keyboard events.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn type_text(&self, text: String) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_text(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::TypeText,
+            text,
+        ))
+    }
+
+    /// Select the text range from `start` to `end` (0-based character offsets).
+    /// Rejects with `InvalidActionDataError` if `start > end`.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn select_text(&self, start: u32, end: u32) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_range(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::SelectText,
+            start,
+            end,
+        ))
+    }
+
+    /// Perform a custom action by its snake_case name.
+    ///
+    /// Use this for actions the element advertises in its `actions` list
+    /// that don't have a dedicated method. Rejects with
+    /// `ActionNotSupportedError` if the element does not advertise `action`.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn perform_action(&self, action: String) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_text(
+            self.provider.clone(),
+            self.data.clone(),
+            ElementActionKind::PerformAction,
+            action,
+        ))
+    }
 }
 
 // ── Task implementations ────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+pub enum ElementActionKind {
+    Press,
+    Focus,
+    Toggle,
+    Expand,
+    Collapse,
+    Select,
+    ShowMenu,
+    ScrollIntoView,
+    Increment,
+    Decrement,
+    SetValue,
+    SetNumericValue,
+    TypeText,
+    SelectText,
+    PerformAction,
+}
+
+pub struct ElementActionTask {
+    provider: Arc<dyn xa11y::Provider>,
+    data: xa11y::ElementData,
+    kind: ElementActionKind,
+    text: Option<String>,
+    num: Option<f64>,
+    range: Option<(u32, u32)>,
+}
+
+impl ElementActionTask {
+    fn nullary(
+        provider: Arc<dyn xa11y::Provider>,
+        data: xa11y::ElementData,
+        kind: ElementActionKind,
+    ) -> Self {
+        Self {
+            provider,
+            data,
+            kind,
+            text: None,
+            num: None,
+            range: None,
+        }
+    }
+
+    fn with_text(
+        provider: Arc<dyn xa11y::Provider>,
+        data: xa11y::ElementData,
+        kind: ElementActionKind,
+        text: String,
+    ) -> Self {
+        Self {
+            provider,
+            data,
+            kind,
+            text: Some(text),
+            num: None,
+            range: None,
+        }
+    }
+
+    fn with_num(
+        provider: Arc<dyn xa11y::Provider>,
+        data: xa11y::ElementData,
+        kind: ElementActionKind,
+        num: f64,
+    ) -> Self {
+        Self {
+            provider,
+            data,
+            kind,
+            text: None,
+            num: Some(num),
+            range: None,
+        }
+    }
+
+    fn with_range(
+        provider: Arc<dyn xa11y::Provider>,
+        data: xa11y::ElementData,
+        kind: ElementActionKind,
+        start: u32,
+        end: u32,
+    ) -> Self {
+        Self {
+            provider,
+            data,
+            kind,
+            text: None,
+            num: None,
+            range: Some((start, end)),
+        }
+    }
+}
+
+impl Task for ElementActionTask {
+    type Output = ();
+    type JsValue = ();
+
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        let r = match self.kind {
+            ElementActionKind::Press => self.provider.press(&self.data),
+            ElementActionKind::Focus => self.provider.focus(&self.data),
+            ElementActionKind::Toggle => self.provider.toggle(&self.data),
+            ElementActionKind::Expand => self.provider.expand(&self.data),
+            ElementActionKind::Collapse => self.provider.collapse(&self.data),
+            ElementActionKind::Select => self.provider.select(&self.data),
+            ElementActionKind::ShowMenu => self.provider.show_menu(&self.data),
+            ElementActionKind::ScrollIntoView => self.provider.scroll_into_view(&self.data),
+            ElementActionKind::Increment => self.provider.increment(&self.data),
+            ElementActionKind::Decrement => self.provider.decrement(&self.data),
+            ElementActionKind::SetValue => self
+                .provider
+                .set_value(&self.data, self.text.as_deref().unwrap_or("")),
+            ElementActionKind::SetNumericValue => {
+                let value = self.num.unwrap_or(0.0);
+                if !value.is_finite() {
+                    return Err(map_err(xa11y::Error::InvalidActionData {
+                        message: format!("set_numeric_value requires a finite value, got {value}"),
+                    }));
+                }
+                self.provider.set_numeric_value(&self.data, value)
+            }
+            ElementActionKind::TypeText => self
+                .provider
+                .type_text(&self.data, self.text.as_deref().unwrap_or("")),
+            ElementActionKind::SelectText => {
+                let (start, end) = self.range.unwrap_or((0, 0));
+                if start > end {
+                    return Err(map_err(xa11y::Error::InvalidActionData {
+                        message: format!(
+                            "select_text start ({start}) must be <= end ({end})"
+                        ),
+                    }));
+                }
+                self.provider.set_text_selection(&self.data, start, end)
+            }
+            ElementActionKind::PerformAction => self
+                .provider
+                .perform_action(&self.data, self.text.as_deref().unwrap_or("")),
+        };
+        r.map_err(map_err)
+    }
+
+    fn resolve(&mut self, _env: Env, _output: Self::Output) -> napi::Result<Self::JsValue> {
+        Ok(())
+    }
+}
 
 pub struct ChildrenTask {
     data: xa11y::ElementData,

--- a/xa11y-js/src/mock.rs
+++ b/xa11y-js/src/mock.rs
@@ -9,6 +9,41 @@ use std::sync::Arc;
 use crate::locator::Locator;
 use crate::subscription::NativeSubscription;
 
+#[napi]
+pub struct TestActionProbe {
+    provider: Arc<xa11y::mock::MockProvider>,
+}
+
+#[napi]
+impl TestActionProbe {
+    #[napi]
+    pub fn locator(&self) -> Locator {
+        Locator::from_inner(xa11y::Locator::new(
+            self.provider.clone() as Arc<dyn xa11y::Provider>,
+            None,
+            "application",
+        ))
+    }
+
+    #[napi(ts_return_type = "Array<[number, string, string | null]>")]
+    pub fn actions(&self) -> serde_json::Value {
+        serde_json::Value::Array(
+            self.provider
+                .actions()
+                .into_iter()
+                .map(|(handle, action, data)| {
+                    serde_json::json!([handle, action, data])
+                })
+                .collect(),
+        )
+    }
+
+    #[napi]
+    pub fn clear_actions(&self) {
+        self.provider.clear_actions();
+    }
+}
+
 /// Create a mock `Locator` rooted at the shared synthetic tree. Used only
 /// from the JS unit tests — not part of the public API.
 #[napi(js_name = "_makeTestLocator")]
@@ -23,6 +58,19 @@ pub fn make_test_locator() -> Locator {
         None,
         "application",
     ))
+}
+
+/// Create a mock provider probe with a locator and inspectable action log.
+/// Used only from the JS unit tests — not part of the public API.
+#[napi(js_name = "_makeTestActionProbe")]
+#[allow(
+    dead_code,
+    reason = "Exported via napi-derive for JS unit tests; the lib-test clippy build doesn't see the JS-side consumer"
+)]
+pub fn make_test_action_probe() -> TestActionProbe {
+    TestActionProbe {
+        provider: xa11y::mock::build_provider(),
+    }
 }
 
 /// Create a `_NativeSubscription` whose backing channel has already been

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -77,6 +77,7 @@ extern "C" {
         value: CFTypeRef,
     ) -> i32;
     fn safe_ax_create_application(pid: i32) -> AXUIElementRef;
+    fn safe_ax_set_messaging_timeout(element: AXUIElementRef, timeout_seconds: f32) -> i32;
     fn safe_ax_value_get_value(value: CFTypeRef, the_type: i32, value_ptr: *mut c_void) -> bool;
     fn safe_cg_window_list_copy(option: u32, relative_to: u32) -> CFArrayRef;
     fn safe_ax_observer_create(
@@ -158,6 +159,29 @@ impl Drop for AXElement {
             unsafe { safe_cf_release(self.0) };
         }
     }
+}
+
+/// Per-AX-element messaging timeout, in seconds. AX calls into an
+/// unresponsive target process block indefinitely by default, which wedges
+/// any global tree walk if a single pid is in a bad state (sandboxed,
+/// AX-API-disabled, hung). Apple exposes `AXUIElementSetMessagingTimeout`
+/// for exactly this case; we set it on every app element we create.
+///
+/// 0.5s is short enough that a global walk over ~30 apps with a couple
+/// of bad apples still completes in a few seconds, but generous enough
+/// that a healthy-but-slow app (large tree, busy main thread) still
+/// answers within one round-trip. Apple's default is 6 seconds, which is
+/// far too long for our use.
+const APP_MESSAGING_TIMEOUT_SECS: f32 = 0.5;
+
+/// Wrap `AXUIElementCreateApplication` and immediately apply the messaging
+/// timeout. Returns a null-checked `AXElement` ready for use.
+fn create_app_element(pid: i32) -> AXElement {
+    let ptr = unsafe { safe_ax_create_application(pid) };
+    if !ptr.is_null() {
+        unsafe { safe_ax_set_messaging_timeout(ptr, APP_MESSAGING_TIMEOUT_SECS) };
+    }
+    AXElement::from_owned(ptr)
 }
 
 // ── AX Call Counters (test-only) ──────────────────────────────────────────────
@@ -1727,20 +1751,25 @@ impl Provider for MacOSProvider {
     fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
         match element {
             None => {
-                // Top-level: list all GUI apps as application elements
+                // Top-level: list all GUI apps as application elements.
+                // Parallelised because each `build_element_data` is an AX
+                // round-trip whose worst-case is `APP_MESSAGING_TIMEOUT_SECS`
+                // when a target app's main thread is unresponsive — without
+                // rayon, one bad apple serialises the whole list.
                 let apps = Self::list_gui_apps();
-                let mut results = Vec::new();
-                for (pid, app_name) in &apps {
-                    let app_element =
-                        AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
-                    if app_element.is_null() {
-                        continue;
-                    }
-                    let mut data = self.build_element_data(&app_element, Some(*pid as u32));
-                    // Override name with the CGWindowList name (more reliable)
-                    data.name = Some(app_name.clone());
-                    results.push(data);
-                }
+                let results: Vec<ElementData> = apps
+                    .par_iter()
+                    .filter_map(|(pid, app_name)| {
+                        let app_element = create_app_element(*pid);
+                        if app_element.is_null() {
+                            return None;
+                        }
+                        let mut data = self.build_element_data(&app_element, Some(*pid as u32));
+                        // CGWindowList name is more reliable than AX's.
+                        data.name = Some(app_name.clone());
+                        Some(data)
+                    })
+                    .collect();
                 Ok(results)
             }
             Some(element_data) => {
@@ -1808,33 +1837,39 @@ impl Provider for MacOSProvider {
                     ))
                 ) {
                     let apps = Self::list_gui_apps();
-                    let mut matching: Vec<ElementData> = Vec::new();
-                    for (pid, app_name) in &apps {
-                        // Check name filters against CGWindowList name
-                        let name_matches = first.filters.iter().all(|f| {
-                            if f.attr != "name" {
-                                return true; // non-name filters checked after build
+                    // Parallelise the per-pid AX build. Each `build_element_data`
+                    // is an AX round-trip capped at `APP_MESSAGING_TIMEOUT_SECS`
+                    // on an unresponsive target, so a serial walk pays the
+                    // worst-case timeout for every wedged app. We drop the
+                    // early-break optimisation `phase1_limit` provided and
+                    // truncate after — the build itself is the only expensive
+                    // step, so the savings would be marginal compared to the
+                    // parallelism win.
+                    let mut matching: Vec<ElementData> = apps
+                        .par_iter()
+                        .filter_map(|(pid, app_name)| {
+                            // Check name filters against CGWindowList name
+                            let name_matches = first.filters.iter().all(|f| {
+                                if f.attr != "name" {
+                                    return true; // non-name filters checked after build
+                                }
+                                match_op(&f.op, &f.value, Some(app_name.as_str()))
+                            });
+                            if !name_matches {
+                                return None;
                             }
-                            match_op(&f.op, &f.value, Some(app_name.as_str()))
-                        });
-                        if !name_matches {
-                            continue;
-                        }
 
-                        let app_element =
-                            AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
-                        if app_element.is_null() {
-                            continue;
-                        }
-                        let mut data = self.build_element_data(&app_element, Some(*pid as u32));
-                        data.name = Some(app_name.clone());
-                        matching.push(data);
-
-                        if let Some(limit) = phase1_limit {
-                            if matching.len() >= limit {
-                                break;
+                            let app_element = create_app_element(*pid);
+                            if app_element.is_null() {
+                                return None;
                             }
-                        }
+                            let mut data = self.build_element_data(&app_element, Some(*pid as u32));
+                            data.name = Some(app_name.clone());
+                            Some(data)
+                        })
+                        .collect();
+                    if let Some(limit) = phase1_limit {
+                        matching.truncate(limit);
                     }
 
                     // Apply :nth
@@ -2301,6 +2336,9 @@ impl MacOSProvider {
                 selector: format!("application with pid:{}", pid),
             });
         }
+        // Cap how long any AX call against this app blocks. See
+        // `APP_MESSAGING_TIMEOUT_SECS` for rationale.
+        unsafe { safe_ax_set_messaging_timeout(app_element, APP_MESSAGING_TIMEOUT_SECS) };
 
         let notifications = [
             "AXFocusedUIElementChanged",

--- a/xa11y-macos/src/exception_safe.m
+++ b/xa11y-macos/src/exception_safe.m
@@ -119,6 +119,20 @@ AXUIElementRef safe_ax_create_application(int pid) {
     }
 }
 
+// Safe wrapper for AXUIElementSetMessagingTimeout.
+// Caps how long any AX call against `element` may block before returning
+// kAXErrorCannotComplete (-25204). Without a cap, AX calls into an
+// unresponsive target process block indefinitely — breaks `App.list()` and
+// any global tree walk if a single pid is wedged.
+// Returns the AX error code, or -9999 if an ObjC exception was thrown.
+int safe_ax_set_messaging_timeout(AXUIElementRef element, float timeout_seconds) {
+    @try {
+        return AXUIElementSetMessagingTimeout(element, timeout_seconds);
+    } @catch (NSException *e) {
+        return -9999;
+    }
+}
+
 // ── AXValue Extraction ──────────────────────────────────────────────────────
 
 // Safe wrapper for AXValueGetValue.


### PR DESCRIPTION
## Summary\n- Add async action methods directly on JS Element snapshots, delegating to the stored Provider and ElementData.\n- Add a test-only action probe and unit coverage for every new Element action method.\n- Rebuilt xa11y-js native artifacts locally to verify generated Element typings include the new methods.\n\n## Tests\n- cargo build --workspace\n- cargo test --all\n- cd xa11y-js && pnpm build\n- cd xa11y-js && pnpm test\n- cd xa11y-js && node -e smoke check for Element press/setValue/performAction methods\n\nNote: cargo xtask fmt could not run in this environment because rustfmt and ruff are not installed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
