### PR TITLE
feat(element): expose action methods on Element for snapshot-bound invocation

### DIFF
--- a/docs/site/src/content/docs/guides/design.mdx
+++ b/docs/site/src/content/docs/guides/design.mdx
@@ -18,6 +18,8 @@ xa11y is a Rust workspace organised into a platform-independent core, three plat
 
 The public surface — `App`, `Element`, `Locator`, `Subscription`, `Selector` — is platform-agnostic. Each backend implements a small set of provider traits, and `xa11y-core` is responsible for everything that *can* be cross-platform: the selector parser, the locator engine, retry/wait loops, error mapping, and screenshot encoding.
 
+Actions (`press`, `set_value`, `type_text`, …) are exposed on both `Locator` and `Element`. `Locator` is the auto-waiting wrapper: it re-resolves its selector and waits for visible+enabled before dispatching. `Element` calls go straight through to the provider handle captured at fetch time — no re-resolution, no wait — and surface `ElementStale` if the handle is gone. Both shapes share a single underlying provider call, so action fidelity (tenet 3) is enforced in one place.
+
 ## Design tenets
 
 These four tenets are the firm defaults for every new piece of provider or binding code. They are restated verbatim in `CLAUDE.md` so reviewers and AI agents apply them consistently.

--- a/docs/site/src/content/docs/guides/overview.mdx
+++ b/docs/site/src/content/docs/guides/overview.mdx
@@ -76,8 +76,8 @@ xa11y supports subscribing to these event streams per-app via `app.subscribe()`.
 xa11y is built around three core types:
 
 - **App** — entry point for interacting with an application. Construct via `App::by_name()`, `App::by_pid()`, or `App::list()`. An App provides three paths: `app.children()` for navigating the tree, `app.locator(selector)` for actions and waits, and `app.subscribe()` for event streams.
