### PR TITLE
feat(selector): support comma-separated alternation groups (#191)

### DIFF
--- a/docs/site/src/content/docs/guides/overview.mdx
+++ b/docs/site/src/content/docs/guides/overview.mdx
@@ -389,14 +389,15 @@ Reach for `Element` actions when you've already inspected an element — typical
 xa11y uses a CSS-like selector syntax to find elements. Selectors are used by `app.locator(selector)` to target elements for actions, waits, and queries.
 
 ```
-button                           # by role
-button[name='Submit']            # role + exact name match
-text_field[name^='Search']       # starts-with (case-insensitive)
-text_field[name*='email']        # contains (case-insensitive)
-button[name$='Cancel']           # ends-with (case-insensitive)
-group > button                   # direct child combinator
-window button[name='OK']         # descendant (any depth)
-button:nth(2)                    # 2nd match (1-based)
+button                              # by role
+button[name='Submit']               # role + exact name match
+text_field[name^='Search']          # starts-with (case-insensitive)
+text_field[name*='email']           # contains (case-insensitive)
+button[name$='Cancel']              # ends-with (case-insensitive)
+group > button                      # direct child combinator
+window button[name='OK']            # descendant (any depth)
+button:nth(2)                       # 2nd match (1-based)
+button[name='Play'], button[name='Pause']  # alternation — see below
 ```
 
 **Supported attributes:** `name`, `value`, `description`, `role`.
@@ -404,6 +405,8 @@ button:nth(2)                    # 2nd match (1-based)
 **Operators:** `=` (exact, case-sensitive), `*=` (contains), `^=` (starts-with), `$=` (ends-with). Substring operators are case-insensitive.
 
 **Roles use `snake_case`:** `button`, `text_field`, `check_box`, `radio_button`, `menu_item`, `tab_group`, `static_text`, `combo_box`, `list_item`, `table_row`, `table_cell`, `scroll_bar`, `progress_bar`, `tree_item`, `web_area`, `split_group`, `spin_button`, etc.
+
+**Selector groups (alternation):** A top-level comma separates alternation clauses, just like CSS selector lists. The result is the union of each clause's matches, deduplicated by element identity and returned in document order. Each clause is parsed independently, so combinators apply per clause: `window button, dialog button` means "buttons under a window *or* buttons under a dialog." Chained `descendant()` / `child()` calls on a group locator distribute over every clause — `locator("toolbar, dialog").descendant("button")` is equivalent to `locator("toolbar button, dialog button")`. Commas inside quoted attribute values (`[name='a,b']`) are not separators.
 
 ## Events
 

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -170,15 +170,43 @@ After changing permissions, restart your terminal for them to take effect. `App:
 
 ## Selector syntax
 
-| Pattern                        | Meaning                          |
-| ------------------------------ | -------------------------------- |
-| `button`                       | Elements with role `Button`      |
-| `button[name='OK']`            | Button named exactly "OK"        |
-| `textfield[name^='Search']`    | Text field whose name starts with "Search" |
-| `textfield[name*='email']`     | Text field whose name contains "email" |
-| `group > button`               | Buttons that are direct children of a group |
-| `window button[name='OK']`     | Button named "OK" anywhere inside a window |
-| `button:nth(2)`                | The 2nd button match             |
+| Pattern                                    | Meaning                          |
+| ------------------------------------------ | -------------------------------- |
+| `button`                                   | Elements with role `Button`      |
+| `button[name='OK']`                        | Button named exactly "OK"        |
+| `textfield[name^='Search']`                | Text field whose name starts with "Search" |
+| `textfield[name*='email']`                 | Text field whose name contains "email" |
+| `group > button`                           | Buttons that are direct children of a group |
+| `window button[name='OK']`                 | Button named "OK" anywhere inside a window |
+| `button:nth(2)`                            | The 2nd button match             |
+| `button[name='All Clear'], button[name='Clear']` | Either button — see *Selector groups* below |
+
+### Selector groups (alternation)
+
+A top-level comma separates *alternation clauses*: the result is the union
+of each clause's matches, deduplicated by element identity and returned in
+document order — the same semantics CSS uses for selector lists. This is
+useful when the label of an element changes with state and you want one
+locator that handles every variant:
+
+```python
+# macOS Calculator's leftmost button is "All Clear" when the display is 0
+# and "Clear" once you've typed anything — match either.
+app.locator("button[name='All Clear'], button[name='Clear']").press()
+```
+
+Each clause is parsed independently, so combinators apply per clause:
+`window button, dialog button` reads as "(window > > button) or (dialog > >
+button)", not as a stray comma inside one selector. Chained
+[`descendant()`](/api/rust/) and [`child()`](/api/rust/) calls on a group
+locator distribute over every clause:
+
+```python
+# Equivalent to: "toolbar button, dialog button"
+app.locator("toolbar, dialog").descendant("button")
+```
+
+Commas inside quoted attribute values (`[name='a,b']`) are not separators.
 
 ## Next steps
 

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -31,7 +31,7 @@ pub use locator::Locator;
 pub use provider::Provider;
 pub use role::{unknown_role, Role};
 pub use screenshot::{Screenshot, ScreenshotProvider};
-pub use selector::Selector;
+pub use selector::{Selector, SelectorGroup};
 
 /// Maximum tree traversal depth for providers. Prevents stack overflow from
 /// circular accessibility trees (e.g. Qt/PySide6 apps where the application

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -5,7 +5,7 @@ use crate::element::{Element, ElementData};
 use crate::error::{Error, Result};
 use crate::event::ElementState;
 use crate::provider::Provider;
-use crate::selector::Selector;
+use crate::selector::{chain_combinator, SelectorGroup};
 
 /// A lazy element descriptor that re-resolves against a fresh accessibility
 /// tree on every operation.
@@ -77,18 +77,22 @@ impl Locator {
 
     /// Return a new Locator scoped to a direct child matching `child_selector`.
     ///
-    /// Appends ` > {child_selector}` to the current selector.
+    /// Appends ` > {child_selector}` to the current selector. If either side
+    /// is a comma-separated selector group, the combinator distributes over
+    /// every clause: e.g. `"a, b".child("c") => "a > c, b > c"`.
     pub fn child(mut self, child_selector: &str) -> Self {
-        self.selector = format!("{} > {}", self.selector, child_selector);
+        self.selector = chain_combinator(&self.selector, " > ", child_selector);
         self.nth = None;
         self
     }
 
     /// Return a new Locator scoped to a descendant matching `desc_selector`.
     ///
-    /// Appends ` {desc_selector}` to the current selector.
+    /// Appends ` {desc_selector}` to the current selector. If either side is
+    /// a comma-separated selector group, the combinator distributes over
+    /// every clause: e.g. `"a, b".descendant("c") => "a c, b c"`.
     pub fn descendant(mut self, desc_selector: &str) -> Self {
-        self.selector = format!("{} {}", self.selector, desc_selector);
+        self.selector = chain_combinator(&self.selector, " ", desc_selector);
         self.nth = None;
         self
     }
@@ -120,14 +124,19 @@ impl Locator {
 
     /// Resolve the selector to a single ElementData.
     fn resolve_data(&self) -> Result<ElementData> {
-        let selector = Selector::parse(&self.selector)?;
-        let matches = self.provider.find_elements(
-            self.root.as_ref(),
-            &selector,
-            // Fetch enough to satisfy nth
-            Some(self.nth.unwrap_or(0) + 1),
-            None,
-        )?;
+        let group = SelectorGroup::parse(&self.selector)?;
+        // For multi-clause groups we can't safely truncate at the provider
+        // call to `nth+1` — a low-priority clause's match might come
+        // *before* a high-priority clause's in document order, so we need
+        // the full union to apply `nth` correctly.
+        let provider_limit = if group.is_single() {
+            Some(self.nth.unwrap_or(0) + 1)
+        } else {
+            None
+        };
+        let matches =
+            self.provider
+                .find_elements_group(self.root.as_ref(), &group, provider_limit, None)?;
         let idx = self.nth.unwrap_or(0);
         matches
             .into_iter()
@@ -150,10 +159,10 @@ impl Locator {
 
     /// Count matching elements.
     pub fn count(&self) -> Result<usize> {
-        let selector = Selector::parse(&self.selector)?;
+        let group = SelectorGroup::parse(&self.selector)?;
         let matches = self
             .provider
-            .find_elements(self.root.as_ref(), &selector, None, None)?;
+            .find_elements_group(self.root.as_ref(), &group, None, None)?;
         Ok(matches.len())
     }
 
@@ -165,10 +174,10 @@ impl Locator {
 
     /// Get all matching elements.
     pub fn elements(&self) -> Result<Vec<Element>> {
-        let selector = Selector::parse(&self.selector)?;
+        let group = SelectorGroup::parse(&self.selector)?;
         let matches = self
             .provider
-            .find_elements(self.root.as_ref(), &selector, None, None)?;
+            .find_elements_group(self.root.as_ref(), &group, None, None)?;
         Ok(matches
             .into_iter()
             .map(|d| Element::new(d, Arc::clone(&self.provider)))
@@ -402,5 +411,139 @@ impl Locator {
 
             std::thread::sleep(poll_interval);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end tests for [`Locator`] against the in-memory mock provider.
+    //!
+    //! These focus on the selector-group (comma alternation) behaviour:
+    //! - union, dedup, document order across clauses;
+    //! - `count()`, `elements()`, `nth()` and `element()` against groups;
+    //! - chained `.descendant()` / `.child()` distributing per clause.
+    //!
+    //! The mock tree topology is documented on [`crate::mock`].
+
+    use super::*;
+    use crate::mock::build_provider;
+
+    fn root_locator(selector: &str) -> Locator {
+        let provider = build_provider();
+        let provider_dyn: Arc<dyn Provider> = provider;
+        Locator::new(provider_dyn, None, selector)
+    }
+
+    fn names(elements: &[Element]) -> Vec<String> {
+        elements
+            .iter()
+            .map(|e| e.data().name.clone().unwrap_or_default())
+            .collect()
+    }
+
+    #[test]
+    fn group_count_returns_union_size_across_clauses() {
+        // Two non-overlapping clauses; count is the sum.
+        let loc = root_locator("check_box, slider");
+        assert_eq!(loc.count().unwrap(), 2);
+    }
+
+    #[test]
+    fn group_count_dedups_overlapping_clauses() {
+        // `button` matches "Back" and "Forward"; `[name="Back"]` overlaps
+        // with "Back". The union must dedupe to 2 unique elements.
+        let loc = root_locator(r#"button, [name="Back"]"#);
+        assert_eq!(loc.count().unwrap(), 2);
+    }
+
+    #[test]
+    fn group_elements_returned_in_document_order() {
+        // Mock tree DFS order through Navigation/Content:
+        //   Back, Forward (toolbar) → Search (text_field) → ... → Item 2.
+        // The result of `button, text_field` must interleave by document
+        // position, not group by clause.
+        let loc = root_locator("button, text_field");
+        let names = names(&loc.elements().unwrap());
+        assert_eq!(names, vec!["Back", "Forward", "Search"]);
+    }
+
+    #[test]
+    fn group_element_returns_first_match_in_document_order() {
+        // `text_field, button` would naively return Search first (the first
+        // text_field clause matches first by clause). Document order makes
+        // "Back" win.
+        let loc = root_locator("text_field, button");
+        let el = loc.element().expect("element must resolve");
+        assert_eq!(el.data().name.as_deref(), Some("Back"));
+    }
+
+    #[test]
+    fn group_nth_picks_across_full_union() {
+        // `.nth(2)` on the document-ordered union [Back, Forward, Search]
+        // must be "Forward", not the 2nd element of any single clause.
+        let loc = root_locator("button, text_field").nth(2);
+        let el = loc.element().unwrap();
+        assert_eq!(el.data().name.as_deref(), Some("Forward"));
+    }
+
+    #[test]
+    fn group_single_clause_behaves_identically() {
+        // Sanity: no-comma selectors are unaffected by SelectorGroup parsing.
+        let single = root_locator("button");
+        assert_eq!(single.count().unwrap(), 2);
+        assert_eq!(names(&single.elements().unwrap()), vec!["Back", "Forward"],);
+    }
+
+    #[test]
+    fn descendant_distributes_over_clauses() {
+        // `.descendant("button")` on a group of (toolbar, group) parents
+        // must apply to *both* parents. Direct child buttons exist only
+        // under "toolbar"; if distribution failed, we'd miss them. Inverse
+        // case is harder to construct in this fixture, but we verify the
+        // generated string round-trips and matches buttons under each
+        // clause's subtree.
+        let loc = root_locator("toolbar, group").descendant("button");
+        // After chaining, the stored selector must distribute per clause:
+        assert_eq!(loc.selector(), "toolbar button, group button");
+        // And resolve to the two buttons (both under toolbar; the group
+        // subtree has no buttons in this fixture).
+        let names = names(&loc.elements().unwrap());
+        assert_eq!(names, vec!["Back", "Forward"]);
+    }
+
+    #[test]
+    fn child_distributes_over_clauses() {
+        // `.child("button")` on a (toolbar, group) parent group should
+        // distribute the `>` combinator over each clause.
+        let loc = root_locator("toolbar, group").child("button");
+        assert_eq!(loc.selector(), "toolbar > button, group > button");
+        let names = names(&loc.elements().unwrap());
+        assert_eq!(names, vec!["Back", "Forward"]);
+    }
+
+    #[test]
+    fn descendant_after_group_then_another_group_cross_products() {
+        // Repeated chained navigation keeps distributing — and a group
+        // suffix multiplies clauses (cross product). Verify the stored
+        // selector form is what we expect; semantic resolution is covered
+        // by the other tests.
+        let loc = root_locator("toolbar, group").descendant("button, text_field");
+        assert_eq!(
+            loc.selector(),
+            "toolbar button, toolbar text_field, group button, group text_field",
+        );
+    }
+
+    #[test]
+    fn group_exists_true_when_any_clause_matches() {
+        // First clause matches nothing, second matches; existence is union.
+        let loc = root_locator(r#"button[name="Nope"], slider"#);
+        assert!(loc.exists().unwrap());
+    }
+
+    #[test]
+    fn group_exists_false_when_no_clause_matches() {
+        let loc = root_locator(r#"button[name="Nope"], text_field[name="AlsoNope"]"#);
+        assert!(!loc.exists().unwrap());
     }
 }

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -1,7 +1,7 @@
 use crate::element::ElementData;
 use crate::error::Result;
 use crate::event_provider::Subscription;
-use crate::selector::{matches_simple, Combinator, Selector, SelectorSegment};
+use crate::selector::{matches_simple, Combinator, Selector, SelectorGroup, SelectorSegment};
 
 /// Platform backend trait for accessibility tree access.
 ///
@@ -52,6 +52,40 @@ pub trait Provider: Send + Sync {
             |el| self.get_children(el),
             root,
             selector,
+            limit,
+            max_depth,
+        )
+    }
+
+    /// Search for elements matching any clause of a comma-separated selector
+    /// group.
+    ///
+    /// Forwards to [`find_elements`](Self::find_elements) once per clause and
+    /// merges results into the union, deduplicated by element identity and
+    /// returned in document order. Single-clause groups short-circuit to a
+    /// straight `find_elements` call, so providers that override the
+    /// optimized single-clause path keep their fast path.
+    fn find_elements_group(
+        &self,
+        root: Option<&ElementData>,
+        group: &SelectorGroup,
+        limit: Option<usize>,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ElementData>> {
+        if group.clauses.len() == 1 {
+            return self.find_elements(root, &group.clauses[0], limit, max_depth);
+        }
+        // Each clause goes through the provider's own (possibly optimized)
+        // `find_elements`. The merge below walks once more via
+        // `get_children` to recover document order across clauses.
+        let mut clause_results = Vec::with_capacity(group.clauses.len());
+        for clause in &group.clauses {
+            clause_results.push(self.find_elements(root, clause, None, max_depth)?);
+        }
+        crate::selector::merge_clause_results_in_document_order(
+            |el| self.get_children(el),
+            root,
+            clause_results,
             limit,
             max_depth,
         )
@@ -210,6 +244,15 @@ impl<T: Provider + ?Sized> Provider for &T {
         max_depth: Option<u32>,
     ) -> Result<Vec<ElementData>> {
         (**self).find_elements(root, selector, limit, max_depth)
+    }
+    fn find_elements_group(
+        &self,
+        root: Option<&ElementData>,
+        group: &SelectorGroup,
+        limit: Option<usize>,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ElementData>> {
+        (**self).find_elements_group(root, group, limit, max_depth)
     }
     fn narrow_multi_segment(
         &self,

--- a/xa11y-core/src/selector.rs
+++ b/xa11y-core/src/selector.rs
@@ -2,6 +2,7 @@
 //!
 //! Grammar:
 //! ```text
+//! group         := selector ("," selector)*
 //! selector      := simple_selector (combinator simple_selector)*
 //! combinator    := " "          // descendant (any depth)
 //!                | " > "       // direct child
@@ -14,8 +15,12 @@
 //! pseudo        := ":nth(" integer ")"
 //! integer       := [1-9][0-9]*
 //! ```
+//!
+//! A top-level comma separates an *alternation group*: the result is the
+//! union of each clause's matches, deduplicated by element identity and
+//! returned in document order. See [`SelectorGroup`].
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::element::{ElementData, Toggled};
 use crate::error::{Error, Result};
@@ -323,6 +328,122 @@ impl Selector {
     }
 }
 
