### PR TITLE
test(windows): drop flaky is_window_control_unit

### DIFF
--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -2343,25 +2343,6 @@ mod tests {
     }
 
     #[test]
-    fn is_window_control_unit() {
-        // Covers the boolean helper used by the focus handler's window
-        // ancestor walk. Given a real control-type read succeeds, equality
-        // against UIA_WindowControlTypeId determines the answer. We can't
-        // construct an IUIAutomationElement in a unit test, but we can
-        // exercise the pattern via `try_provider`.
-        let Some(provider) = try_provider() else {
-            return;
-        };
-        let apps = provider.get_children(None).unwrap_or_default();
-        // Every top-level enumerable element is a Window by construction.
-        for a in &apps {
-            // The helper takes a live IUIAutomationElement — we can only
-            // verify via the ElementData role surface.
-            assert_eq!(a.role, Role::Window);
-        }
-    }
-
-    #[test]
     fn property_change_ids_covers_design_doc() {
         // Property IDs mandated by the events design doc for the Windows
         // PropertyChanged pathway.


### PR DESCRIPTION
## Summary

- `is_window_control_unit` enumerated every top-level window on the runner's desktop and asserted each was `Role::Window`. That stopped being true once #183 added the `UIA_IsDialogPropertyId` refinement — any visible top-level window with `IsDialog=true` (UAC prompts, credential dialogs, system popups) now resolves to `Role::Dialog`.
- PR-time CI runs hit clean runners and passed; main's post-merge run on `e5bbf15` rolled a runner with a dialog up and the assertion fired: [run 25636220639](https://github.com/xa11y/xa11y/actions/runs/25636220639/job/75248438715) — `left: Dialog, right: Window`.
- #183 already added the hermetic replacement, `window_control_type_maps_to_window_not_dialog`, which exercises the `WindowControlTypeId → Role::Window` mapping without touching the desktop. Dropping the old test removes the flake without losing coverage.

## Test plan

- [ ] Windows unit tests pass on this branch
- [ ] `window_control_type_maps_to_window_not_dialog` still present and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)