-- **Element** — a live handle to a node in the accessibility tree. Navigate with `children()` and `parent()` — each call queries the platform lazily. Read properties like `role`, `name`, `value`, `states`, `bounds`. Capture the subtree as a structured snapshot with `tree(max_depth)` or as an indented string with `dump(max_depth)`.
-- **Locator** — a lazy selector that re-resolves on every operation. Use for actions (`press()`, `set_value()`, and others), waits (`wait_visible()`, and others), and querying (`element()`, `elements()`). Inspired by [Playwright's Locator pattern](https://playwright.dev/docs/locators).
+- **Element** — a live handle to a node in the accessibility tree. Navigate with `children()` and `parent()` — each call queries the platform lazily. Read properties like `role`, `name`, `value`, `states`, `bounds`. Capture the subtree as a structured snapshot with `tree(max_depth)` or as an indented string with `dump(max_depth)`. Actions (`press()`, `set_value()`, etc.) are available too, acting on the captured handle without re-resolution or auto-wait.
+- **Locator** — a lazy selector that re-resolves on every operation. Use for actions (`press()`, `set_value()`, and others), waits (`wait_visible()`, and others), and querying (`element()`, `elements()`). Auto-waits for visible+enabled before acting and is the recommended path for most code. Inspired by [Playwright's Locator pattern](https://playwright.dev/docs/locators).
 - **Subscription** — live event stream from an app. Created via `app.subscribe()`. Pull events with `try_recv()`, `recv(timeout)`, `wait_for(predicate, timeout)`, or iterate with `iter()`. Drop to unsubscribe.
 - **Selector** — CSS-like query syntax used by Locator. Supports role matching, attribute filters, combinators, and nth selection.
 
@@ -336,6 +336,53 @@ A `Locator` holds a selector and **re-resolves on every operation**. Create one 
 **Chaining:** `nth(n)`, `first()`, `child(selector)`, `descendant(selector)`.
 
 Locator re-resolves its selector on every operation, making it resilient to UI changes between calls. To inspect element properties or traverse the subtree, call `.element()` first — `tree()` and `dump()` live on `Element`, not `Locator`.
+
+### Element actions
+
+The same action verbs are also available directly on `Element`. A `Locator` re-resolves its selector and auto-waits for the element to be visible and enabled before acting; an `Element` acts on the snapshot you already captured, with no re-resolution and no auto-wait. If the underlying element has been destroyed since you fetched it, the call returns an `ElementStale` error.
+
+Reach for `Element` actions when you've already inspected an element — typically after `.dump()` or reading `.actions` — and want to act on that same instance. For everything else, use a `Locator`: it stays correct across UI changes and is the path most code should take.
+
+<Tabs syncKey="lang">
+  <TabItem label="Rust">
+    ```rust
+    // Locator: re-resolves and auto-waits — robust for changing UIs.
+    calc.locator("button[name='Save']").press()?;
+
+    // Element: acts on the captured snapshot — useful when you've already
+    // inspected the element and want to act on the same instance.
+    let btn = calc.locator("button[name='Save']").element()?;
+    println!("{:?}", btn.actions);  // ["press", "focus"]
+    btn.press()?;
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    # Locator: re-resolves and auto-waits — robust for changing UIs.
+    calc.locator("button[name='Save']").press()
+
+    # Element: acts on the captured snapshot — useful when you've already
+    # inspected the element and want to act on the same instance.
+    btn = calc.locator("button[name='Save']").element()
+    print(btn.actions)  # ["press", "focus"]
+    btn.press()
+    ```
+  </TabItem>
+  <TabItem label="JavaScript">
+    ```js
+    // Locator: re-resolves and auto-waits — robust for changing UIs.
+    await calc.locator("button[name='Save']").press();
+
+    // Element: acts on the captured snapshot — useful when you've already
+    // inspected the element and want to act on the same instance.
+    const btn = await calc.locator("button[name='Save']").element();
+    console.log(btn.actions);  // ["press", "focus"]
+    await btn.press();
+    ```
+  </TabItem>
+</Tabs>
+
+**Recommended path: Locator.** Auto-wait and selector re-resolution make Locator resilient to tree changes between operations. Use `Element` actions only when you already hold the element and want to act on that exact instance.
 
 ## Selectors
 

--- a/tests/suites/js/02_actions.test.js
+++ b/tests/suites/js/02_actions.test.js
@@ -144,3 +144,149 @@ test('act() helper re-reads the tree after an action', async () => {
   const updated = await act(addBtn, 'press');
   assert.ok(updated);
 });
+
+// ---------------------------------------------------------------------------
+// Element-bound action variants.
+//
+// These mirror the Locator-bound tests above but invoke the action against a
+// captured Element snapshot (`await locator.element()`) instead of going
+// through the auto-resolving Locator. The provider call underneath is the
+// same, so results should match — what's exercised here is the binding.
+// ---------------------------------------------------------------------------
+
+test('press on primary button via Element', async () => {
+  if (!appConfig.okButtonName) return;
+  const app = await getApp();
+  const el = await app.locator(`button[name="${appConfig.okButtonName}"]`).element();
+  await el.press();
+});
+
+test('Element.press() flips checkbox checked state', async () => {
+  if (!appConfig.hasCheckbox) return;
+  const selector = 'check_box[name="Agree to terms"]';
+  let app = await getApp();
+  const el = await app.locator(selector).element().catch(() => null);
+  if (!el) return; // schema mismatch — skip
+  const before = el.checked;
+  assert.ok(['on', 'off'].includes(before));
+
+  try {
+    await el.press();
+  } catch (err) {
+    if (err instanceof ActionNotSupportedError) return;
+    throw err;
+  }
+  await sleep(200);
+
+  app = await getApp();
+  const afterEls = await app.locator(selector).elements();
+  if (afterEls.length === 0) return;
+  const after = afterEls[0].checked;
+  assert.ok(['on', 'off'].includes(after));
+  assert.notEqual(before, after, 'checkbox state should have flipped');
+});
+
+test('Element.setValue on text field is exercised (AT-SPI may reject)', async () => {
+  const app = await getApp();
+  const selector = appConfig.textFieldName
+    ? `text_field[name="${appConfig.textFieldName}"]`
+    : 'text_field';
+  const fieldLocator = app.locator(selector);
+  if (!(await fieldLocator.exists())) return;
+  const el = await fieldLocator.element();
+  try {
+    await el.setValue('Jane Doe');
+    await sleep(200);
+    const refreshed = await one(await getApp(), selector);
+    assert.ok(typeof refreshed.value === 'string' || refreshed.value === null);
+  } catch (err) {
+    if (!(err instanceof ActionNotSupportedError)) throw err;
+  }
+});
+
+test('Element.focus() resolves on text field or button', async () => {
+  const app = await getApp();
+  const selector = appConfig.textFieldName
+    ? `text_field[name="${appConfig.textFieldName}"]`
+    : 'button';
+  const locator = app.locator(selector);
+  if (!(await locator.exists())) return;
+  const el = await locator.element();
+  try {
+    await el.focus();
+  } catch (err) {
+    if (err instanceof ActionNotSupportedError) return;
+    throw err;
+  }
+});
+
+test('Element.setNumericValue on slider', async () => {
+  // Sliders are exposed by the qt/cocoa/tauri/gtk/accesskit apps but not all
+  // of them name the slider consistently. Try a name-qualified selector first
+  // and fall back to a bare role selector.
+  const app = await getApp();
+  let locator = app.locator('slider[name="Volume"]');
+  if (!(await locator.exists())) {
+    locator = app.locator('slider');
+    if (!(await locator.exists())) return; // app has no slider
+  }
+  const el = await locator.element();
+  try {
+    await el.setNumericValue(77);
+  } catch (err) {
+    // Qt under AT-SPI2 and WebKit-backed sliders sometimes reject
+    // SetCurrentValue. The same path is xfailed in the python suite.
+    if (err instanceof ActionNotSupportedError) return;
+    throw err;
+  }
+  await sleep(200);
+  const refreshedEls = await app.locator('slider').elements();
+  if (refreshedEls.length === 0) return;
+  // Numeric value may not always reflect immediately on every adapter — just
+  // assert the call did not throw and the slider is still readable.
+  assert.ok(refreshedEls[0] !== undefined);
+});
+
+test('Element.performAction("press") is equivalent to press', async () => {
+  if (!appConfig.okButtonName) return;
+  const app = await getApp();
+  const el = await app.locator(`button[name="${appConfig.okButtonName}"]`).element();
+  try {
+    await el.performAction('press');
+  } catch (err) {
+    if (err instanceof ActionNotSupportedError) return;
+    throw err;
+  }
+});
+
+test('snapshot-bound Element can be pressed twice', async () => {
+  // Capture once, invoke twice. The second invocation goes against the same
+  // captured snapshot (no auto re-resolve like Locator does), so we're
+  // exercising the binding's reuse semantics, not auto-wait.
+  const app = await getApp();
+  const addBtn = app.locator('button[name="Add Item"]');
+  if (!(await addBtn.exists())) return;
+  const el = await addBtn.element();
+  const countBefore = await app.locator('[name^="Item "]').count();
+  try {
+    await el.press();
+    await sleep(200);
+    await el.press();
+  } catch (err) {
+    if (err instanceof ActionNotSupportedError) return;
+    throw err;
+  }
+  await sleep(500);
+  let app2 = await getApp();
+  let countAfter = await app2.locator('[name^="Item "]').count();
+  for (let i = 0; i < 10 && countAfter <= countBefore; i++) {
+    await sleep(200);
+    app2 = await getApp();
+    countAfter = await app2.locator('[name^="Item "]').count();
+  }
+  if (countAfter === countBefore) return; // platform/schema mismatch
+  assert.ok(
+    countAfter >= countBefore + 1,
+    `expected >= ${countBefore + 1} items after two presses, got ${countAfter}`,
+  );
+});

--- a/tests/suites/python/test_actions.py
+++ b/tests/suites/python/test_actions.py
@@ -247,3 +247,178 @@ def test_textfield_set_value(app, app_name, app_config):
     initial = app_config.get("textfield_initial_value") or "hello world"
     loc.set_value(initial)
     time.sleep(ACTION_SETTLE)
+
+
+# ---------------------------------------------------------------------------
+# Element-bound action variants
+#
+# Mirror the Locator-bound tests above but invoke the action against a
+# captured Element snapshot (``locator.element()``) rather than going through
+# the auto-resolving Locator. The provider call beneath is the same — what's
+# exercised here is the binding.
+# ---------------------------------------------------------------------------
+
+
+def test_button_press_via_element(app, app_config):
+    """Element.press() on a button does not raise."""
+    ok_name = app_config["ok_button_name"]
+    el = app.locator(f'button[name="{ok_name}"]').element()
+    el.press()
+    time.sleep(ACTION_SETTLE)
+
+
+def test_perform_action_press_via_element(app, app_config):
+    """Element.perform_action('press') is equivalent to press()."""
+    ok_name = app_config["ok_button_name"]
+    el = app.locator(f'button[name="{ok_name}"]').element()
+    el.perform_action("press")
+    time.sleep(ACTION_SETTLE)
+
+
+def test_button_focus_via_element(app, app_config):
+    """Element.focus() on a button is accepted without raising."""
+    ok_name = app_config["ok_button_name"]
+    el = app.locator(f'button[name="{ok_name}"]').element()
+    try:
+        el.focus()
+    except xa11y.ActionNotSupportedError:
+        pytest.xfail("focus() not exposed by this platform's AT bridge for buttons")
+    time.sleep(ACTION_SETTLE)
+
+
+def test_checkbox_toggle_via_element(app, app_name, app_config):
+    """Element.toggle() flips checked state on a captured snapshot."""
+    if not app_config.get("has_checkbox"):
+        pytest.skip("app has no checkbox widgets")
+    if app_name == "gtk":
+        pytest.skip(
+            "GTK4 Gtk.CheckButton does not expose AT-SPI2 Action interface "
+            "actions; toggle() requires 'toggle'/'click'/'activate'."
+        )
+    name = app_config["checkbox_unchecked_name"]
+    loc = app.locator(f'check_box[name="{name}"]')
+    el_before = loc.element()
+    before = el_before.checked
+    try:
+        el_before.toggle()
+    except xa11y.ActionNotSupportedError:
+        pytest.xfail("toggle() rejected by this platform's AT bridge for check_box")
+    time.sleep(ACTION_SETTLE)
+    after = loc.element().checked
+    assert before != after, f"toggle() did not change checked state: {before} == {after}"
+    # Restore — re-resolve a fresh snapshot for the second call.
+    loc.element().toggle()
+    time.sleep(ACTION_SETTLE)
+
+
+def test_checkbox_press_via_element(app, app_name, app_config):
+    """Element.press() on a checkbox flips checked state where supported."""
+    if not app_config.get("has_checkbox"):
+        pytest.skip("app has no checkbox widgets")
+    name = app_config["checkbox_unchecked_name"]
+    loc = app.locator(f'check_box[name="{name}"]')
+    el = loc.element()
+    before = el.checked
+    try:
+        el.press()
+    except xa11y.ActionNotSupportedError:
+        pytest.xfail("press() not exposed for check_box on this platform")
+    time.sleep(ACTION_SETTLE)
+    after = loc.element().checked
+    assert before != after, f"press() did not change checked state: {before} == {after}"
+    # Restore.
+    try:
+        loc.element().press()
+        time.sleep(ACTION_SETTLE)
+    except xa11y.ActionNotSupportedError:
+        pass
+
+
+@pytest.mark.xfail(
+    sys.platform == "linux" or (
+        sys.platform == "darwin"
+        and os.environ.get("XA11Y_TEST_APP") in ("tauri", "electron")
+    ),
+    reason=(
+        "Qt AT-SPI2 sliders: SetCurrentValue may be rejected on some Qt versions. "
+        "WebKit2GTK / WKWebView: SetCurrentValue not reliable for HTML range inputs."
+    ),
+    strict=False,
+)
+def test_slider_set_numeric_value_via_element(app, app_config):
+    """Element.set_numeric_value() writes a value to a slider snapshot."""
+    sel = app_config.get("slider_selector")
+    if not sel:
+        pytest.skip("app has no slider widget")
+    loc = app.locator(sel)
+    loc.element().set_numeric_value(77.0)
+    time.sleep(ACTION_SETTLE)
+    after = loc.element().numeric_value
+    assert after is not None
+    assert abs(after - 77.0) < 1.0, f"expected ~77.0, got {after}"
+    # Restore.
+    loc.element().set_numeric_value(50.0)
+    time.sleep(ACTION_SETTLE)
+
+
+def test_slider_increment_via_element(app, app_config):
+    """Element.increment() raises numeric_value on a slider snapshot."""
+    sel = app_config.get("slider_selector")
+    if not sel:
+        pytest.skip("app has no slider widget")
+    loc = app.locator(sel)
+    el = loc.element()
+    before = el.numeric_value
+    try:
+        el.increment()
+    except xa11y.ActionNotSupportedError:
+        pytest.xfail("increment() not exposed for slider on this platform")
+    time.sleep(ACTION_SETTLE)
+    after = loc.element().numeric_value
+    assert before is not None and after is not None
+    assert after != before, "increment() did not change the slider value"
+
+
+def test_textfield_set_value_via_element(app, app_name, app_config):
+    """Element.set_value() writes text to a text_field snapshot."""
+    sel = app_config.get("textfield_selector")
+    if not sel:
+        pytest.skip("app has no text_field widget")
+    if app_name in ("tauri", "electron"):
+        pytest.skip(
+            f"WebKit2GTK / Chromium ({app_name}) expose HTML <input> through "
+            "AT-SPI2 without a functional EditableText interface."
+        )
+    loc = app.locator(sel)
+    try:
+        loc.element().set_value("test input")
+    except xa11y.ActionNotSupportedError:
+        pytest.xfail("set_value() not exposed for text_field on this platform")
+    time.sleep(ACTION_SETTLE)
+    assert loc.element().value == "test input"
+    # Restore.
+    initial = app_config.get("textfield_initial_value") or "hello world"
+    loc.element().set_value(initial)
+    time.sleep(ACTION_SETTLE)
+
+
+def test_snapshot_bound_element_press_twice(app, app_config):
+    """A captured Element can be pressed multiple times against the snapshot.
+
+    Locators auto-re-resolve before each action; Elements act on the captured
+    node id. This verifies the binding accepts repeat invocation.
+    """
+    add_name = app_config.get("add_item_button_name")
+    if not add_name:
+        pytest.skip("app has no Add Item button")
+    add_btn = app.locator(f'button[name="{add_name}"]')
+    if not add_btn.exists():
+        pytest.skip("Add Item button not present in current tree")
+    el = add_btn.element()
+    try:
+        el.press()
+        time.sleep(ACTION_SETTLE)
+        el.press()
+    except xa11y.ActionNotSupportedError:
+        pytest.xfail("press() not exposed for button on this platform")
+    time.sleep(ACTION_SETTLE)

--- a/xa11y-core/src/element.rs
+++ b/xa11y-core/src/element.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::Error;
 use crate::provider::Provider;
 use crate::role::Role;
 
@@ -188,6 +189,117 @@ impl Element {
         write_tree_node(&node, 0, &mut out);
         Ok(out)
     }
+
+    // ── Actions ─────────────────────────────────────────────────────
+    //
+    // Element actions invoke the platform via the captured provider handle —
+    // they do **not** re-resolve the selector. If the underlying element has
+    // been destroyed since this snapshot was taken, the provider returns a
+    // platform-specific "gone" error. For resilient retry-on-change semantics,
+    // use the equivalent method on [`crate::Locator`] instead.
+
+    /// Click / invoke this element via the accessibility action layer.
+    pub fn press(&self) -> crate::error::Result<()> {
+        self.provider.press(&self.data)
+    }
+
+    /// Set keyboard focus to this element.
+    pub fn focus(&self) -> crate::error::Result<()> {
+        self.provider.focus(&self.data)
+    }
+
+    /// Remove keyboard focus from this element.
+    pub fn blur(&self) -> crate::error::Result<()> {
+        self.provider.blur(&self.data)
+    }
+
+    /// Toggle a two- or three-state control (checkbox, switch).
+    pub fn toggle(&self) -> crate::error::Result<()> {
+        self.provider.toggle(&self.data)
+    }
+
+    /// Select this element (list item, tab, row).
+    pub fn select(&self) -> crate::error::Result<()> {
+        self.provider.select(&self.data)
+    }
+
+    /// Expand a disclosure, menu, combo box, or tree item.
+    pub fn expand(&self) -> crate::error::Result<()> {
+        self.provider.expand(&self.data)
+    }
+
+    /// Collapse an expanded element.
+    pub fn collapse(&self) -> crate::error::Result<()> {
+        self.provider.collapse(&self.data)
+    }
+
+    /// Open this element's context menu or dropdown.
+    pub fn show_menu(&self) -> crate::error::Result<()> {
+        self.provider.show_menu(&self.data)
+    }
+
+    /// Increment a numeric control (slider, spinner) by its platform step.
+    pub fn increment(&self) -> crate::error::Result<()> {
+        self.provider.increment(&self.data)
+    }
+
+    /// Decrement a numeric control (slider, spinner) by its platform step.
+    pub fn decrement(&self) -> crate::error::Result<()> {
+        self.provider.decrement(&self.data)
+    }
+
+    /// Scroll this element into the visible area.
+    ///
+    /// No-op on macOS — the macOS accessibility API has no equivalent.
+    pub fn scroll_into_view(&self) -> crate::error::Result<()> {
+        self.provider.scroll_into_view(&self.data)
+    }
+
+    /// Set the text value of this element. Replaces the entire value rather
+    /// than inserting at the caret — use [`Element::type_text`] for insertion.
+    pub fn set_value(&self, value: &str) -> crate::error::Result<()> {
+        self.provider.set_value(&self.data, value)
+    }
+
+    /// Set the numeric value of this element (slider, spinner).
+    ///
+    /// Returns [`Error::InvalidActionData`] if `value` is NaN or infinite.
+    pub fn set_numeric_value(&self, value: f64) -> crate::error::Result<()> {
+        if !value.is_finite() {
+            return Err(Error::InvalidActionData {
+                message: format!("set_numeric_value requires a finite value, got {}", value),
+            });
+        }
+        self.provider.set_numeric_value(&self.data, value)
+    }
+
+    /// Insert text at the current cursor position.
+    ///
+    /// Uses the platform accessibility API — never simulates keyboard events.
+    pub fn type_text(&self, text: &str) -> crate::error::Result<()> {
+        self.provider.type_text(&self.data, text)
+    }
+
+    /// Select the text range from `start` to `end` (0-based character offsets).
+    ///
+    /// Returns [`Error::InvalidActionData`] if `start > end`.
+    pub fn select_text(&self, start: u32, end: u32) -> crate::error::Result<()> {
+        if start > end {
+            return Err(Error::InvalidActionData {
+                message: format!("select_text start ({}) must be <= end ({})", start, end),
+            });
+        }
+        self.provider.set_text_selection(&self.data, start, end)
+    }
+
+    /// Perform an action by its `snake_case` name.
+    ///
+    /// Use this for actions the element advertises in its [`actions`](ElementData::actions)
+    /// list that don't have a dedicated method. Well-known names (`"press"`,
+    /// `"focus"`, etc.) also work — providers delegate to the named methods.
+    pub fn perform_action(&self, action: &str) -> crate::error::Result<()> {
+        self.provider.perform_action(&self.data, action)
+    }
 }
 
 fn build_tree_node(
@@ -315,4 +427,188 @@ pub struct TreeNode {
     pub name: Option<String>,
     pub value: Option<String>,
     pub children: Vec<TreeNode>,
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for `Element` action methods. Verifies each action records the
+    //! expected entry in the mock provider's action log and that validation
+    //! errors fire before the provider is ever called.
+
+    use super::*;
+    use crate::mock::{build_provider, MockProvider};
+    use crate::selector::Selector;
+
+    /// Resolve `selector` against the mock tree and return the first match
+    /// wrapped in an `Element`. Panics on no match — these are unit tests, not
+    /// production paths.
+    fn find_element(provider: &Arc<MockProvider>, selector: &str) -> Element {
+        let parsed = Selector::parse(selector).expect("selector must parse");
+        let provider_dyn: Arc<dyn Provider> = provider.clone();
+        let mut matches = provider_dyn
+            .find_elements(None, &parsed, Some(1), None)
+            .expect("find_elements must succeed");
+        let data = matches.pop().expect("selector matched no elements");
+        Element::new(data, provider_dyn)
+    }
+
+    fn last_action(provider: &Arc<MockProvider>) -> (u64, String, Option<String>) {
+        provider
+            .actions()
+            .last()
+            .cloned()
+            .expect("expected at least one recorded action")
+    }
+
+    #[test]
+    fn nullary_actions_record_correct_name() {
+        let provider = build_provider();
+        let cases = [
+            (r#"button[name="Back"]"#, "press" as &str),
+            (r#"button[name="Back"]"#, "focus"),
+            (r#"button[name="Back"]"#, "blur"),
+            (r#"check_box[name="Agree"]"#, "toggle"),
+            (r#"list_item[name="Item 1"]"#, "select"),
+            (r#"list[name="Items"]"#, "expand"),
+            (r#"list[name="Items"]"#, "collapse"),
+            (r#"button[name="Back"]"#, "show_menu"),
+            (r#"slider[name="Volume"]"#, "increment"),
+            (r#"slider[name="Volume"]"#, "decrement"),
+            (r#"button[name="Back"]"#, "scroll_into_view"),
+        ];
+        for (selector, action) in cases {
+            provider.clear_actions();
+            let el = find_element(&provider, selector);
+            match action {
+                "press" => el.press().unwrap(),
+                "focus" => el.focus().unwrap(),
+                "blur" => el.blur().unwrap(),
+                "toggle" => el.toggle().unwrap(),
+                "select" => el.select().unwrap(),
+                "expand" => el.expand().unwrap(),
+                "collapse" => el.collapse().unwrap(),
+                "show_menu" => el.show_menu().unwrap(),
+                "increment" => el.increment().unwrap(),
+                "decrement" => el.decrement().unwrap(),
+                "scroll_into_view" => el.scroll_into_view().unwrap(),
+                _ => unreachable!(),
+            }
+            let (handle, name, data) = last_action(&provider);
+            assert_eq!(
+                name, action,
+                "wrong action recorded for selector {selector}"
+            );
+            assert_eq!(data, None, "nullary action should not carry data");
+            assert_eq!(handle, el.data.handle);
+        }
+    }
+
+    #[test]
+    fn set_value_records_text_payload() {
+        let provider = build_provider();
+        let el = find_element(&provider, r#"text_field[name="Search"]"#);
+        el.set_value("world").unwrap();
+        let (handle, name, data) = last_action(&provider);
+        assert_eq!(handle, el.data.handle);
+        assert_eq!(name, "set_value");
+        assert_eq!(data.as_deref(), Some("world"));
+    }
+
+    #[test]
+    fn set_numeric_value_records_payload() {
+        let provider = build_provider();
+        let el = find_element(&provider, r#"slider[name="Volume"]"#);
+        el.set_numeric_value(42.0).unwrap();
+        let (_, name, data) = last_action(&provider);
+        assert_eq!(name, "set_numeric_value");
+        assert_eq!(data.as_deref(), Some("42"));
+    }
+
+    #[test]
+    fn set_numeric_value_rejects_non_finite() {
+        let provider = build_provider();
+        let el = find_element(&provider, r#"slider[name="Volume"]"#);
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(matches!(
+                el.set_numeric_value(bad),
+                Err(Error::InvalidActionData { .. })
+            ));
+        }
+        // None of the validation failures should have reached the provider.
+        assert!(provider.actions().is_empty());
+    }
+
+    #[test]
+    fn type_text_records_payload() {
+        let provider = build_provider();
+        let el = find_element(&provider, r#"text_field[name="Search"]"#);
+        el.type_text("abc").unwrap();
+        let (_, name, data) = last_action(&provider);
+        assert_eq!(name, "type_text");
+        assert_eq!(data.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn select_text_records_range() {
+        let provider = build_provider();
+        let el = find_element(&provider, r#"text_field[name="Search"]"#);
+        el.select_text(1, 4).unwrap();
+        let (_, name, data) = last_action(&provider);
+        assert_eq!(name, "set_text_selection");
+        assert_eq!(data.as_deref(), Some("1..4"));
+    }
+
+    #[test]
+    fn select_text_rejects_inverted_range() {
+        let provider = build_provider();
+        let el = find_element(&provider, r#"text_field[name="Search"]"#);
+        assert!(matches!(
+            el.select_text(5, 2),
+            Err(Error::InvalidActionData { .. })
+        ));
+        assert!(provider.actions().is_empty());
+    }
+
+    #[test]
+    fn perform_action_records_arbitrary_name() {
+        let provider = build_provider();
+        let el = find_element(&provider, r#"button[name="Back"]"#);
+        el.perform_action("raise").unwrap();
+        let (_, name, _) = last_action(&provider);
+        assert_eq!(name, "raise");
+    }
+
+    #[test]
+    fn locator_actions_desugar_to_element_actions() {
+        // Locator's auto-wait wraps the resolved data in an Element and calls
+        // its action — no duplication at the provider call site. This test
+        // pins that behavior: pressing via the Locator should record exactly
+        // the same entry as pressing via the Element it resolves to.
+        let provider = build_provider();
+        let provider_dyn: Arc<dyn Provider> = provider.clone();
+        let locator = crate::locator::Locator::new(provider_dyn, None, r#"button[name="Back"]"#);
+        locator.press().unwrap();
+        let (_, name, data) = last_action(&provider);
+        assert_eq!(name, "press");
+        assert_eq!(data, None);
+    }
+
+    #[test]
+    fn locator_validation_runs_before_auto_wait() {
+        // Locator validates payloads before entering its 5s auto-wait poll.
+        // We verify by passing invalid input against a never-matching selector:
+        // if validation fired first we get InvalidActionData immediately, not
+        // a Timeout 5 seconds later.
+        let provider = build_provider();
+        let provider_dyn: Arc<dyn Provider> = provider.clone();
+        let locator =
+            crate::locator::Locator::new(provider_dyn, None, r#"button[name="never-matches"]"#);
+        let started = std::time::Instant::now();
+        let err = locator.set_numeric_value(f64::NAN).unwrap_err();
+        assert!(matches!(err, Error::InvalidActionData { .. }));
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "validation must short-circuit auto-wait",
+        );
+    }
 }

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -177,8 +177,10 @@ impl Locator {
 
     // ── Auto-wait ──────────────────────────────────────────────────
 
-    /// Poll until the element is attached, visible, and enabled, returning its data.
-    fn auto_wait(&self) -> Result<ElementData> {
+    /// Poll until the element is attached, visible, and enabled, returning a
+    /// live [`Element`] handle. Used by the action methods below to provide
+    /// resilience against transient unactionable states.
+    fn auto_wait(&self) -> Result<Element> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
 
@@ -189,7 +191,9 @@ impl Locator {
             }
 
             match self.resolve_data() {
-                Ok(data) if data.states.visible && data.states.enabled => return Ok(data),
+                Ok(data) if data.states.visible && data.states.enabled => {
+                    return Ok(Element::new(data, Arc::clone(&self.provider)));
+                }
                 Ok(_) | Err(Error::SelectorNotMatched { .. }) => {
                     // Not yet actionable — poll again
                 }
@@ -200,97 +204,89 @@ impl Locator {
         }
     }
 
-    // ── Common actions (auto-wait, then delegate to provider) ──────
+    // ── Actions ────────────────────────────────────────────────────
+    //
+    // Locator actions auto-wait for the element to be visible and enabled
+    // (re-resolving the selector on each poll), then delegate to the
+    // [`Element`] action of the same name. For snapshot-bound actions that
+    // do not re-resolve, capture an [`Element`] via [`Locator::element`]
+    // and call its action methods directly.
 
     /// Click / invoke the matched element.
     pub fn press(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.press(&el)
+        self.auto_wait()?.press()
     }
 
     /// Set keyboard focus on the matched element.
     pub fn focus(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.focus(&el)
+        self.auto_wait()?.focus()
     }
 
     /// Remove keyboard focus from the matched element.
     pub fn blur(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.blur(&el)
+        self.auto_wait()?.blur()
     }
 
     /// Toggle the matched element (checkbox, switch).
     pub fn toggle(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.toggle(&el)
+        self.auto_wait()?.toggle()
     }
 
     /// Select the matched element (list item, etc.).
     pub fn select(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.select(&el)
+        self.auto_wait()?.select()
     }
 
     /// Expand the matched element.
     pub fn expand(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.expand(&el)
+        self.auto_wait()?.expand()
     }
 
     /// Collapse the matched element.
     pub fn collapse(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.collapse(&el)
+        self.auto_wait()?.collapse()
     }
 
     /// Show the context menu for the matched element.
     pub fn show_menu(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.show_menu(&el)
+        self.auto_wait()?.show_menu()
     }
 
     /// Increment the matched element (slider, spinner).
     pub fn increment(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.increment(&el)
+        self.auto_wait()?.increment()
     }
 
     /// Decrement the matched element (slider, spinner).
     pub fn decrement(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.decrement(&el)
+        self.auto_wait()?.decrement()
     }
 
     /// Scroll the matched element into view.
     pub fn scroll_into_view(&self) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.scroll_into_view(&el)
+        self.auto_wait()?.scroll_into_view()
     }
-
-    // ── Typed operations (auto-wait, then delegate) ────────────────
 
     /// Set the text value of the matched element.
     pub fn set_value(&self, value: &str) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.set_value(&el, value)
+        self.auto_wait()?.set_value(value)
     }
 
     /// Set the numeric value of the matched element (slider, spinner).
     pub fn set_numeric_value(&self, value: f64) -> Result<()> {
+        // Validate up-front so callers fail fast on NaN/inf without burning
+        // the auto-wait timeout.
         if !value.is_finite() {
             return Err(Error::InvalidActionData {
                 message: format!("set_numeric_value requires a finite value, got {}", value),
             });
         }
-        let el = self.auto_wait()?;
-        self.provider.set_numeric_value(&el, value)
+        self.auto_wait()?.set_numeric_value(value)
     }
 
     /// Type text at the current cursor position on the matched element.
     pub fn type_text(&self, text: &str) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.type_text(&el, text)
+        self.auto_wait()?.type_text(text)
     }
 
     /// Select a text range within the matched element.
@@ -300,19 +296,15 @@ impl Locator {
                 message: format!("select_text start ({}) must be <= end ({})", start, end),
             });
         }
-        let el = self.auto_wait()?;
-        self.provider.set_text_selection(&el, start, end)
+        self.auto_wait()?.select_text(start, end)
     }
-
-    // ── Generic action escape hatch ────────────────────────────────
 
     /// Perform an action by name (with auto-wait).
     ///
     /// This is the escape hatch for platform-specific actions not covered
     /// by the named methods above. Also works for well-known action names.
     pub fn perform_action(&self, action: &str) -> Result<()> {
-        let el = self.auto_wait()?;
-        self.provider.perform_action(&el, action)
+        self.auto_wait()?.perform_action(action)
     }
 
     // ── Wait operations ─────────────────────────────────────────────

--- a/xa11y-js/__test__/unit/element-actions.test.js
+++ b/xa11y-js/__test__/unit/element-actions.test.js
@@ -1,0 +1,191 @@
+// Element action invocation — verifies that each action method on the JS
+// Element binding dispatches into the core Element and lands the right
+// entry in the mock provider's action log.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { _makeTestActionProbe, InvalidActionDataError } = require('../../index.js');
+
+async function findDescendant(root, predicate) {
+  // Depth-first walk of the mock tree until predicate is satisfied.
+  const queue = [root];
+  while (queue.length > 0) {
+    const el = queue.shift();
+    if (predicate(el)) return el;
+    queue.push(...(await el.children()));
+  }
+  return null;
+}
+
+async function probeWith(predicate) {
+  const probe = _makeTestActionProbe();
+  const app = await probe.locator().element();
+  const el = await findDescendant(app, predicate);
+  assert.ok(el, 'fixture element not found in mock tree');
+  return { probe, el };
+}
+
+function lastAction(probe) {
+  const log = probe.actions();
+  return log[log.length - 1];
+}
+
+// ── Nullary actions ────────────────────────────────────────────────────
+
+test('press() records on the captured element', async () => {
+  const { probe, el } = await probeWith((e) => e.name === 'Back');
+  await el.press();
+  const [, action, data] = lastAction(probe);
+  assert.equal(action, 'press');
+  assert.equal(data, null);
+});
+
+test('focus() records', async () => {
+  const { probe, el } = await probeWith((e) => e.name === 'Back');
+  await el.focus();
+  assert.equal(lastAction(probe)[1], 'focus');
+});
+
+test('blur() records', async () => {
+  const { probe, el } = await probeWith((e) => e.name === 'Back');
+  await el.blur();
+  assert.equal(lastAction(probe)[1], 'blur');
+});
+
+test('toggle() records on a checkbox', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'check_box');
+  await el.toggle();
+  assert.equal(lastAction(probe)[1], 'toggle');
+});
+
+test('expand() records on the list', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'list');
+  await el.expand();
+  assert.equal(lastAction(probe)[1], 'expand');
+});
+
+test('collapse() records on the list', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'list');
+  await el.collapse();
+  assert.equal(lastAction(probe)[1], 'collapse');
+});
+
+test('select() records on a list item', async () => {
+  const { probe, el } = await probeWith((e) => e.name === 'Item 2');
+  await el.select();
+  assert.equal(lastAction(probe)[1], 'select');
+});
+
+test('showMenu() records', async () => {
+  const { probe, el } = await probeWith((e) => e.name === 'Back');
+  await el.showMenu();
+  assert.equal(lastAction(probe)[1], 'show_menu');
+});
+
+test('scrollIntoView() records', async () => {
+  const { probe, el } = await probeWith((e) => e.name === 'Back');
+  await el.scrollIntoView();
+  assert.equal(lastAction(probe)[1], 'scroll_into_view');
+});
+
+test('increment() records on the slider', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'slider');
+  await el.increment();
+  assert.equal(lastAction(probe)[1], 'increment');
+});
+
+test('decrement() records on the slider', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'slider');
+  await el.decrement();
+  assert.equal(lastAction(probe)[1], 'decrement');
+});
+
+// ── Actions with payloads ──────────────────────────────────────────────
+
+test('setValue() forwards the value arg', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'text_field');
+  await el.setValue('world');
+  const [, action, data] = lastAction(probe);
+  assert.equal(action, 'set_value');
+  assert.equal(data, 'world');
+});
+
+test('setNumericValue() forwards a finite value', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'slider');
+  await el.setNumericValue(42);
+  const [, action, data] = lastAction(probe);
+  assert.equal(action, 'set_numeric_value');
+  assert.equal(data, '42');
+});
+
+test('typeText() forwards the text arg', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'text_field');
+  await el.typeText('abc');
+  const [, action, data] = lastAction(probe);
+  assert.equal(action, 'type_text');
+  assert.equal(data, 'abc');
+});
+
+test('selectText() forwards the range', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'text_field');
+  await el.selectText(1, 4);
+  const [, action, data] = lastAction(probe);
+  assert.equal(action, 'set_text_selection');
+  assert.equal(data, '1..4');
+});
+
+test('performAction() forwards an arbitrary action name', async () => {
+  const { probe, el } = await probeWith((e) => e.name === 'Back');
+  await el.performAction('press');
+  // perform_action records under the action name itself, not "perform_action".
+  assert.equal(lastAction(probe)[1], 'press');
+});
+
+// ── Validation paths ───────────────────────────────────────────────────
+
+test('setNumericValue(NaN) rejects with InvalidActionDataError', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'slider');
+  await assert.rejects(() => el.setNumericValue(NaN), InvalidActionDataError);
+  // Ensure no provider call landed despite the rejection.
+  assert.equal(probe.actions().length, 0);
+});
+
+test('setNumericValue(Infinity) rejects with InvalidActionDataError', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'slider');
+  await assert.rejects(
+    () => el.setNumericValue(Number.POSITIVE_INFINITY),
+    InvalidActionDataError,
+  );
+  assert.equal(probe.actions().length, 0);
+});
+
+test('selectText() with start > end rejects with InvalidActionDataError', async () => {
+  const { probe, el } = await probeWith((e) => e.role === 'text_field');
+  await assert.rejects(() => el.selectText(5, 2), InvalidActionDataError);
+  assert.equal(probe.actions().length, 0);
+});
+
+// ── Snapshot semantics ─────────────────────────────────────────────────
+
+test('actions act on the captured snapshot — not a fresh resolve', async () => {
+  // Distinct elements with the same role should each route to their own
+  // handle in the action log, proving the binding uses the snapshot's
+  // identity rather than re-querying the tree.
+  const probe = _makeTestActionProbe();
+  const root = await probe.locator().element();
+  const item1 = await findDescendant(root, (e) => e.name === 'Item 1');
+  const item2 = await findDescendant(root, (e) => e.name === 'Item 2');
+  assert.ok(item1 && item2);
+
+  await item1.select();
+  await item2.select();
+
+  const log = probe.actions();
+  assert.equal(log.length, 2);
+  assert.equal(log[0][1], 'select');
+  assert.equal(log[1][1], 'select');
+  assert.notEqual(log[0][0], log[1][0], 'each item should record under its own handle');
+});

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -507,6 +507,7 @@ module.exports = {
 
   // @internal -- used by unit tests
   _makeTestLocator: native._makeTestLocator,
+  _makeTestActionProbe: native._makeTestActionProbe,
   _makeDisconnectedSubscription: native._makeDisconnectedSubscription,
   _Subscription: Subscription,
 };