+/// A comma-separated alternation of [`Selector`] clauses.
+///
+/// Mirrors CSS selector lists: matching produces the union of each clause's
+/// matches, deduplicated by element identity and returned in document order.
+/// A group with a single clause behaves identically to that lone selector.
+///
+/// Constructed from a string via [`SelectorGroup::parse`]. Commas inside
+/// quoted attribute values are not treated as separators.
+#[derive(Debug, Clone)]
+pub struct SelectorGroup {
+    /// Selector clauses, in source order.
+    pub clauses: Vec<Selector>,
+}
+
+impl SelectorGroup {
+    /// Parse a (possibly comma-separated) selector string into a group.
+    ///
+    /// Single-clause inputs round-trip exactly as if parsed via
+    /// [`Selector::parse`]; multi-clause inputs are split on top-level commas
+    /// (quoted attribute values are respected).
+    pub fn parse(input: &str) -> Result<Self> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(Error::InvalidSelector {
+                selector: input.to_string(),
+                message: "empty selector".to_string(),
+            });
+        }
+        let parts = split_top_level_commas(trimmed);
+        let mut clauses = Vec::with_capacity(parts.len());
+        for part in parts {
+            let p = part.trim();
+            if p.is_empty() {
+                return Err(Error::InvalidSelector {
+                    selector: input.to_string(),
+                    message: "empty clause in selector group".to_string(),
+                });
+            }
+            clauses.push(Selector::parse(p)?);
+        }
+        // `split_top_level_commas` always returns at least one part, so the
+        // emptiness check above guarantees we have ≥1 clause here.
+        Ok(SelectorGroup { clauses })
+    }
+
+    /// True if the group has exactly one clause (no top-level comma).
+    pub fn is_single(&self) -> bool {
+        self.clauses.len() == 1
+    }
+}
+
+/// Split a selector string on top-level commas.
+///
+/// Commas inside quoted attribute values (single or double quotes) are
+/// treated as content, not separators. Returns one or more parts; whitespace
+/// trimming and emptiness checks are the caller's responsibility.
+///
+/// An unterminated quoted string is tolerated here — it falls through as one
+/// trailing part, and the eventual `Selector::parse` call will surface the
+/// real "unterminated string" error with the original input.
+pub fn split_top_level_commas(input: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    for ch in input.chars() {
+        match quote {
+            Some(q) if ch == q => {
+                quote = None;
+                current.push(ch);
+            }
+            Some(_) => {
+                current.push(ch);
+            }
+            None => {
+                if ch == '\'' || ch == '"' {
+                    quote = Some(ch);
+                    current.push(ch);
+                } else if ch == ',' {
+                    parts.push(std::mem::take(&mut current));
+                } else {
+                    current.push(ch);
+                }
+            }
+        }
+    }
+    parts.push(current);
+    parts
+}
+
+/// Distribute a `combinator + suffix` over each clause of `existing`.
+///
+/// Used by `Locator::descendant` / `Locator::child` so that chained
+/// navigation on a group locator applies to every clause:
+///
+/// ```text
+/// chain_combinator("a, b", " ", "c")          => "a c, b c"
+/// chain_combinator("x", " > ", "a, b")        => "x > a, x > b"
+/// chain_combinator("x, y", " > ", "a, b")     => "x > a, x > b, y > a, y > b"
+/// ```
+///
+/// Each clause is trimmed before being concatenated; the produced string is
+/// always re-parseable as a [`SelectorGroup`] when both inputs were.
+pub fn chain_combinator(existing: &str, combinator: &str, suffix: &str) -> String {
+    let existing_parts = split_top_level_commas(existing);
+    let suffix_parts = split_top_level_commas(suffix);
+    let mut out = Vec::with_capacity(existing_parts.len() * suffix_parts.len());
+    for ep in &existing_parts {
+        let ep = ep.trim();
+        for sp in &suffix_parts {
+            let sp = sp.trim();
+            out.push(format!("{}{}{}", ep, combinator, sp));
+        }
+    }
+    out.join(", ")
+}
+
 /// Check if an element matches a simple selector (no combinators).
 pub fn matches_simple(element: &ElementData, simple: &SimpleSelector) -> bool {
     // Check role
@@ -574,6 +695,151 @@ pub fn find_elements_in_tree(
     }
 
     Ok(candidates)
+}
+
+/// Multi-clause variant of [`find_elements_in_tree`].
+///
+/// Runs each clause in `group` independently, then returns the **union** of
+/// matches in **document order**, deduplicated by `ElementData.handle`. A
+/// single-clause group is forwarded straight to `find_elements_in_tree` with
+/// no extra traversal.
+///
+/// For multi-clause groups this performs one traversal per clause plus a
+/// second pass over the tree to recover document order (each clause's own
+/// result list is in DFS order, but DFS positions across clauses aren't
+/// comparable without a re-walk). The second walk short-circuits as soon as
+/// `limit` is hit or the entire union has been emitted.
+pub fn find_elements_in_tree_group<F>(
+    get_children_fn: F,
+    root: Option<&ElementData>,
+    group: &SelectorGroup,
+    limit: Option<usize>,
+    max_depth: Option<u32>,
+) -> Result<Vec<ElementData>>
+where
+    F: Fn(Option<&ElementData>) -> Result<Vec<ElementData>>,
+{
+    if group.clauses.len() == 1 {
+        return find_elements_in_tree(get_children_fn, root, &group.clauses[0], limit, max_depth);
+    }
+
+    // Run each clause independently. Re-borrow the closure for each inner
+    // call so the outer `get_children_fn` can still be used for the
+    // document-order merge below — `&F` implements `Fn` when `F` does, so
+    // we hand a shared borrow to `find_elements_in_tree` without moving the
+    // value.
+    let f = &get_children_fn;
+    let mut clause_results = Vec::with_capacity(group.clauses.len());
+    for clause in &group.clauses {
+        clause_results.push(find_elements_in_tree(f, root, clause, None, max_depth)?);
+    }
+    merge_clause_results_in_document_order(get_children_fn, root, clause_results, limit, max_depth)
+}
+
+/// Merge per-clause result lists into the union, deduped by element
+/// identity, in document order.
+///
+/// Each input vec is one clause's matches (in any order — typically DFS
+/// from that clause's own traversal). The merge walks the tree once via
+/// `get_children_fn`, emitting any element whose handle appears in the
+/// union, stopping early when `limit` is satisfied or every union member
+/// has been emitted.
+///
+/// `ElementData` snapshots are taken from the clause results (not the
+/// traversal), so the returned elements carry the attribute state the
+/// matcher actually saw — important if attributes drift between the
+/// per-clause walk and the merge walk.
+pub fn merge_clause_results_in_document_order<F>(
+    get_children_fn: F,
+    root: Option<&ElementData>,
+    clause_results: Vec<Vec<ElementData>>,
+    limit: Option<usize>,
+    max_depth: Option<u32>,
+) -> Result<Vec<ElementData>>
+where
+    F: Fn(Option<&ElementData>) -> Result<Vec<ElementData>>,
+{
+    let mut snapshots: HashMap<u64, ElementData> = HashMap::new();
+    for results in clause_results {
+        for e in results {
+            snapshots.entry(e.handle).or_insert(e);
+        }
+    }
+    if snapshots.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let max_depth = max_depth.unwrap_or(crate::MAX_TREE_DEPTH);
+    let mut session = DocOrderEmit {
+        snapshots: &snapshots,
+        emitted: HashSet::new(),
+        out: Vec::with_capacity(snapshots.len().min(limit.unwrap_or(usize::MAX))),
+        max_depth,
+        limit,
+    };
+    emit_in_document_order(&get_children_fn, root, &mut session, 0)?;
+    Ok(session.out)
+}
+
+/// Per-call state bundled together so [`emit_in_document_order`] stays
+/// under the `too_many_arguments` clippy threshold and so the read-only
+/// (`snapshots`, `max_depth`, `limit`) and write (`emitted`, `out`) halves
+/// of the walk live in one place.
+struct DocOrderEmit<'a> {
+    snapshots: &'a HashMap<u64, ElementData>,
+    emitted: HashSet<u64>,
+    out: Vec<ElementData>,
+    max_depth: u32,
+    limit: Option<usize>,
+}
+
+impl DocOrderEmit<'_> {
+    /// True if we've hit `limit` (when set).
+    fn at_limit(&self) -> bool {
+        self.limit.is_some_and(|l| self.out.len() >= l)
+    }
+}
+
+/// DFS-walk the tree and emit each handle in `session.snapshots` exactly
+/// once, in document order, stopping once `limit` is hit or every handle
+/// has been emitted.
+fn emit_in_document_order(
+    get_children_fn: &impl Fn(Option<&ElementData>) -> Result<Vec<ElementData>>,
+    root: Option<&ElementData>,
+    session: &mut DocOrderEmit<'_>,
+    depth: u32,
+) -> Result<()> {
+    if depth > session.max_depth {
+        return Ok(());
+    }
+    if session.at_limit() {
+        return Ok(());
+    }
+    if session.emitted.len() == session.snapshots.len() {
+        // Every winning handle has been emitted — no need to keep walking.
+        return Ok(());
+    }
+    let children = get_children_fn(root)?;
+    for child in children {
+        if let Some(snap) = session.snapshots.get(&child.handle) {
+            // A handle that appears multiple times in the tree (rare, but
+            // some Qt providers expose the same node via different parents)
+            // is still emitted only once — `emitted` tracks that.
+            if session.emitted.insert(child.handle) {
+                // Prefer the snapshot captured by clause matching — it
+                // carries the attribute state the matcher actually saw.
+                session.out.push(snap.clone());
+                if session.at_limit() {
+                    return Ok(());
+                }
+            }
+        }
+        emit_in_document_order(get_children_fn, Some(&child), session, depth + 1)?;
+        if session.at_limit() {
+            return Ok(());
+        }
+    }
+    Ok(())
 }
 
 /// Apply a `:nth(N)` (1-based) filter to a candidate list, collapsing it to
