### PR TITLE
Add AT-SPI state selector fast-path coverage

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -9,6 +9,8 @@ Snapshot after PR #129. Resolved items are in `git log main`. This is the live l
 ### Linux: fast-path selector matcher gap
 `xa11y-linux/src/atspi.rs::matches_ref` only answers `role` / `name` / `value` / `description`. Selectors like `[enabled="true"]`, `[checked="on"]`, `[focused="true"]` silently return empty on Linux because the fast path filters elements out before a full `ElementData` is built. The delegation fix landed in PR #129 and was reverted as a side effect of the GTK debugging — see #132 for the related Linux refactor puzzle. Needs a proper fix: either extend `matches_ref` to answer state attrs directly from AT-SPI state flags, or re-land the fallthrough-to-full-build approach once the GTK issue is understood.
 
+**A1 update:** `matches_ref` now resolves normalized state attributes from AT-SPI `GetState` bits through the same `StateSet` formatting used by the slow selector path, so Linux fast-path selectors for `enabled`, `checked`, and `focused` no longer drop candidates before `ElementData` is built. Added Linux-only AT-SPI Python coverage in `tests/suites/python/atspi/` for `[enabled="true"]`, `[enabled="false"]`, `[checked="on"]`, and `[focused="true"]`. This does not change the unresolved `StaticProviderRef` delegation work tracked in #132.
+
 ---
 
 ## Umbrella crate

--- a/tests/suites/python/atspi/test_state_selectors.py
+++ b/tests/suites/python/atspi/test_state_selectors.py
@@ -1,0 +1,70 @@
+"""AT-SPI selector tests for state attributes handled by the Linux fast path."""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import pytest
+import xa11y
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="AT-SPI state selector tests run only on Linux",
+)
+
+
+def test_atspi_selector_enabled_true_matches_enabled_button(app, app_config):
+    """[enabled="true"] is matched from AT-SPI state flags."""
+    ok_name = app_config["ok_button_name"]
+
+    matches = app.locator(f'button[name="{ok_name}"][enabled="true"]').elements()
+
+    assert matches, "expected OK button to match enabled='true'"
+    assert all(element.enabled is True for element in matches)
+
+
+def test_atspi_selector_enabled_false_matches_disabled_button(app, app_config):
+    """[enabled="false"] is matched from AT-SPI state flags."""
+    cancel_name = app_config["cancel_button_name"]
+
+    matches = app.locator(f'button[name="{cancel_name}"][enabled="false"]').elements()
+
+    assert matches, "expected Cancel button to match enabled='false'"
+    assert all(element.enabled is False for element in matches)
+
+
+def test_atspi_selector_checked_on_matches_checked_widget(app, app_config):
+    """[checked="on"] is matched from AT-SPI state flags."""
+    checked_name = app_config.get("checkbox_checked_name")
+    if checked_name:
+        selector = f'check_box[name="{checked_name}"][checked="on"]'
+    elif app_config.get("has_radio") and app_config.get("radio_a_name"):
+        role = app_config["radio_role"]
+        radio_name = app_config["radio_a_name"]
+        selector = f'{role}[name="{radio_name}"][checked="on"]'
+    else:
+        pytest.skip("app has no initially checked widget")
+
+    matches = app.locator(selector).elements()
+
+    assert matches, f"expected {selector} to match"
+    assert all(element.checked == "on" for element in matches)
+
+
+def test_atspi_selector_focused_true_matches_after_focus(app, app_config):
+    """[focused="true"] is matched from AT-SPI state flags."""
+    ok_name = app_config["ok_button_name"]
+    ok = app.locator(f'button[name="{ok_name}"]')
+
+    try:
+        ok.focus()
+    except xa11y.ActionNotSupportedError:
+        pytest.xfail("focus() is not exposed by this AT-SPI bridge for buttons")
+    time.sleep(0.3)
+
+    matches = app.locator(f'button[name="{ok_name}"][focused="true"]').elements()
+
+    assert matches, "expected focused OK button to match focused='true'"
+    assert all(element.focused is True for element in matches)


### PR DESCRIPTION
## Summary
- add Linux-only AT-SPI Python coverage for state selector fast-path attributes
- cover enabled=true, enabled=false, checked=on, and focused=true selectors
- document the A1 Linux fast-path state matcher fix in REVIEW.md while leaving StaticProviderRef untouched

## Validation
- cargo test --all
- cargo clippy --all -- -D warnings
- pytest tests/suites/python/atspi/ -v --rootdir="$PWD" (collected 4, skipped on Darwin because AT-SPI tests are Linux-only)
- cd xa11y-js && pnpm install && pnpm build

Note: the repository remote has main, not master, so this PR targets main.

Made with [Orca](https://github.com/stablyai/orca) 🐋