--- a/xa11y-js/src/element.rs
+++ b/xa11y-js/src/element.rs
@@ -673,7 +673,9 @@ impl Task for ElementActionTask {
             ElementActionKind::Increment => element.increment(),
             ElementActionKind::Decrement => element.decrement(),
             ElementActionKind::SetValue => element.set_value(self.text.as_deref().unwrap_or("")),
-            ElementActionKind::SetNumericValue => element.set_numeric_value(self.num.unwrap_or(0.0)),
+            ElementActionKind::SetNumericValue => {
+                element.set_numeric_value(self.num.unwrap_or(0.0))
+            }
             ElementActionKind::TypeText => element.type_text(self.text.as_deref().unwrap_or("")),
             ElementActionKind::SelectText => {
                 let (s, e) = self.range.unwrap_or((0, 0));

--- a/xa11y-js/src/element.rs
+++ b/xa11y-js/src/element.rs
@@ -259,6 +259,204 @@ impl Element {
             max_depth: max_depth.map(|d| d as usize),
         })
     }
+
+    // ── Actions (act on the captured snapshot — do not re-resolve) ──────
+
+    /// Click / invoke this element. Acts on the captured snapshot — does
+    /// not re-resolve.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn press(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Press,
+        ))
+    }
+
+    /// Move keyboard focus to this element. Acts on the captured snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn focus(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Focus,
+        ))
+    }
+
+    /// Remove keyboard focus from this element. Acts on the captured
+    /// snapshot.
+    ///
+    /// Not supported on Linux or Windows — on those platforms this rejects
+    /// with `ActionNotSupportedError`.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn blur(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Blur,
+        ))
+    }
+
+    /// Toggle a two- or three-state control (checkbox, switch, toggle
+    /// button). Acts on the captured snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn toggle(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Toggle,
+        ))
+    }
+
+    /// Expand a disclosure, menu, or tree item. Acts on the captured
+    /// snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn expand(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Expand,
+        ))
+    }
+
+    /// Collapse a disclosure, menu, or tree item. Acts on the captured
+    /// snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn collapse(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Collapse,
+        ))
+    }
+
+    /// Select this element (list item, tab, row). Acts on the captured
+    /// snapshot.
+    #[napi(js_name = "select", ts_return_type = "Promise<void>")]
+    pub fn select_(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Select,
+        ))
+    }
+
+    /// Open this element's context menu. Acts on the captured snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn show_menu(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::ShowMenu,
+        ))
+    }
+
+    /// Scroll this element into the visible area. Acts on the captured
+    /// snapshot.
+    ///
+    /// No-op on macOS — the macOS accessibility API has no equivalent. Uses
+    /// `Component.ScrollTo` on Linux and `ScrollItemPattern` on Windows.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn scroll_into_view(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::ScrollIntoView,
+        ))
+    }
+
+    /// Increment a numeric value (slider, spin button) by its platform step.
+    /// Acts on the captured snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn increment(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Increment,
+        ))
+    }
+
+    /// Decrement a numeric value (slider, spin button) by its platform step.
+    /// Acts on the captured snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn decrement(&self) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::nullary(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::Decrement,
+        ))
+    }
+
+    /// Set the text value of this element. Replaces the entire value rather
+    /// than inserting at the caret — use `typeText` for insertion. Acts on
+    /// the captured snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn set_value(&self, value: String) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_text(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::SetValue,
+            value,
+        ))
+    }
+
+    /// Set the numeric value of this element (slider, spin button). Acts on
+    /// the captured snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn set_numeric_value(&self, value: f64) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_num(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::SetNumericValue,
+            value,
+        ))
+    }
+
+    /// Type `text` at the current caret position. Acts on the captured
+    /// snapshot.
+    ///
+    /// Uses the platform accessibility API — never simulates keyboard events.
+    /// For synthesised keystrokes (global shortcuts, drag gestures), use the
+    /// `InputSim` surface instead.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn type_text(&self, text: String) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_text(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::TypeText,
+            text,
+        ))
+    }
+
+    /// Select the text range from `start` to `end` (0-based character
+    /// offsets). Rejects with `InvalidActionDataError` if `start > end`.
+    /// Acts on the captured snapshot.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn select_text(&self, start: u32, end: u32) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_range(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::SelectText,
+            start,
+            end,
+        ))
+    }
+
+    /// Perform a custom action by its snake_case name. Acts on the captured
+    /// snapshot.
+    ///
+    /// Use this for actions the element advertises in its `actions` list
+    /// that don't have a dedicated method. Rejects with
+    /// `ActionNotSupportedError` if the element does not advertise `action`.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn perform_action(&self, action: String) -> AsyncTask<ElementActionTask> {
+        AsyncTask::new(ElementActionTask::with_text(
+            self.data.clone(),
+            self.provider.clone(),
+            ElementActionKind::PerformAction,
+            action,
+        ))
+    }
 }
 
 // ── Task implementations ────────────────────────────────────────────────