@@ -1239,5 +1505,386 @@ mod tests {
 
         el.states.checked = None;
         assert!(!matches_simple(&el, &sel.segments[0].simple));
+    }
+
+    // ── SelectorGroup / comma alternation ───────────────────────────────────
+
+    #[test]
+    fn split_top_level_commas_basic() {
+        assert_eq!(split_top_level_commas("a"), vec!["a".to_string()]);
+        assert_eq!(
+            split_top_level_commas("a,b"),
+            vec!["a".to_string(), "b".to_string()],
+        );
+        assert_eq!(
+            split_top_level_commas("a , b"),
+            vec!["a ".to_string(), " b".to_string()],
+        );
+    }
+
+    #[test]
+    fn split_top_level_commas_ignores_quoted_commas() {
+        // Commas inside quoted attribute values must NOT split the group.
+        assert_eq!(
+            split_top_level_commas(r#"[name="a,b"]"#),
+            vec![r#"[name="a,b"]"#.to_string()],
+        );
+        assert_eq!(
+            split_top_level_commas(r#"[name='a,b'], button"#),
+            vec![r#"[name='a,b']"#.to_string(), " button".to_string()],
+        );
+    }
+
+    #[test]
+    fn parse_group_single_clause_matches_selector_parse() {
+        // Single-clause groups must produce one clause whose AST equals what
+        // `Selector::parse` returns. This is the "existing single-pattern
+        // selectors keep working unchanged" guarantee.
+        let group = SelectorGroup::parse("button").unwrap();
+        assert_eq!(group.clauses.len(), 1);
+        assert!(group.is_single());
+        assert!(matches!(
+            group.clauses[0].segments[0].simple.role,
+            Some(RoleMatch::Normalized(Role::Button))
+        ));
+    }
+
+    #[test]
+    fn parse_group_two_clauses() {
+        let group = SelectorGroup::parse(r#"button[name="All Clear"], button[name="Clear"]"#)
+            .expect("group parses");
+        assert_eq!(group.clauses.len(), 2);
+        assert!(!group.is_single());
+        assert_eq!(
+            group.clauses[0].segments[0].simple.filters[0].value,
+            "All Clear"
+        );
+        assert_eq!(
+            group.clauses[1].segments[0].simple.filters[0].value,
+            "Clear"
+        );
+    }
+
+    #[test]
+    fn parse_group_whitespace_tolerance() {
+        // Both `a,b` and `a , b` (and the asymmetric variants) must parse to
+        // the same shape.
+        for input in &["a,b", "a ,b", "a, b", "a , b", "a  ,  b"] {
+            let group = SelectorGroup::parse(input).expect("parses");
+            assert_eq!(group.clauses.len(), 2, "input: {input:?}");
+            assert!(matches!(
+                group.clauses[0].segments[0].simple.role,
+                Some(RoleMatch::Platform(ref s)) if s == "a"
+            ));
+            assert!(matches!(
+                group.clauses[1].segments[0].simple.role,
+                Some(RoleMatch::Platform(ref s)) if s == "b"
+            ));
+        }
+    }
+
+    #[test]
+    fn parse_group_combinator_per_clause() {
+        // `window button, dialog button` should parse as two independent
+        // selectors, each with its own combinator chain — NOT as one selector
+        // containing a stray comma.
+        let group = SelectorGroup::parse("window button, dialog button").unwrap();
+        assert_eq!(group.clauses.len(), 2);
+        assert_eq!(group.clauses[0].segments.len(), 2);
+        assert_eq!(group.clauses[1].segments.len(), 2);
+        assert!(matches!(
+            group.clauses[0].segments[0].simple.role,
+            Some(RoleMatch::Normalized(Role::Window))
+        ));
+        assert!(matches!(
+            group.clauses[1].segments[0].simple.role,
+            Some(RoleMatch::Normalized(Role::Dialog))
+        ));
+        assert_eq!(
+            group.clauses[0].segments[1].combinator,
+            Combinator::Descendant
+        );
+        assert_eq!(
+            group.clauses[1].segments[1].combinator,
+            Combinator::Descendant
+        );
+    }
+
+    #[test]
+    fn parse_group_mixed_attribute_clauses() {
+        // Different attribute filters per clause must parse independently —
+        // makes sure the `[...]` machinery doesn't carry state across commas.
+        let group =
+            SelectorGroup::parse(r#"button[name="OK"], text_field[name*="search"]"#).unwrap();
+        assert_eq!(group.clauses.len(), 2);
+        assert_eq!(
+            group.clauses[0].segments[0].simple.filters[0].op,
+            MatchOp::Exact
+        );
+        assert_eq!(
+            group.clauses[1].segments[0].simple.filters[0].op,
+            MatchOp::Contains
+        );
+    }
+
+    #[test]
+    fn parse_group_quoted_comma_kept_in_value() {
+        // `[name="a,b"]` must reach the matcher with its comma intact.
+        let group = SelectorGroup::parse(r#"[name="a,b"]"#).unwrap();
+        assert_eq!(group.clauses.len(), 1);
+        assert_eq!(group.clauses[0].segments[0].simple.filters[0].value, "a,b");
+    }
+
+    #[test]
+    fn parse_group_large_count() {
+        // Eight clauses: covers "large group counts" from the issue without
+        // turning the test into a stress benchmark.
+        let input = (1..=8)
+            .map(|i| format!(r#"button[name="b{i}"]"#))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let group = SelectorGroup::parse(&input).unwrap();
+        assert_eq!(group.clauses.len(), 8);
+        for (i, clause) in group.clauses.iter().enumerate() {
+            assert_eq!(
+                clause.segments[0].simple.filters[0].value,
+                format!("b{}", i + 1)
+            );
+        }
+    }
+
+    #[test]
+    fn parse_group_empty_error() {
+        // Trailing, leading, double, and whitespace-only commas all surface
+        // as "empty clause" rather than silently producing fewer clauses.
+        for input in &[",a", "a,", ",,", "a,,b", "  ,  ", " , "] {
+            assert!(
+                SelectorGroup::parse(input).is_err(),
+                "expected parse error for {input:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_group_propagates_clause_errors() {
+        // A malformed clause must surface as an Err, not silently drop.
+        assert!(SelectorGroup::parse("button, :nth(0)").is_err());
+        assert!(SelectorGroup::parse("button, foo[unterminated=").is_err());
+    }
+
+    #[test]
+    fn chain_combinator_distributes_left_side() {
+        assert_eq!(chain_combinator("a, b", " ", "c"), "a c, b c");
+        assert_eq!(chain_combinator("a, b", " > ", "c"), "a > c, b > c");
+        assert_eq!(chain_combinator("a", " ", "c"), "a c");
+    }
+
+    #[test]
+    fn chain_combinator_cross_products_groups() {
+        // Both sides are groups → cross product, keeping `a, b → x, y` in
+        // left-major order.
+        assert_eq!(chain_combinator("a, b", " ", "x, y"), "a x, a y, b x, b y",);
+    }
+
+    #[test]
+    fn chain_combinator_ignores_commas_in_quotes() {
+        // Quoted commas on either side must not cause a split.
+        assert_eq!(
+            chain_combinator(r#"[name="a,b"]"#, " ", "c"),
+            r#"[name="a,b"] c"#,
+        );
+        assert_eq!(
+            chain_combinator("p", " > ", r#"[name="a,b"]"#),
+            r#"p > [name="a,b"]"#,
+        );
+    }
+
+    // ── find_elements_in_tree_group ────────────────────────────────────────
+
+    /// Mini tree fixture for group-matching tests.
+    ///
+    /// Shape (DFS order, names in []):
+    /// ```text
+    /// root (application)
+    ///   ├── toolbar [T]
+    ///   │   ├── button [Clear]
+    ///   │   ├── text_field [Search]
+    ///   │   └── button [Save]
+    ///   └── dialog [D]
+    ///       ├── button [Cancel]
+    ///       └── text_field [Password]
+    /// ```
+    struct GroupRow {
+        handle: u64,
+        role: Role,
+        name: &'static str,
+        parent: Option<u64>,
+    }
+
+    fn group_fixture() -> Vec<GroupRow> {
+        vec![
+            GroupRow {
+                handle: 0,
+                role: Role::Application,
+                name: "root",
+                parent: None,
+            },
+            GroupRow {
+                handle: 1,
+                role: Role::Toolbar,
+                name: "T",
+                parent: Some(0),
+            },
+            GroupRow {
+                handle: 2,
+                role: Role::Button,
+                name: "Clear",
+                parent: Some(1),
+            },
+            GroupRow {
+                handle: 3,
+                role: Role::TextField,
+                name: "Search",
+                parent: Some(1),
+            },
+            GroupRow {
+                handle: 4,
+                role: Role::Button,
+                name: "Save",
+                parent: Some(1),
+            },
+            GroupRow {
+                handle: 5,
+                role: Role::Dialog,
+                name: "D",
+                parent: Some(0),
+            },
+            GroupRow {
+                handle: 6,
+                role: Role::Button,
+                name: "Cancel",
+                parent: Some(5),
+            },
+            GroupRow {
+                handle: 7,
+                role: Role::TextField,
+                name: "Password",
+                parent: Some(5),
+            },
+        ]
+    }
+
+    fn group_get_children(
+        tree: &[GroupRow],
+    ) -> impl Fn(Option<&ElementData>) -> Result<Vec<ElementData>> + '_ {
+        let make_data = |row: &GroupRow| ElementData {
+            role: row.role,
+            name: Some(row.name.to_string()),
+            value: None,
+            description: None,
+            bounds: None,
+            actions: vec![],
+            states: crate::element::StateSet::default(),
+            numeric_value: None,
+            min_value: None,
+            max_value: None,
+            stable_id: None,
+            pid: Some(1),
+            raw: std::collections::HashMap::new(),
+            handle: row.handle,
+        };
+        move |parent: Option<&ElementData>| -> Result<Vec<ElementData>> {
+            let parent_handle = parent.map(|e| e.handle);
+            Ok(tree
+                .iter()
+                .filter(|row| row.parent == parent_handle)
+                .map(make_data)
+                .collect())
+        }
+    }
+
+    fn names(elements: &[ElementData]) -> Vec<String> {
+        elements
+            .iter()
+            .map(|e| e.name.clone().unwrap_or_default())
+            .collect()
+    }
+
+    #[test]
+    fn group_match_union_in_document_order() {
+        let tree = group_fixture();
+        let group = SelectorGroup::parse("button, text_field").unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        // Document order is DFS: Clear, Search, Save, Cancel, Password.
+        // NOT [all buttons, then all text_fields] — that would be the naive
+        // concat order this test guards against.
+        assert_eq!(
+            names(&results),
+            vec!["Clear", "Search", "Save", "Cancel", "Password"],
+        );
+    }
+
+    #[test]
+    fn group_match_dedup_overlapping_clauses() {
+        // Both clauses match the same element (`Clear`). The union must
+        // include it exactly once.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse(r#"button[name="Clear"], button[name*="lea"]"#).unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        assert_eq!(names(&results), vec!["Clear"]);
+    }
+
+    #[test]
+    fn group_match_combinator_per_clause() {
+        // `toolbar button, dialog button` — each clause has its own
+        // combinator chain. Result: buttons under toolbar OR under dialog,
+        // in document order.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse("toolbar button, dialog button").unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        assert_eq!(names(&results), vec!["Clear", "Save", "Cancel"]);
+    }
+
+    #[test]
+    fn group_match_limit_truncates_in_document_order() {
+        let tree = group_fixture();
+        let group = SelectorGroup::parse("button, text_field").unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, Some(2), None)
+                .unwrap();
+        assert_eq!(names(&results), vec!["Clear", "Search"]);
+    }
+
+    #[test]
+    fn group_match_single_clause_matches_single_path() {
+        // A 1-clause group must produce identical output to find_elements_in_tree.
+        let tree = group_fixture();
+        let sel_single = Selector::parse("button").unwrap();
+        let group_single = SelectorGroup::parse("button").unwrap();
+
+        let via_single =
+            find_elements_in_tree(group_get_children(&tree), None, &sel_single, None, None)
+                .unwrap();
+        let via_group =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group_single, None, None)
+                .unwrap();
+        assert_eq!(names(&via_single), names(&via_group));
+    }
+
+    #[test]
+    fn group_match_no_matches_returns_empty() {
+        // None of the clauses match — result is empty, not an error.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse(r#"button[name="Nope"], slider"#).unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        assert!(results.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Closes #191. Adds CSS-style selector lists to the selector grammar:
`button[name='All Clear'], button[name='Clear']` matches either button,
with the union deduped by element identity and returned in document order.

- New `SelectorGroup` type wraps a `Vec<Selector>`; `Selector` and the existing single-pattern grammar are unchanged.
- New default `Provider::find_elements_group` runs each clause through the provider's own (possibly optimized) `find_elements` and merges results via a single document-order tree walk. Single-clause groups short-circuit to the existing fast path.
- `Locator::child` / `Locator::descendant` distribute the chained combinator over every clause on the left side, and cross-product when both sides are groups.
- Commas inside quoted attribute values (`[name='a,b']`) are not separators.
- `quick-start.mdx` and `overview.mdx` get a new row + section covering the syntax and chaining rules.

## Test plan

- [x] `cargo test -p xa11y-core --lib` — 85 passing, including 24 new tests covering parser, matcher, and Locator-level behaviour
- [x] `cargo clippy -p xa11y-core --all-targets` clean
- [x] `cargo xtask fmt --check` clean
- [ ] CI: full workspace lint, unit, Python, JS

### New tests added

Parser (selector.rs):
- `split_top_level_commas_basic` / `..._ignores_quoted_commas`
- `parse_group_{single_clause_matches_selector_parse, two_clauses, whitespace_tolerance, combinator_per_clause, mixed_attribute_clauses, quoted_comma_kept_in_value, large_count, empty_error, propagates_clause_errors}`
- `chain_combinator_{distributes_left_side, cross_products_groups, ignores_commas_in_quotes}`

Matching (selector.rs):
- `group_match_{union_in_document_order, dedup_overlapping_clauses, combinator_per_clause, limit_truncates_in_document_order, single_clause_matches_single_path, no_matches_returns_empty}`

End-to-end Locator (locator.rs, via mock provider):
- `group_count_{returns_union_size_across_clauses, dedups_overlapping_clauses}`
- `group_elements_returned_in_document_order`
- `group_element_returns_first_match_in_document_order`
- `group_nth_picks_across_full_union`
- `group_single_clause_behaves_identically`
- `descendant_distributes_over_clauses` / `child_distributes_over_clauses`
- `descendant_after_group_then_another_group_cross_products`
- `group_exists_{true_when_any_clause_matches, false_when_no_clause_matches}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)