### PR TITLE
feat(app, locator): add tree(), dump(), as_element() across bindings

### DIFF
--- a/docs/site/src/content/docs/guides/cli.mdx
+++ b/docs/site/src/content/docs/guides/cli.mdx
@@ -52,6 +52,8 @@ application "Calculator" [enabled visible] bounds=(0,0,400,600)
 
 This is the fastest way to understand an app's structure. Every element shows its role, name, value, states, bounds, and available actions.
 
+The same output is available in-code via `Element.dump()` (and `Element.tree()` for a structured snapshot) in every language binding. See the [Quick Start](/guides/quick-start/#discover-the-tree-first) for examples.
+
 ### `xa11y find`
 
 Find elements matching a CSS-like selector.

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -43,6 +43,67 @@ After changing permissions, restart your terminal for them to take effect. `App:
 
 **Windows** — No special permissions needed.
 
+## Discover the tree first
+
+Before writing selectors, dump the app's accessibility tree so you know the exact roles and names to target. Accessibility labels are often different from what's painted on screen, so don't guess.
+
+The fastest way is the CLI — it dumps the whole app in one command and works the same regardless of language:
+
+```bash
+xa11y apps                      # list running apps with PIDs
+xa11y tree --app Calculator     # full indented tree
+xa11y find "button" --app Calculator   # try a selector before using it
+```
+
+See the [CLI guide](/guides/cli/) for the full command reference.
+
+From code, `dump()` and `tree()` are available on `App`, `Locator`, and `Element` in every binding:
+
+<Tabs syncKey="lang">
+  <TabItem label="Python">
+    ```python
+    import xa11y
+
+    calc = xa11y.App.by_name("Calculator")
+
+    print(calc.dump())              # full indented tree, rooted at the app
+    print(calc.dump(max_depth=2))   # limit depth
+    snapshot = calc.tree()          # same data as a nested dict
+
+    # Locators and elements also support dump() / tree()
+    print(calc.locator("group[name='Keypad']").dump())
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use xa11y::*;
+
+    let calc = App::by_name("Calculator")?;
+
+    println!("{}", calc.dump(None)?);            // full indented tree
+    println!("{}", calc.dump(Some(2))?);         // limit depth
+    let snapshot = calc.tree(None)?;             // same data as a TreeNode
+
+    // Locators and elements also support dump() / tree()
+    println!("{}", calc.locator("group[name='Keypad']").dump(None)?);
+    ```
+  </TabItem>
+  <TabItem label="JavaScript">
+    ```js
+    import { App } from '@crowecawcaw/xa11y';
+
+    const calc = await App.byName('Calculator');
+
+    console.log(await calc.dump());              // full indented tree
+    console.log(await calc.dump(2));             // limit depth
+    const snapshot = await calc.tree();          // same data as a nested object
+
+    // Locators and elements also support dump() / tree()
+    console.log(await calc.locator("group[name='Keypad']").dump());
+    ```
+  </TabItem>
+</Tabs>
+
 ## Example
 
 <Tabs syncKey="lang">

--- a/xa11y-core/src/app.rs
+++ b/xa11y-core/src/app.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::element::{Element, ElementData};
+use crate::element::{Element, ElementData, TreeNode};
 use crate::error::{Error, Result};
 use crate::event_provider::Subscription;
 use crate::locator::Locator;
@@ -222,6 +222,34 @@ impl App {
             .collect())
     }
 
+    /// Capture the application's accessibility tree as a recursive snapshot,
+    /// rooted at the application element.
+    ///
+    /// Equivalent to `self.as_element().tree(max_depth)`. See
+    /// [`Element::tree`] for `max_depth` semantics.
+    pub fn tree(&self, max_depth: Option<usize>) -> Result<TreeNode> {
+        self.as_element().tree(max_depth)
+    }
+
+    /// Render the application's accessibility tree as an indented string,
+    /// rooted at the application element.
+    ///
+    /// The primary inspection helper for figuring out the role/name of every
+    /// element in an app before writing selectors. Equivalent to
+    /// `self.as_element().dump(max_depth)`. See [`Element::dump`] for the
+    /// output format.
+    pub fn dump(&self, max_depth: Option<usize>) -> Result<String> {
+        self.as_element().dump(max_depth)
+    }
+
+    /// Get an [`Element`] handle for the application root.
+    ///
+    /// Useful when you want to use Element-level methods (e.g. `tree`,
+    /// `dump`, `children`) without going through a locator.
+    pub fn as_element(&self) -> Element {
+        Element::new(self.data.clone(), Arc::clone(&self.provider))
+    }
+
     /// Get the provider reference.
     pub fn provider(&self) -> &Arc<dyn Provider> {
         &self.provider
@@ -246,8 +274,69 @@ impl std::fmt::Debug for App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mock::build_provider;
     use crate::selector::{matches_simple, Combinator};
     use serde_json::json;
+
+    fn mock_app() -> App {
+        let provider: Arc<dyn Provider> = build_provider();
+        App::by_name_with(provider, "TestApp").expect("TestApp must exist in mock tree")
+    }
+
+    #[test]
+    fn app_tree_returns_application_root() {
+        let node = mock_app().tree(None).expect("tree must succeed");
+        assert_eq!(node.role, "application");
+        assert_eq!(node.name.as_deref(), Some("TestApp"));
+        assert!(
+            !node.children.is_empty(),
+            "TestApp must have at least one window child"
+        );
+    }
+
+    #[test]
+    fn app_tree_max_depth_zero_has_no_children() {
+        let node = mock_app().tree(Some(0)).expect("tree must succeed");
+        assert_eq!(node.role, "application");
+        assert!(node.children.is_empty());
+    }
+
+    #[test]
+    fn app_tree_max_depth_one_stops_at_direct_children() {
+        let node = mock_app().tree(Some(1)).expect("tree must succeed");
+        assert!(!node.children.is_empty());
+        for child in &node.children {
+            assert!(
+                child.children.is_empty(),
+                "max_depth=1 must stop after direct children"
+            );
+        }
+    }
+
+    #[test]
+    fn app_dump_contains_application_root() {
+        let s = mock_app().dump(None).expect("dump must succeed");
+        assert!(
+            s.contains(r#"application "TestApp""#),
+            "dump output should include the application root: {s}"
+        );
+    }
+
+    #[test]
+    fn app_dump_max_depth_zero_is_one_line() {
+        let s = mock_app().dump(Some(0)).expect("dump must succeed");
+        let non_empty: Vec<&str> = s.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(non_empty.len(), 1, "max_depth=0 should be a single line");
+        assert!(non_empty[0].contains("application"));
+    }
+
+    #[test]
+    fn app_as_element_is_root() {
+        let app = mock_app();
+        let el = app.as_element();
+        assert_eq!(el.data().role, Role::Application);
+        assert_eq!(el.data().name.as_deref(), Some("TestApp"));
+    }
 
     #[test]
     fn role_named_preserves_literal_name_with_special_chars() {

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -184,6 +184,21 @@ impl Locator {
             .collect())
     }
 
+    /// Capture the subtree rooted at the matched element as a recursive
+    /// snapshot. Resolves the selector once (no auto-wait — inspection ops
+    /// should fail fast on selector miss). See [`Element::tree`] for
+    /// `max_depth` semantics.
+    pub fn tree(&self, max_depth: Option<usize>) -> Result<crate::element::TreeNode> {
+        self.element()?.tree(max_depth)
+    }
+
+    /// Render the subtree rooted at the matched element as an indented
+    /// string. Resolves the selector once (no auto-wait). See
+    /// [`Element::dump`] for the output format.
+    pub fn dump(&self, max_depth: Option<usize>) -> Result<String> {
+        self.element()?.dump(max_depth)
+    }
+
     // ── Auto-wait ──────────────────────────────────────────────────
 
     /// Poll until the element is attached, visible, and enabled, returning a
@@ -418,10 +433,12 @@ impl Locator {
 mod tests {
     //! End-to-end tests for [`Locator`] against the in-memory mock provider.
     //!
-    //! These focus on the selector-group (comma alternation) behaviour:
-    //! - union, dedup, document order across clauses;
-    //! - `count()`, `elements()`, `nth()` and `element()` against groups;
-    //! - chained `.descendant()` / `.child()` distributing per clause.
+    //! Covers:
+    //! - selector-group (comma alternation): union, dedup, document order
+    //!   across clauses; `count()`, `elements()`, `nth()`, `element()`;
+    //!   chained `.descendant()` / `.child()` distributing per clause.
+    //! - tree/dump inspection helpers (subtree capture, depth limits,
+    //!   fail-fast on miss).
     //!
     //! The mock tree topology is documented on [`crate::mock`].
 
@@ -545,5 +562,69 @@ mod tests {
     fn group_exists_false_when_no_clause_matches() {
         let loc = root_locator(r#"button[name="Nope"], text_field[name="AlsoNope"]"#);
         assert!(!loc.exists().unwrap());
+    }
+
+    // ── tree() / dump() ─────────────────────────────────────────────
+
+    #[test]
+    fn locator_tree_returns_subtree_rooted_at_match() {
+        let node = root_locator("application")
+            .tree(None)
+            .expect("tree must succeed");
+        assert_eq!(node.role, "application");
+        assert_eq!(node.name.as_deref(), Some("TestApp"));
+        assert!(!node.children.is_empty());
+    }
+
+    #[test]
+    fn locator_tree_respects_max_depth() {
+        let node = root_locator("application")
+            .tree(Some(0))
+            .expect("tree must succeed");
+        assert!(node.children.is_empty(), "max_depth=0 should drop children");
+    }
+
+    #[test]
+    fn locator_dump_renders_selector_subtree() {
+        let s = root_locator("application")
+            .dump(None)
+            .expect("dump must succeed");
+        assert!(
+            s.contains(r#"application "TestApp""#),
+            "dump should render the matched root: {s}"
+        );
+    }
+
+    #[test]
+    fn locator_dump_max_depth_zero_is_one_line() {
+        let s = root_locator("application")
+            .dump(Some(0))
+            .expect("dump must succeed");
+        let non_empty: Vec<&str> = s.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(non_empty.len(), 1);
+    }
+
+    #[test]
+    fn locator_tree_no_match_returns_selector_not_matched() {
+        let err = root_locator(r#"button[name="DoesNotExist"]"#)
+            .tree(None)
+            .expect_err("tree must fail on miss");
+        assert!(
+            matches!(err, Error::SelectorNotMatched { .. }),
+            "expected SelectorNotMatched, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn locator_dump_does_not_auto_wait() {
+        // Locator dump/tree are inspection ops — they must fail fast, not poll.
+        let locator = root_locator(r#"button[name="DoesNotExist"]"#);
+        let start = std::time::Instant::now();
+        let _ = locator.dump(None);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "dump should fail fast, took {elapsed:?}"
+        );
     }
 }

--- a/xa11y-js/__test__/unit/tree.test.js
+++ b/xa11y-js/__test__/unit/tree.test.js
@@ -5,7 +5,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { _makeTestLocator } = require('../../index.js');
+const { _makeTestApp, _makeTestLocator, SelectorNotMatchedError } = require('../../index.js');
 
 function root() {
   return _makeTestLocator();
@@ -13,6 +13,10 @@ function root() {
 
 async function rootElement() {
   return await root().element();
+}
+
+function mockApp() {
+  return _makeTestApp();
 }
 
 // ── Element.tree() ─────────────────────────────────────────────────────────
@@ -85,5 +89,95 @@ test('dump() includes value for nodes that have one', async () => {
   const textField = await root().descendant('text_field').element();
   const text = await textField.dump(0);
   assert.ok(text.includes('value="hello"'));
+});
+
+// ── App.tree() / App.dump() ────────────────────────────────────────────────
+
+test('App.tree() returns the application root', async () => {
+  const node = await mockApp().tree();
+  assert.equal(node.role, 'application');
+  assert.equal(node.name, 'TestApp');
+  assert.ok(node.children.length >= 1);
+});
+
+test('App.tree(0) returns only the application node', async () => {
+  const node = await mockApp().tree(0);
+  assert.equal(node.role, 'application');
+  assert.deepEqual(node.children, []);
+});
+
+test('App.tree(1) stops at direct children', async () => {
+  const node = await mockApp().tree(1);
+  assert.ok(node.children.length >= 1);
+  for (const child of node.children) {
+    assert.deepEqual(child.children, []);
+  }
+});
+
+test('App.dump() returns a string containing the application root', async () => {
+  const text = await mockApp().dump();
+  assert.equal(typeof text, 'string');
+  assert.ok(text.includes('application "TestApp"'));
+});
+
+test('App.dump(0) produces exactly one non-empty line', async () => {
+  const text = await mockApp().dump(0);
+  const lines = text.split('\n').filter((l) => l.trim());
+  assert.equal(lines.length, 1);
+});
+
+test('App.dump() matches Element.dump() on the app root', async () => {
+  const fromApp = await mockApp().dump();
+  const fromElement = await (await rootElement()).dump();
+  assert.equal(fromApp, fromElement);
+});
+
+// ── Locator.tree() / Locator.dump() ────────────────────────────────────────
+
+test('Locator.tree() returns the matched subtree', async () => {
+  const node = await root().tree();
+  assert.equal(node.role, 'application');
+  assert.equal(node.name, 'TestApp');
+});
+
+test('Locator.tree() scopes to the selector', async () => {
+  const node = await root().descendant('toolbar').tree();
+  assert.equal(node.role, 'toolbar');
+  assert.equal(node.children.length, 2);
+});
+
+test('Locator.tree(0) drops children', async () => {
+  const node = await root().descendant('toolbar').tree(0);
+  assert.equal(node.role, 'toolbar');
+  assert.deepEqual(node.children, []);
+});
+
+test('Locator.dump() returns a string of the matched subtree', async () => {
+  const text = await root().descendant('toolbar').dump();
+  assert.equal(typeof text, 'string');
+  assert.ok(text.includes('toolbar'));
+});
+
+test('Locator.dump(0) is one line', async () => {
+  const text = await root().descendant('toolbar').dump(0);
+  const lines = text.split('\n').filter((l) => l.trim());
+  assert.equal(lines.length, 1);
+});
+
+test('Locator.tree() rejects with SelectorNotMatchedError on miss', async () => {
+  await assert.rejects(
+    root().descendant('button[name="DoesNotExist"]').tree(),
+    SelectorNotMatchedError,
+  );
+});
+
+test('Locator.dump() fails fast on miss (no auto-wait)', async () => {
+  const start = process.hrtime.bigint();
+  await assert.rejects(
+    root().descendant('button[name="DoesNotExist"]').dump(),
+    SelectorNotMatchedError,
+  );
+  const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+  assert.ok(elapsedMs < 500, `dump should fail fast, took ${elapsedMs}ms`);
 });
 

--- a/xa11y-js/index.d.ts
+++ b/xa11y-js/index.d.ts
@@ -29,6 +29,7 @@ export {
   Screenshot,
   inputSim,
   locator,
+  _makeTestApp,
   _makeTestLocator,
 } from './native.js';
 

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -507,6 +507,7 @@ module.exports = {
 
   // @internal -- used by unit tests
   _makeTestLocator: native._makeTestLocator,
+  _makeTestApp: native._makeTestApp,
   _makeTestActionProbe: native._makeTestActionProbe,
   _makeDisconnectedSubscription: native._makeDisconnectedSubscription,
   _Subscription: Subscription,

--- a/xa11y-js/src/app.rs
+++ b/xa11y-js/src/app.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use napi::bindgen_prelude::{AsyncTask, Env, Task};
 
-use crate::element::Element;
+use crate::element::{DumpTask, Element, TreeTask};
 use crate::locator::Locator;
 use crate::map_err;
 use crate::subscription::NativeSubscription;
@@ -24,7 +24,7 @@ pub struct App {
 }
 
 impl App {
-    fn from_core(app: xa11y::App) -> Self {
+    pub(crate) fn from_core(app: xa11y::App) -> Self {
         Self {
             name: app.name.clone(),
             pid: app.pid,
@@ -116,6 +116,16 @@ impl App {
         })
     }
 
+    /// Get an `Element` handle for the application root.
+    ///
+    /// Useful for invoking Element-level methods (`children()`, `parent()`,
+    /// etc.) without going through a locator. Synchronous — the App already
+    /// holds the application's accessibility data.
+    #[napi]
+    pub fn as_element(&self) -> Element {
+        Element::new(self.data.clone(), self.provider.clone())
+    }
+
     /// Subscribe to accessibility events from this application.
     #[napi(ts_return_type = "Promise<_NativeSubscription>")]
     pub fn subscribe(&self) -> AsyncTask<AppSubscribeTask> {
@@ -123,6 +133,43 @@ impl App {
             data: self.data.clone(),
             provider: self.provider.clone(),
         })
+    }
+
+    /// Capture this application's accessibility tree as a recursive snapshot,
+    /// rooted at the application element.
+    ///
+    /// `maxDepth` limits traversal depth: `0` = only the application node,
+    /// `1` = application + direct children (typically windows), and so on.
+    /// Omit for the full subtree.
+    #[napi(
+        ts_args_type = "maxDepth?: number | null",
+        ts_return_type = "Promise<TreeNode>"
+    )]
+    pub fn tree(&self, max_depth: Option<u32>) -> AsyncTask<TreeTask> {
+        AsyncTask::new(TreeTask::new(
+            self.data.clone(),
+            self.provider.clone(),
+            max_depth.map(|d| d as usize),
+        ))
+    }
+
+    /// Render this application's accessibility tree as an indented string.
+    ///
+    /// Returns the string without printing it. The primary inspection helper
+    /// — call `console.log(await app.dump())` to discover the role and name
+    /// of every element in the app before writing selectors.
+    ///
+    /// For the same output from the shell, use `xa11y tree --app NAME`.
+    #[napi(
+        ts_args_type = "maxDepth?: number | null",
+        ts_return_type = "Promise<string>"
+    )]
+    pub fn dump(&self, max_depth: Option<u32>) -> AsyncTask<DumpTask> {
+        AsyncTask::new(DumpTask::new(
+            self.data.clone(),
+            self.provider.clone(),
+            max_depth.map(|d| d as usize),
+        ))
     }
 }
 

--- a/xa11y-js/src/element.rs
+++ b/xa11y-js/src/element.rs
@@ -526,6 +526,20 @@ pub struct TreeTask {
     max_depth: Option<usize>,
 }
 
+impl TreeTask {
+    pub fn new(
+        data: xa11y::ElementData,
+        provider: Arc<dyn xa11y::Provider>,
+        max_depth: Option<usize>,
+    ) -> Self {
+        Self {
+            data,
+            provider,
+            max_depth,
+        }
+    }
+}
+
 impl Task for TreeTask {
     type Output = xa11y::TreeNode;
     type JsValue = TreeNode;
@@ -544,6 +558,20 @@ pub struct DumpTask {
     data: xa11y::ElementData,
     provider: Arc<dyn xa11y::Provider>,
     max_depth: Option<usize>,
+}
+
+impl DumpTask {
+    pub fn new(
+        data: xa11y::ElementData,
+        provider: Arc<dyn xa11y::Provider>,
+        max_depth: Option<usize>,
+    ) -> Self {
+        Self {
+            data,
+            provider,
+            max_depth,
+        }
+    }
 }
 
 impl Task for DumpTask {

--- a/xa11y-js/src/locator.rs
+++ b/xa11y-js/src/locator.rs
@@ -6,6 +6,7 @@ use napi::bindgen_prelude::{AsyncTask, Env, Task};
 
 use crate::element::Element;
 use crate::map_err;
+use crate::types::TreeNode;
 
 /// A resilient element reference that re-queries on each interaction.
 ///
@@ -106,6 +107,40 @@ impl Locator {
     pub fn elements(&self) -> AsyncTask<ElementsTask> {
         AsyncTask::new(ElementsTask {
             inner: self.inner.clone(),
+        })
+    }
+
+    /// Capture the subtree rooted at the matched element as a recursive
+    /// snapshot.
+    ///
+    /// `maxDepth` limits traversal depth: `0` = only this node (no children),
+    /// `1` = node + direct children, and so on. Omit for the full subtree.
+    ///
+    /// Resolves the selector once; rejects with `SelectorNotMatchedError`
+    /// if no match — does not auto-wait.
+    #[napi(
+        ts_args_type = "maxDepth?: number | null",
+        ts_return_type = "Promise<TreeNode>"
+    )]
+    pub fn tree(&self, max_depth: Option<u32>) -> AsyncTask<LocatorTreeTask> {
+        AsyncTask::new(LocatorTreeTask {
+            inner: self.inner.clone(),
+            max_depth: max_depth.map(|d| d as usize),
+        })
+    }
+
+    /// Render the subtree rooted at the matched element as an indented string.
+    ///
+    /// Returns the string without printing it. Same depth and resolution
+    /// semantics as `tree()`.
+    #[napi(
+        ts_args_type = "maxDepth?: number | null",
+        ts_return_type = "Promise<string>"
+    )]
+    pub fn dump(&self, max_depth: Option<u32>) -> AsyncTask<LocatorDumpTask> {
+        AsyncTask::new(LocatorDumpTask {
+            inner: self.inner.clone(),
+            max_depth: max_depth.map(|d| d as usize),
         })
     }
 
@@ -441,6 +476,36 @@ impl Task for ElementsTask {
                 Element::new(data, provider)
             })
             .collect())
+    }
+}
+
+pub struct LocatorTreeTask {
+    inner: xa11y::Locator,
+    max_depth: Option<usize>,
+}
+impl Task for LocatorTreeTask {
+    type Output = xa11y::TreeNode;
+    type JsValue = TreeNode;
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        self.inner.tree(self.max_depth).map_err(map_err)
+    }
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        Ok(output.into())
+    }
+}
+
+pub struct LocatorDumpTask {
+    inner: xa11y::Locator,
+    max_depth: Option<usize>,
+}
+impl Task for LocatorDumpTask {
+    type Output = String;
+    type JsValue = String;
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        self.inner.dump(self.max_depth).map_err(map_err)
+    }
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        Ok(output)
     }
 }
 

--- a/xa11y-js/src/mock.rs
+++ b/xa11y-js/src/mock.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use crate::app::App;
 use crate::locator::Locator;
 use crate::subscription::NativeSubscription;
 
@@ -23,6 +24,19 @@ pub fn make_test_locator() -> Locator {
         None,
         "application",
     ))
+}
+
+/// Create a mock `App` resolved against the shared synthetic tree
+/// (`TestApp`). Used only from the JS unit tests — not part of the public API.
+#[napi(js_name = "_makeTestApp")]
+#[allow(
+    dead_code,
+    reason = "Exported via napi-derive for JS unit tests; the lib-test clippy build doesn't see the JS-side consumer"
+)]
+pub fn make_test_app() -> napi::Result<App> {
+    let provider = xa11y::mock::build_provider() as Arc<dyn xa11y::Provider>;
+    let app = xa11y::App::by_name_with(provider, "TestApp").map_err(crate::map_err)?;
+    Ok(App::from_core(app))
 }
 
 /// Test handle that pairs a mock `Locator` with read-access to the mock's

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -146,6 +146,32 @@ class App:
         """Subscribe to accessibility events from this application."""
     def children(self) -> list[Element]:
         """Get direct children (typically windows) of this application."""
+    def as_element(self) -> Element:
+        """Get an :class:`Element` handle for the application root.
+
+        Useful for invoking Element-level methods (``children()``,
+        ``parent()``, etc.) without going through a locator.
+        """
+    def tree(self, max_depth: int | None = None) -> dict:
+        """Capture this application's accessibility tree as a recursive dict.
+
+        Each dict has keys ``role``, ``name``, ``value``, and ``children``
+        (a list of dicts with the same shape). ``max_depth`` limits traversal:
+        ``0`` = only the application node, ``1`` = application + direct
+        children (typically windows), ``None`` = full subtree.
+
+        Equivalent to ``Element.tree(...)`` on the application's root element.
+        """
+    def dump(self, max_depth: int | None = None) -> str:
+        """Render this application's accessibility tree as an indented string.
+
+        Returns the string without printing it. Same depth semantics as
+        :meth:`tree`. This is the primary inspection helper — call
+        ``print(app.dump())`` to discover the role and name of every element
+        in the app before writing selectors.
+
+        For the same output from the shell, use ``xa11y tree --app NAME``.
+        """
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
 
@@ -212,6 +238,28 @@ class Element:
         """Get direct children (lazy — each call queries the provider)."""
     def parent(self) -> Element | None:
         """Get parent element (lazy — each call queries the provider)."""
+    def tree(self, max_depth: int | None = None) -> dict:
+        """Capture the subtree rooted at this element as a recursive dict snapshot.
+
+        Each dict has keys ``role``, ``name``, ``value``, and ``children``
+        (a list of dicts with the same shape). ``max_depth`` limits traversal:
+        ``0`` = only this node, ``1`` = node + direct children, ``None`` = full
+        subtree.
+
+        Use this when you need to inspect or analyze the tree programmatically.
+        For an indented human-readable string, see :meth:`dump`. For ad-hoc
+        exploration from the shell, see the ``xa11y tree`` CLI command.
+        """
+    def dump(self, max_depth: int | None = None) -> str:
+        """Render the subtree rooted at this element as an indented string.
+
+        Returns the string without printing. Same depth semantics as
+        :meth:`tree`. Useful as a first step when writing a test against an
+        unfamiliar app — call ``print(app.dump())`` to discover the role and
+        name of every element, then turn those into selectors.
+
+        For the same output from the shell, use ``xa11y tree --app NAME``.
+        """
     def subscribe(self) -> Subscription:
         """Subscribe to accessibility events for this element (typically an app)."""
     def press(self) -> None:
@@ -278,6 +326,23 @@ class Locator:
         """Get a single Element handle for the matched element."""
     def elements(self) -> list[Element]:
         """Get all matching elements."""
+    def tree(self, max_depth: int | None = None) -> dict:
+        """Capture the subtree rooted at the matched element as a recursive dict.
+
+        Each dict has keys ``role``, ``name``, ``value``, and ``children``
+        (a list of dicts with the same shape). ``max_depth`` limits traversal:
+        ``0`` = only this node, ``1`` = node + direct children, ``None`` =
+        full subtree.
+
+        Resolves the selector once; fails fast with
+        :class:`SelectorNotMatchedError` if no match — does not auto-wait.
+        """
+    def dump(self, max_depth: int | None = None) -> str:
+        """Render the subtree rooted at the matched element as an indented string.
+
+        Returns the string without printing it. Same depth and resolution
+        semantics as :meth:`tree`.
+        """
     def press(self) -> None:
         """Click / invoke the matched element."""
     def focus(self) -> None:

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -546,6 +546,35 @@ impl Locator {
             .collect()
     }
 
+    /// Capture the subtree rooted at the matched element as a recursive dict.
+    ///
+    /// Each dict has keys ``role``, ``name``, ``value``, and ``children``
+    /// (a list of dicts with the same shape). ``max_depth`` limits traversal:
+    /// ``0`` = only this node, ``1`` = node + direct children, ``None`` =
+    /// full subtree.
+    ///
+    /// Resolves the selector once; fails fast with
+    /// :class:`SelectorNotMatchedError` if no match — does not auto-wait.
+    #[pyo3(signature = (max_depth=None))]
+    fn tree(&self, py: Python<'_>, max_depth: Option<usize>) -> PyResult<PyObject> {
+        let locator = self.inner.clone();
+        let node = py
+            .allow_threads(move || locator.tree(max_depth))
+            .map_err(to_py_err)?;
+        tree_node_to_py(py, &node)
+    }
+
+    /// Render the subtree rooted at the matched element as an indented string.
+    ///
+    /// Returns the string without printing it. Same depth and resolution
+    /// semantics as :meth:`tree`.
+    #[pyo3(signature = (max_depth=None))]
+    fn dump(&self, py: Python<'_>, max_depth: Option<usize>) -> PyResult<String> {
+        let locator = self.inner.clone();
+        py.allow_threads(move || locator.dump(max_depth))
+            .map_err(to_py_err)
+    }
+
     // ── Actions ──
 
     fn press(&self) -> PyResult<()> {
@@ -1079,6 +1108,46 @@ impl App {
             .collect()
     }
 
+    /// Get an :class:`Element` handle for the application root.
+    ///
+    /// Useful for invoking Element-level methods (``children()``,
+    /// ``parent()``, etc.) without going through a locator.
+    fn as_element(&self, py: Python<'_>) -> PyResult<Py<Element>> {
+        make_py_element(py, &self.inner_data, self.provider.clone())
+    }
+
+    /// Capture this application's accessibility tree as a recursive dict snapshot.
+    ///
+    /// Each dict has keys ``role``, ``name``, ``value``, and ``children``
+    /// (a list of dicts with the same shape). ``max_depth`` limits traversal:
+    /// ``0`` = only the application node, ``1`` = application + direct
+    /// children (typically windows), ``None`` = full subtree.
+    ///
+    /// Equivalent to ``Element.tree(...)`` on the application's root element.
+    #[pyo3(signature = (max_depth=None))]
+    fn tree(&self, py: Python<'_>, max_depth: Option<usize>) -> PyResult<PyObject> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        let node = py
+            .allow_threads(move || element.tree(max_depth))
+            .map_err(to_py_err)?;
+        tree_node_to_py(py, &node)
+    }
+
+    /// Render this application's accessibility tree as an indented string.
+    ///
+    /// Returns the string without printing it. Same depth semantics as
+    /// ``tree()``. This is the primary inspection helper — call
+    /// ``print(app.dump())`` to discover the role and name of every element
+    /// in the app before writing selectors.
+    ///
+    /// For the same output from the shell, use ``xa11y tree --app NAME``.
+    #[pyo3(signature = (max_depth=None))]
+    fn dump(&self, py: Python<'_>, max_depth: Option<usize>) -> PyResult<String> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.dump(max_depth))
+            .map_err(to_py_err)
+    }
+
     fn __repr__(&self) -> String {
         match self.pid {
             Some(pid) => format!("App(name='{}', pid={})", self.name, pid),
@@ -1404,6 +1473,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Test helpers
     m.add_function(wrap_pyfunction!(_make_test_locator, m)?)?;
+    m.add_function(wrap_pyfunction!(_make_test_app, m)?)?;
     m.add_function(wrap_pyfunction!(_make_disconnected_subscription, m)?)?;
     m.add_function(wrap_pyfunction!(_make_test_action_probe, m)?)?;
 
@@ -1431,6 +1501,14 @@ fn _make_test_locator() -> PyResult<Locator> {
     Ok(Locator {
         inner: xa11y::Locator::new(provider as Arc<dyn xa11y::Provider>, None, "application"),
     })
+}
+
+/// Create a test App backed by the shared mock provider (resolves "TestApp").
+#[pyfunction]
+fn _make_test_app() -> PyResult<App> {
+    let provider = xa11y::mock::build_provider() as Arc<dyn xa11y::Provider>;
+    let app = xa11y::App::by_name_with(provider, "TestApp").map_err(to_py_err)?;
+    Ok(App::from_core(app))
 }
 
 /// Create a Subscription whose backing channel has already been disconnected.

--- a/xa11y-python/tests/conftest.py
+++ b/xa11y-python/tests/conftest.py
@@ -1,8 +1,14 @@
 import pytest
-from xa11y._native import _make_test_locator
+from xa11y._native import _make_test_app, _make_test_locator
 
 
 @pytest.fixture
 def test_app():
     """A Locator backed by a mock provider targeting the test app element."""
     return _make_test_locator()
+
+
+@pytest.fixture
+def mock_app():
+    """An App backed by a mock provider (resolves TestApp from the shared mock tree)."""
+    return _make_test_app()

--- a/xa11y-python/tests/test_tree.py
+++ b/xa11y-python/tests/test_tree.py
@@ -184,3 +184,98 @@ def test_query_no_match(test_app):
 def test_query_invalid_selector(test_app):
     with pytest.raises(xa11y.InvalidSelectorError):
         test_app.descendant("[[[invalid").elements()
+
+
+# ── App.tree() / App.dump() ─────────────────────────────────────────────────
+
+
+def test_app_tree_returns_application_root(mock_app):
+    node = mock_app.tree()
+    assert node["role"] == "application"
+    assert node["name"] == "TestApp"
+    assert len(node["children"]) >= 1
+
+
+def test_app_tree_max_depth_zero_no_children(mock_app):
+    node = mock_app.tree(max_depth=0)
+    assert node["role"] == "application"
+    assert node["children"] == []
+
+
+def test_app_tree_max_depth_one_stops_at_direct_children(mock_app):
+    node = mock_app.tree(max_depth=1)
+    assert len(node["children"]) >= 1
+    for child in node["children"]:
+        assert child["children"] == []
+
+
+def test_app_dump_returns_string(mock_app):
+    assert isinstance(mock_app.dump(), str)
+
+
+def test_app_dump_contains_application_root(mock_app):
+    text = mock_app.dump()
+    assert 'application "TestApp"' in text
+
+
+def test_app_dump_max_depth_zero_is_one_line(mock_app):
+    text = mock_app.dump(max_depth=0)
+    lines = [line for line in text.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert "application" in lines[0]
+
+
+def test_app_dump_matches_element_dump(mock_app, test_app):
+    """App.dump() must produce the same output as Element.dump() on the app root."""
+    assert mock_app.dump() == test_app.element().dump()
+
+
+# ── Locator.tree() / Locator.dump() ─────────────────────────────────────────
+
+
+def test_locator_tree_returns_subtree(test_app):
+    node = test_app.tree()
+    assert node["role"] == "application"
+    assert node["name"] == "TestApp"
+
+
+def test_locator_tree_scoped_to_selector(test_app):
+    node = test_app.descendant("toolbar").tree()
+    assert node["role"] == "toolbar"
+    assert len(node["children"]) == 2  # Back and Forward buttons
+
+
+def test_locator_tree_max_depth_zero_drops_children(test_app):
+    node = test_app.descendant("toolbar").tree(max_depth=0)
+    assert node["role"] == "toolbar"
+    assert node["children"] == []
+
+
+def test_locator_dump_returns_string(test_app):
+    assert isinstance(test_app.dump(), str)
+
+
+def test_locator_dump_contains_selector_root(test_app):
+    text = test_app.descendant("toolbar").dump()
+    assert "toolbar" in text
+
+
+def test_locator_dump_max_depth_zero_is_one_line(test_app):
+    text = test_app.descendant("toolbar").dump(max_depth=0)
+    lines = [line for line in text.splitlines() if line.strip()]
+    assert len(lines) == 1
+
+
+def test_locator_tree_no_match_raises(test_app):
+    with pytest.raises(xa11y.SelectorNotMatchedError):
+        test_app.descendant('button[name="DoesNotExist"]').tree()
+
+
+def test_locator_dump_no_match_raises_fast(test_app):
+    """Locator.dump() is inspection, not an action — it must fail fast, not auto-wait."""
+    import time
+
+    start = time.monotonic()
+    with pytest.raises(xa11y.SelectorNotMatchedError):
+        test_app.descendant('button[name="DoesNotExist"]').dump()
+    assert time.monotonic() - start < 0.5


### PR DESCRIPTION
## Summary

`Element::tree` / `Element::dump` (added in #184) only existed on `Element`. Inspecting an app required navigating `App.children()[0]` first, or constructing a locator. This PR adds the same methods to `App` and `Locator` with matching shape across all three bindings, so the first thing a user does when writing a test — *"what's in this app?"* — is a one-liner.

Motivated by [first-time-user feedback](https://github.com/xa11y/xa11y/issues/192) on writing a Calculator E2E test against the Python binding: the lack of `App.dump()` was the single highest-friction gap.

## What's added

**xa11y-core**
- `App::tree(max_depth)` / `App::dump(max_depth)` — delegate to a new `App::as_element()` helper.
- `Locator::tree(max_depth)` / `Locator::dump(max_depth)` — resolve the selector once and delegate to `Element`. **Inspection ops, so they fail fast on miss; no auto-wait.**

**xa11y-python**
- `App.tree` / `App.dump` / `App.as_element` pymethods.
- `Locator.tree` / `Locator.dump` pymethods.
- `_native.pyi` stubs so the generated reference page picks them up.
- New `_make_test_app()` test helper backed by the shared mock provider.

**xa11y-js**
- `App.tree` / `App.dump` / `App.asElement` napi methods. `App.tree`/`dump` reuse the existing `Element` `TreeTask`/`DumpTask` via new `pub fn new` constructors.
- `Locator.tree` / `Locator.dump` napi methods with their own `LocatorTreeTask` / `LocatorDumpTask`.
- New `_makeTestApp()` mock helper, re-exported through `index.js` / `index.d.ts`.

**Docs**
- Quick Start: new *"Discover the tree first"* section showing `dump`/`tree` on `App`, `Locator`, and `Element` in Python, Rust, and JS.
- CLI guide: cross-link from the `xa11y tree` section to the in-code API.

## Tests

- **Rust**: 12 new unit tests in `xa11y-core` (`app.rs` + `locator.rs`), including a fail-fast/no-auto-wait timing check on `Locator::dump`.
- **Python**: 14 new tests in `test_tree.py`, including a cross-API check that `App.dump() == Element.dump()` on the application root.
- **JS**: 14 new tests mirroring the Python suite.

## Verification

\`cargo xtask check\` passes end-to-end: fmt, lint, unit tests, Python tests, bindings-parity (kept in sync — `App::as_element` is mirrored in both bindings), JS build + typecheck + 85 unit tests.

## Test plan

- [x] \`cargo xtask check\` clean locally
- [x] Rust unit tests pass (xa11y-core)
- [x] Python tests pass (196 / 196)
- [x] JS unit tests pass (85 / 85)
- [x] Bindings-parity check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)