@@ -359,5 +557,136 @@ impl Task for DumpTask {
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
         Ok(output)
+    }
+}
+
+// ── Element action task ────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+pub enum ElementActionKind {
+    Press,
+    Focus,
+    Blur,
+    Toggle,
+    Expand,
+    Collapse,
+    Select,
+    ShowMenu,
+    ScrollIntoView,
+    Increment,
+    Decrement,
+    SetValue,
+    SetNumericValue,
+    TypeText,
+    SelectText,
+    PerformAction,
+}
+
+pub struct ElementActionTask {
+    data: xa11y::ElementData,
+    provider: Arc<dyn xa11y::Provider>,
+    kind: ElementActionKind,
+    text: Option<String>,
+    num: Option<f64>,
+    range: Option<(u32, u32)>,
+}
+
+impl ElementActionTask {
+    fn nullary(
+        data: xa11y::ElementData,
+        provider: Arc<dyn xa11y::Provider>,
+        kind: ElementActionKind,
+    ) -> Self {
+        Self {
+            data,
+            provider,
+            kind,
+            text: None,
+            num: None,
+            range: None,
+        }
+    }
+    fn with_text(
+        data: xa11y::ElementData,
+        provider: Arc<dyn xa11y::Provider>,
+        kind: ElementActionKind,
+        text: String,
+    ) -> Self {
+        Self {
+            data,
+            provider,
+            kind,
+            text: Some(text),
+            num: None,
+            range: None,
+        }
+    }
+    fn with_num(
+        data: xa11y::ElementData,
+        provider: Arc<dyn xa11y::Provider>,
+        kind: ElementActionKind,
+        num: f64,
+    ) -> Self {
+        Self {
+            data,
+            provider,
+            kind,
+            text: None,
+            num: Some(num),
+            range: None,
+        }
+    }
+    fn with_range(
+        data: xa11y::ElementData,
+        provider: Arc<dyn xa11y::Provider>,
+        kind: ElementActionKind,
+        start: u32,
+        end: u32,
+    ) -> Self {
+        Self {
+            data,
+            provider,
+            kind,
+            text: None,
+            num: None,
+            range: Some((start, end)),
+        }
+    }
+}
+
+impl Task for ElementActionTask {
+    type Output = ();
+    type JsValue = ();
+
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        let element = xa11y::Element::new(self.data.clone(), self.provider.clone());
+        let r = match self.kind {
+            ElementActionKind::Press => element.press(),
+            ElementActionKind::Focus => element.focus(),
+            ElementActionKind::Blur => element.blur(),
+            ElementActionKind::Toggle => element.toggle(),
+            ElementActionKind::Expand => element.expand(),
+            ElementActionKind::Collapse => element.collapse(),
+            ElementActionKind::Select => element.select(),
+            ElementActionKind::ShowMenu => element.show_menu(),
+            ElementActionKind::ScrollIntoView => element.scroll_into_view(),
+            ElementActionKind::Increment => element.increment(),
+            ElementActionKind::Decrement => element.decrement(),
+            ElementActionKind::SetValue => element.set_value(self.text.as_deref().unwrap_or("")),
+            ElementActionKind::SetNumericValue => element.set_numeric_value(self.num.unwrap_or(0.0)),
+            ElementActionKind::TypeText => element.type_text(self.text.as_deref().unwrap_or("")),
+            ElementActionKind::SelectText => {
+                let (s, e) = self.range.unwrap_or((0, 0));
+                element.select_text(s, e)
+            }
+            ElementActionKind::PerformAction => {
+                element.perform_action(self.text.as_deref().unwrap_or(""))
+            }
+        };
+        r.map_err(map_err)
+    }
+
+    fn resolve(&mut self, _env: Env, _output: Self::Output) -> napi::Result<Self::JsValue> {
+        Ok(())
     }
 }

--- a/xa11y-js/src/mock.rs
+++ b/xa11y-js/src/mock.rs
@@ -25,6 +25,68 @@ pub fn make_test_locator() -> Locator {
     ))
 }
 
+/// Test handle that pairs a mock `Locator` with read-access to the mock's
+/// action log. Lets JS unit tests assert that an action method dispatched
+/// to the expected provider call. Not part of the public API.
+#[napi(js_name = "_TestActionProbe")]
+#[allow(
+    dead_code,
+    reason = "Exported via napi-derive for JS unit tests; the lib-test clippy build doesn't see the JS-side consumer"
+)]
+pub struct TestActionProbe {
+    provider: Arc<xa11y::mock::MockProvider>,
+}
+
+#[napi]
+#[allow(
+    dead_code,
+    reason = "Exported via napi-derive for JS unit tests; the lib-test clippy build doesn't see the JS-side consumer"
+)]
+impl TestActionProbe {
+    /// A `Locator` rooted at the shared synthetic tree, backed by the same
+    /// provider whose action log this probe exposes.
+    #[napi]
+    pub fn locator(&self) -> Locator {
+        Locator::from_inner(xa11y::Locator::new(
+            self.provider.clone() as Arc<dyn xa11y::Provider>,
+            None,
+            "application",
+        ))
+    }
+
+    /// Action log entries recorded so far, as `[handle, action, data?]`
+    /// tuples. `data` is `null` for nullary actions, a stringified
+    /// argument otherwise (matches the core mock's record format).
+    #[napi(ts_return_type = "Array<[number, string, string | null]>")]
+    pub fn actions(&self) -> Vec<(u32, String, Option<String>)> {
+        self.provider
+            .actions()
+            .into_iter()
+            .map(|(h, a, d)| (h as u32, a, d))
+            .collect()
+    }
+
+    /// Clear the recorded action log.
+    #[napi]
+    pub fn clear(&self) {
+        self.provider.clear_actions();
+    }
+}
+
+/// Create a `_TestActionProbe` wrapping a fresh mock provider. Used by JS
+/// unit tests to verify that action methods dispatch to the expected
+/// provider call.
+#[napi(js_name = "_makeTestActionProbe")]
+#[allow(
+    dead_code,
+    reason = "Exported via napi-derive for JS unit tests; the lib-test clippy build doesn't see the JS-side consumer"
+)]
+pub fn make_test_action_probe() -> TestActionProbe {
+    TestActionProbe {
+        provider: xa11y::mock::build_provider(),
+    }
+}
+
 /// Create a `_NativeSubscription` whose backing channel has already been
 /// disconnected. Used by tests to verify the worker loop terminates cleanly
 /// on sender-drop rather than hanging.

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -214,6 +214,38 @@ class Element:
         """Get parent element (lazy — each call queries the provider)."""
     def subscribe(self) -> Subscription:
         """Subscribe to accessibility events for this element (typically an app)."""
+    def press(self) -> None:
+        """Press (default activate) this element."""
+    def focus(self) -> None:
+        """Move keyboard focus to this element."""
+    def blur(self) -> None:
+        """Remove keyboard focus from this element."""
+    def toggle(self) -> None:
+        """Toggle this element's checked state."""
+    def expand(self) -> None:
+        """Expand this element (e.g. tree node, combo box)."""
+    def collapse(self) -> None:
+        """Collapse this element."""
+    def select(self) -> None:
+        """Select this element (e.g. list item, tab)."""
+    def show_menu(self) -> None:
+        """Show this element's context menu."""
+    def scroll_into_view(self) -> None:
+        """Scroll this element into view."""
+    def increment(self) -> None:
+        """Increment this element's value (e.g. slider, spinner)."""
+    def decrement(self) -> None:
+        """Decrement this element's value."""
+    def set_value(self, value: str) -> None:
+        """Replace this element's text value."""
+    def set_numeric_value(self, value: float) -> None:
+        """Set this element's numeric value."""
+    def type_text(self, text: str) -> None:
+        """Insert text at the current cursor position."""
+    def select_text(self, start: int, end: int) -> None:
+        """Select the text range from ``start`` to ``end`` (0-based offsets)."""
+    def perform_action(self, action: str) -> None:
+        """Perform an action by ``snake_case`` name."""
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
 
@@ -393,3 +425,10 @@ def screenshot(
 
 def _make_test_locator() -> Locator: ...
 def _make_disconnected_subscription() -> Subscription: ...
+
+class _TestActionProbe:
+    def locator(self, selector: str) -> Locator: ...
+    def actions(self) -> list[list[object]]: ...
+    def clear(self) -> None: ...
+
+def _make_test_action_probe() -> _TestActionProbe: ...

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -352,6 +352,108 @@ impl Element {
         Ok(dict.into_any().unbind())
     }
 
+    // ── Actions ──
+    //
+    // These act on the captured snapshot rather than re-resolving the selector
+    // (contrast with Locator, which re-queries the provider on every call).
+
+    /// Press (default activate) this element.
+    fn press(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .press()
+            .map_err(to_py_err)
+    }
+    /// Move keyboard focus to this element.
+    fn focus(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .focus()
+            .map_err(to_py_err)
+    }
+    /// Remove keyboard focus from this element.
+    fn blur(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .blur()
+            .map_err(to_py_err)
+    }
+    /// Toggle this element's checked state.
+    fn toggle(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .toggle()
+            .map_err(to_py_err)
+    }
+    /// Expand this element (e.g. tree node, combo box).
+    fn expand(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .expand()
+            .map_err(to_py_err)
+    }
+    /// Collapse this element.
+    fn collapse(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .collapse()
+            .map_err(to_py_err)
+    }
+    /// Select this element (e.g. list item, tab).
+    fn select(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .select()
+            .map_err(to_py_err)
+    }
+    /// Show this element's context menu.
+    fn show_menu(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .show_menu()
+            .map_err(to_py_err)
+    }
+    /// Scroll this element into view.
+    fn scroll_into_view(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .scroll_into_view()
+            .map_err(to_py_err)
+    }
+    /// Increment this element's value (e.g. slider, spinner).
+    fn increment(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .increment()
+            .map_err(to_py_err)
+    }
+    /// Decrement this element's value.
+    fn decrement(&self) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .decrement()
+            .map_err(to_py_err)
+    }
+    /// Replace this element's text value.
+    fn set_value(&self, value: &str) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .set_value(value)
+            .map_err(to_py_err)
+    }
+    /// Set this element's numeric value.
+    fn set_numeric_value(&self, value: f64) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .set_numeric_value(value)
+            .map_err(to_py_err)
+    }
+    /// Insert text at the current cursor position.
+    fn type_text(&self, text: &str) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .type_text(text)
+            .map_err(to_py_err)
+    }
+    /// Select the text range from `start` to `end` (0-based character offsets).
+    fn select_text(&self, start: u32, end: u32) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .select_text(start, end)
+            .map_err(to_py_err)
+    }
+    /// Perform an action by its ``snake_case`` name.
+    fn perform_action(&self, action: &str) -> PyResult<()> {
+        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
+            .perform_action(action)
+            .map_err(to_py_err)
+    }
+
     fn __repr__(&self) -> String {
         let mut parts = vec![format!("role='{}'", self.role)];
         if let Some(ref n) = self.name {
@@ -1303,6 +1405,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Test helpers
     m.add_function(wrap_pyfunction!(_make_test_locator, m)?)?;
     m.add_function(wrap_pyfunction!(_make_disconnected_subscription, m)?)?;
+    m.add_function(wrap_pyfunction!(_make_test_action_probe, m)?)?;
 
     Ok(())
 }
@@ -1338,6 +1441,61 @@ fn _make_test_locator() -> PyResult<Locator> {
 fn _make_disconnected_subscription() -> Subscription {
     Subscription {
         inner: std::sync::Mutex::new(Some(xa11y::mock::disconnected_subscription())),
+        provider: xa11y::mock::build_provider(),
+    }
+}
+
+/// Probe wrapping a single shared mock provider so tests can drive actions
+/// from a Python `Element` and then inspect the recorded action log.
+#[pyclass]
+struct TestActionProbe {
+    provider: Arc<xa11y::mock::MockProvider>,
+}
+
+#[pymethods]
+impl TestActionProbe {
+    /// Locator rooted at the mock test app, sharing this probe's provider.
+    fn locator(&self, selector: &str) -> Locator {
+        Locator {
+            inner: xa11y::Locator::new(
+                self.provider.clone() as Arc<dyn xa11y::Provider>,
+                None,
+                selector,
+            ),
+        }
+    }
+
+    /// Recorded action log: list of `(handle, action_name, optional_data)`.
+    fn actions(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let entries = self.provider.actions();
+        let list = PyList::empty(py);
+        for (handle, name, data) in entries {
+            let tup = PyList::empty(py);
+            tup.append(handle)?;
+            tup.append(name)?;
+            match data {
+                Some(s) => tup.append(s)?,
+                None => tup.append(py.None())?,
+            }
+            list.append(tup)?;
+        }
+        Ok(list.into_any().unbind())
+    }
+
+    /// Clear the action log.
+    fn clear(&self) {
+        self.provider.clear_actions();
+    }
+}
+
+/// Create a probe over the shared mock provider.
+///
+/// The returned probe exposes a `locator()` helper plus `actions()` /
+/// `clear()` for inspecting and resetting the action log recorded by the
+/// mock provider.
+#[pyfunction]
+fn _make_test_action_probe() -> TestActionProbe {
+    TestActionProbe {
         provider: xa11y::mock::build_provider(),
     }
 }

--- a/xa11y-python/tests/test_element_actions.py
+++ b/xa11y-python/tests/test_element_actions.py
@@ -1,0 +1,230 @@
+"""Tests for Element action methods: press, focus, set_value, etc.
+
+The 16 actions on `Element` mirror those on `Locator` but operate on the
+captured snapshot rather than re-resolving the selector. We use the shared
+mock provider (via `_make_test_action_probe`) so we can assert each call
+landed on the provider with the right name and argument.
+"""
+
+import math
+
+import pytest
+import xa11y
+from xa11y._native import _make_test_action_probe
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _resolve(probe, selector):
+    """Resolve a Locator (rooted at the test app) to its first Element."""
+    return probe.locator("application").descendant(selector).element()
+
+
+def _last_action(probe):
+    actions = probe.actions()
+    assert actions, "expected at least one recorded action"
+    return actions[-1]
+
+
+# ── Basic actions (no arguments) ─────────────────────────────────────────────
+
+
+def test_element_press():
+    probe = _make_test_action_probe()
+    btn = _resolve(probe, 'button[name="Back"]')
+    probe.clear()
+    btn.press()
+    _, name, data = _last_action(probe)
+    assert name == "press"
+    assert data is None
+
+
+def test_element_focus():
+    probe = _make_test_action_probe()
+    btn = _resolve(probe, 'button[name="Back"]')
+    probe.clear()
+    btn.focus()
+    assert _last_action(probe)[1] == "focus"
+
+
+def test_element_blur():
+    probe = _make_test_action_probe()
+    btn = _resolve(probe, 'button[name="Back"]')
+    probe.clear()
+    btn.blur()
+    assert _last_action(probe)[1] == "blur"
+
+
+def test_element_toggle():
+    probe = _make_test_action_probe()
+    cb = _resolve(probe, "check_box")
+    probe.clear()
+    cb.toggle()
+    assert _last_action(probe)[1] == "toggle"
+
+
+def test_element_select():
+    probe = _make_test_action_probe()
+    item = _resolve(probe, 'list_item[name="Item 1"]')
+    probe.clear()
+    item.select()
+    assert _last_action(probe)[1] == "select"
+
+
+def test_element_expand():
+    probe = _make_test_action_probe()
+    lst = _resolve(probe, "list")
+    probe.clear()
+    lst.expand()
+    assert _last_action(probe)[1] == "expand"
+
+
+def test_element_collapse():
+    probe = _make_test_action_probe()
+    lst = _resolve(probe, "list")
+    probe.clear()
+    lst.collapse()
+    assert _last_action(probe)[1] == "collapse"
+
+
+def test_element_show_menu():
+    probe = _make_test_action_probe()
+    btn = _resolve(probe, 'button[name="Back"]')
+    probe.clear()
+    btn.show_menu()
+    assert _last_action(probe)[1] == "show_menu"
+
+
+def test_element_increment():
+    probe = _make_test_action_probe()
+    slider = _resolve(probe, "slider")
+    probe.clear()
+    slider.increment()
+    assert _last_action(probe)[1] == "increment"
+
+
+def test_element_decrement():
+    probe = _make_test_action_probe()
+    slider = _resolve(probe, "slider")
+    probe.clear()
+    slider.decrement()
+    assert _last_action(probe)[1] == "decrement"
+
+
+def test_element_scroll_into_view():
+    probe = _make_test_action_probe()
+    btn = _resolve(probe, 'button[name="Back"]')
+    probe.clear()
+    btn.scroll_into_view()
+    assert _last_action(probe)[1] == "scroll_into_view"
+
+
+# ── Actions with arguments ───────────────────────────────────────────────────
+
+
+def test_element_set_value():
+    probe = _make_test_action_probe()
+    field = _resolve(probe, "text_field")
+    probe.clear()
+    field.set_value("new value")
+    _, name, data = _last_action(probe)
+    assert name == "set_value"
+    assert data == "new value"
+
+
+def test_element_set_numeric_value():
+    probe = _make_test_action_probe()
+    slider = _resolve(probe, "slider")
+    probe.clear()
+    slider.set_numeric_value(42.0)
+    _, name, data = _last_action(probe)
+    assert name == "set_numeric_value"
+    assert data == "42"
+
+
+def test_element_type_text():
+    probe = _make_test_action_probe()
+    field = _resolve(probe, "text_field")
+    probe.clear()
+    field.type_text("hello")
+    _, name, data = _last_action(probe)
+    assert name == "type_text"
+    assert data == "hello"
+
+
+def test_element_select_text():
+    probe = _make_test_action_probe()
+    field = _resolve(probe, "text_field")
+    probe.clear()
+    field.select_text(0, 3)
+    _, name, data = _last_action(probe)
+    assert name == "set_text_selection"
+    assert data == "0..3"
+
+
+def test_element_perform_action():
+    probe = _make_test_action_probe()
+    btn = _resolve(probe, 'button[name="Back"]')
+    probe.clear()
+    btn.perform_action("press")
+    assert _last_action(probe)[1] == "press"
+
+
+# ── Validation rejection paths (handled in core) ─────────────────────────────
+
+
+def test_set_numeric_value_rejects_nan():
+    probe = _make_test_action_probe()
+    slider = _resolve(probe, "slider")
+    probe.clear()
+    with pytest.raises(xa11y.InvalidActionDataError):
+        slider.set_numeric_value(math.nan)
+    # Validation rejects before the provider is touched.
+    assert probe.actions() == []
+
+
+def test_set_numeric_value_rejects_positive_inf():
+    probe = _make_test_action_probe()
+    slider = _resolve(probe, "slider")
+    probe.clear()
+    with pytest.raises(xa11y.InvalidActionDataError):
+        slider.set_numeric_value(math.inf)
+    assert probe.actions() == []
+
+
+def test_set_numeric_value_rejects_negative_inf():
+    probe = _make_test_action_probe()
+    slider = _resolve(probe, "slider")
+    probe.clear()
+    with pytest.raises(xa11y.InvalidActionDataError):
+        slider.set_numeric_value(-math.inf)
+    assert probe.actions() == []
+
+
+def test_select_text_rejects_start_after_end():
+    probe = _make_test_action_probe()
+    field = _resolve(probe, "text_field")
+    probe.clear()
+    with pytest.raises(xa11y.InvalidActionDataError):
+        field.select_text(5, 2)
+    assert probe.actions() == []
+
+
+# ── Snapshot semantics ───────────────────────────────────────────────────────
+
+
+def test_element_action_uses_captured_snapshot():
+    """Element actions act on the captured ElementData, so the same Element
+    handle keeps working across multiple calls without re-resolving."""
+    probe = _make_test_action_probe()
+    btn = _resolve(probe, 'button[name="Back"]')
+    probe.clear()
+    btn.press()
+    btn.focus()
+    btn.press()
+    names = [entry[1] for entry in probe.actions()]
+    assert names == ["press", "focus", "press"]
+    # All three reached the same handle (the captured Back button).
+    handles = {entry[0] for entry in probe.actions()}
+    assert len(handles) == 1

--- a/xa11y-python/tests/test_element_actions.py
+++ b/xa11y-python/tests/test_element_actions.py
@@ -12,7 +12,6 @@ import pytest
 import xa11y
 from xa11y._native import _make_test_action_probe
 
-
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 

--- a/xa11y/tests/integ/actions.rs
+++ b/xa11y/tests/integ/actions.rs
@@ -545,4 +545,82 @@ mod tests {
             Err(e) => println!("TypeText result: {}", e),
         }
     }
+
+    // ════════════════════════════════════════════════════════════════
+    // Element-shape Actions — exercise the new `element.press()` etc. API
+    // ════════════════════════════════════════════════════════════════
+    //
+    // These mirror a small slice of the dispatch tests above but go through
+    // the snapshot-bound `Element` action methods instead of the lower-level
+    // `provider().X(&data)` shape. They prove the new surface compiles and
+    // dispatches end-to-end. Locator-shape coverage is the recommended path
+    // (auto-wait, re-resolve) and stays exhaustive elsewhere.
+
+    #[test]
+    #[ignore]
+    fn action_press_via_element() {
+        let app = h::app_root();
+        let submit = h::named(&app, "Submit");
+        match submit.press() {
+            Ok(()) => println!("Submit pressed via element.press()"),
+            Err(e) => println!("Submit press result: {}", e),
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn action_set_value_via_element() {
+        let app = h::app_root();
+        let text = find_text_entry(&app);
+        match text.set_value("Jane Smith") {
+            Ok(()) => {
+                std::thread::sleep(std::time::Duration::from_millis(300));
+                let app2 = h::app_root();
+                let updated = app2
+                    .locator(r#"[value="Jane Smith"]"#)
+                    .elements()
+                    .unwrap_or_default();
+                if updated.is_empty() {
+                    println!(
+                        "set_value via element succeeded but value not reflected (adapter limitation)"
+                    );
+                }
+            }
+            Err(Error::TextValueNotSupported) => println!("TextValueNotSupported — OK"),
+            Err(e) => panic!("Unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn action_perform_action_via_element() {
+        let app = h::app_root();
+        let submit = h::named(&app, "Submit");
+        // perform_action is the escape hatch for actions without a dedicated
+        // method; "press" is the canonical well-known name and should round-trip
+        // to the same provider call as element.press().
+        match submit.perform_action("press") {
+            Ok(()) => println!("perform_action(\"press\") succeeded"),
+            Err(e) => println!("perform_action result: {}", e),
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn action_set_numeric_value_via_element_rejects_nan() {
+        // The Element wrapper validates NaN/infinite up-front and must return
+        // InvalidActionData *without* dispatching to the provider. This is a
+        // pure-Rust validation path so it's safe to assert strictly even
+        // when the AccessKit app isn't running — but we keep it #[ignore]'d
+        // for consistency with the rest of this file.
+        let app = h::app_root();
+        let sliders = app.locator("slider").elements().unwrap();
+        assert!(!sliders.is_empty(), "No slider in test app");
+        let result = sliders[0].set_numeric_value(f64::NAN);
+        assert!(
+            matches!(result, Err(Error::InvalidActionData { .. })),
+            "set_numeric_value(NaN) should return InvalidActionData, got: {:?}",
+            result
+        );
+    }
 }

--- a/xa11y/tests/integ/events_linux.rs
+++ b/xa11y/tests/integ/events_linux.rs
@@ -50,7 +50,7 @@ mod tests {
             // generic "click" action, not a separate "toggle" — so go
             // through press() to match the existing action_toggle_checkbox
             // integration test.
-            chk.provider().press(&chk).expect("press failed");
+            chk.press().expect("press failed");
             std::thread::sleep(std::time::Duration::from_millis(150));
         }
     }
@@ -158,7 +158,7 @@ mod tests {
             .expect("New button not found");
 
         let sub = app.subscribe().expect("subscribe");
-        target.provider().focus(&target).expect("focus failed");
+        target.focus().expect("focus failed");
 
         let event = sub
             .wait_for(
@@ -283,7 +283,7 @@ mod tests {
             .expect("Announce button not found");
 
         let sub = app.subscribe().expect("subscribe");
-        announce.provider().press(&announce).expect("press failed");
+        announce.press().expect("press failed");
 
         let event = sub
             .wait_for(
@@ -312,7 +312,7 @@ mod tests {
         let was_on = chk.states.checked == Some(Toggled::On);
 
         let sub = app.subscribe().expect("subscribe");
-        chk.provider().press(&chk).expect("press failed");
+        chk.press().expect("press failed");
 
         let event = sub
             .wait_for(

--- a/xa11y/tests/integ/events_macos.rs
+++ b/xa11y/tests/integ/events_macos.rs
@@ -61,7 +61,7 @@ mod tests {
             .expect("check_box not found");
         let is_on = chk.states.checked == Some(Toggled::On);
         if is_on != want_on {
-            chk.provider().toggle(&chk).expect("toggle failed");
+            chk.toggle().expect("toggle failed");
             std::thread::sleep(std::time::Duration::from_millis(150));
         }
     }
@@ -159,7 +159,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(100));
 
         let btn = h::named(&h::app_root(), "Submit");
-        btn.provider().focus(&btn).expect("focus failed");
+        btn.focus().expect("focus failed");
 
         let event = handle
             .join()
@@ -184,7 +184,7 @@ mod tests {
             .expect("Cancel button not found");
 
         let sub = app.subscribe().expect("subscribe");
-        target.provider().focus(&target).expect("focus failed");
+        target.focus().expect("focus failed");
 
         let event = sub
             .wait_for(
@@ -313,7 +313,7 @@ mod tests {
         let was_on = chk.states.checked == Some(Toggled::On);
 
         let sub = app.subscribe().expect("subscribe");
-        chk.provider().toggle(&chk).expect("toggle failed");
+        chk.toggle().expect("toggle failed");
 
         let event = sub
             .wait_for(
@@ -392,7 +392,7 @@ mod tests {
         );
 
         let sub = app.subscribe().expect("subscribe");
-        btn.provider().press(&btn).expect("Announce press failed");
+        btn.press().expect("Announce press failed");
 
         let event = sub
             .wait_for(

--- a/xa11y/tests/integ/events_windows.rs
+++ b/xa11y/tests/integ/events_windows.rs
@@ -60,7 +60,7 @@ mod tests {
             .expect("check_box not found");
         let is_on = chk.states.checked == Some(Toggled::On);
         if is_on != want_on {
-            chk.provider().toggle(&chk).expect("toggle failed");
+            chk.toggle().expect("toggle failed");
             std::thread::sleep(std::time::Duration::from_millis(150));
         }
     }
@@ -167,7 +167,7 @@ mod tests {
             .expect("New toolbar button not found");
 
         let sub = app.subscribe().expect("subscribe");
-        target.provider().focus(&target).expect("focus failed");
+        target.focus().expect("focus failed");
 
         let event = sub
             .wait_for(
@@ -269,7 +269,7 @@ mod tests {
         let was_on = chk.states.checked == Some(Toggled::On);
 
         let sub = app.subscribe().expect("subscribe");
-        chk.provider().toggle(&chk).expect("toggle failed");
+        chk.toggle().expect("toggle failed");
 
         let event = sub
             .wait_for(
@@ -328,7 +328,7 @@ mod tests {
             .expect("check_box not found");
 
         let sub = app.subscribe().expect("subscribe");
-        chk.provider().toggle(&chk).expect("toggle failed");
+        chk.toggle().expect("toggle failed");
 
         let event = sub
             .wait_for(
@@ -385,7 +385,7 @@ mod tests {
             .expect("Announce button not found");
 
         let sub = app.subscribe().expect("subscribe");
-        btn.provider().press(&btn).expect("Announce press failed");
+        btn.press().expect("Announce press failed");
 
         let event = sub
             .wait_for(


### PR DESCRIPTION
## Summary

Adds the full action surface (press, focus, blur, toggle, select, expand, collapse, show_menu, increment, decrement, scroll_into_view, set_value, set_numeric_value, type_text, select_text, perform_action) directly on `Element`. They invoke the platform via the provider handle captured at fetch time — no re-resolution, no auto-wait. If the handle is gone, the call returns `ElementStale`.

`Locator` action methods now desugar to `auto_wait()?.action()`. The Locator path is unchanged from a user perspective: it re-resolves the selector and waits for visible + enabled before dispatching, and remains the recommended primary path. Validation (NaN/inf, inverted ranges) moved to `Element`; `Locator` keeps an up-front validation step so bad input fails fast without burning the 5s auto-wait.

## Why

`Element.actions` already advertised what verbs the platform supports, but offered no way to invoke them without re-locating. Agent code (and humans inspecting an element) naturally writes `el.press()` after reading `el.actions` — currently a non-starter. This closes the look-but-don't-touch gap.

`Locator` is still the recommended path. `Element` actions are for the "I already have it and want to act on this same instance" case (post-`dump()`, post-`tree()` inspection, snapshot-bound flows where re-resolving might pick a different match).

## Design notes

- **No new error variants.** `ElementStale` already existed and is already returned by all three platform providers when their handle table can't relocate the element.
- **No breaking changes.** Locator's public surface is identical.
- **No silent re-resolution from Element.** Stale handles fail loudly. For retry-on-change semantics, use `Locator`.

## Coverage

| Layer | Tests added |
|---|---|
| `xa11y-core` unit (mock provider) | 10 — every verb, validation paths, Locator desugar |
| `xa11y-js` unit (mock provider) | 19 |
| `xa11y-python` unit (mock provider) | 21 |
| JS integ (real apps) | 7 |
| Python integ (real apps) | 9 |

Docs updated: `overview.mdx` (new "Element actions" subsection + recommendation callout) and `design.mdx` (one-paragraph note on the Locator/Element split).

## Test plan

- [ ] CI Linux unit + integ
- [ ] CI macOS unit + integ
- [ ] CI Windows unit + integ
- [ ] Python wheel build green on all platforms
- [ ] JS prebuilds green on all platforms