### PR TITLE
feat(app): auto-wait by default on App.by_name / App.by_pid (closes #190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ Cross-platform accessibility library for reading and interacting with accessibil
 <!-- rust-only -->
 ```rust
 use xa11y::*;
+use std::time::Duration;
 
 fn main() -> Result<()> {
-    let safari = App::by_name("Safari")?;
+    // `by_name` polls for up to the given timeout. Useful when the app
+    // may not yet be registered with the a11y API. Pass `Duration::ZERO`
+    // for a single attempt with no waiting.
+    let safari = App::by_name("Safari", Duration::from_secs(5))?;
 
     // Find elements with CSS-like selectors
     let buttons = safari.locator("button[name='Submit']").elements()?;

--- a/docs/site/src/content/docs/api/rust.mdx
+++ b/docs/site/src/content/docs/api/rust.mdx
@@ -11,8 +11,9 @@ cargo add xa11y
 
 ```rust
 use xa11y::*;
+use std::time::Duration;
 
-let safari = App::by_name("Safari")?;
+let safari = App::by_name("Safari", Duration::from_secs(5))?;
 
 for button in safari.locator("button").elements()? {
     println!("{:?}", button.name);

--- a/docs/site/src/content/docs/guides/desktop-testing.mdx
+++ b/docs/site/src/content/docs/guides/desktop-testing.mdx
@@ -31,7 +31,7 @@ This test opens Calculator, performs `7 × 8`, and asserts the result is `56`.
 
     #[test]
     fn calculator_multiplication() -> Result<()> {
-        let calc = App::by_name("Calculator")?;
+        let calc = App::by_name("Calculator", std::time::Duration::from_secs(5))?;
         let timeout = Duration::from_secs(5);
 
         // Wait for the app to be ready

--- a/docs/site/src/content/docs/guides/input.mdx
+++ b/docs/site/src/content/docs/guides/input.mdx
@@ -52,7 +52,7 @@ xa11y picks the Linux backend at runtime: if `DISPLAY` is set we drive XTest; ot
         sim.mouse().click(Point::new(400, 300))?;
 
         // Click at the centre of an element's current bounds
-        let app = App::by_name("Finder")?;
+        let app = App::by_name("Finder", std::time::Duration::from_secs(5))?;
         let button = app.locator("button[name='New Folder']").element()?;
         sim.mouse().click(&button)?;
 
@@ -254,7 +254,7 @@ Drag-and-drop has no accessibility equivalent on most platforms. Resolve both en
 <Tabs syncKey="lang">
   <TabItem label="Rust">
     ```rust
-    let app = App::by_name("Finder")?;
+    let app = App::by_name("Finder", std::time::Duration::from_secs(5))?;
     let source = app.locator("list_item[name='notes.txt']").element()?;
     let target = app.locator("list_item[name='Archive']").element()?;
 

--- a/docs/site/src/content/docs/guides/overview.mdx
+++ b/docs/site/src/content/docs/guides/overview.mdx
@@ -87,12 +87,16 @@ xa11y is built around three core types:
   <TabItem label="Rust">
     ```rust
     use xa11y::*;
+    use std::time::Duration;
 
-    // Connect by name (returns PermissionDenied if accessibility is not enabled)
-    let safari = App::by_name("Safari")?;
+    // Connect by name. The second argument is a polling timeout —
+    // useful when the app may not yet be registered with the a11y API.
+    // Pass `Duration::ZERO` for a single attempt with no waiting.
+    // (Returns PermissionDenied if accessibility is not enabled.)
+    let safari = App::by_name("Safari", Duration::from_secs(5))?;
 
     // Connect by PID
-    let app = App::by_pid(1234)?;
+    let app = App::by_pid(1234, Duration::from_secs(5))?;
 
     // List all running apps
     let all = App::list()?;
@@ -137,7 +141,7 @@ xa11y is built around three core types:
 <Tabs syncKey="lang">
   <TabItem label="Rust">
     ```rust
-    let calc = App::by_name("Calculator")?;
+    let calc = App::by_name("Calculator", Duration::from_secs(5))?;
     let windows = calc.children()?;
 
     let children = windows[0].children()?;
@@ -265,7 +269,7 @@ A `Locator` holds a selector and **re-resolves on every operation**. Create one 
 <Tabs syncKey="lang">
   <TabItem label="Rust">
     ```rust
-    let calc = App::by_name("Calculator")?;
+    let calc = App::by_name("Calculator", Duration::from_secs(5))?;
     let btn = calc.locator("button[name='=']");
 
     // Each call re-resolves the selector, finds the element, then acts
@@ -414,7 +418,7 @@ Subscribe to accessibility events from an app with `app.subscribe()`.
     The returned `Subscription` is a pull-based event stream — no filters or selectors, just all events for the app.
 
     ```rust
-    let calc = App::by_name("Calculator")?;
+    let calc = App::by_name("Calculator", Duration::from_secs(5))?;
     let sub = calc.subscribe()?;
 
     // Block until a specific event arrives

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -52,9 +52,11 @@ After changing permissions, restart your terminal for them to take effect. `App:
     use std::time::Duration;
 
     fn main() -> Result<()> {
-        // Connect to the Calculator app
+        // Connect to the Calculator app, polling up to 5 seconds for it to
+        // register with the platform's a11y API (pass Duration::ZERO for a
+        // single attempt with no waiting).
         // (returns PermissionDenied if accessibility is not enabled)
-        let calc = App::by_name("Calculator")?;
+        let calc = App::by_name("Calculator", Duration::from_secs(5))?;
 
         // Navigate the tree
         for window in calc.children()? {

--- a/docs/site/src/content/docs/guides/screenshots.mdx
+++ b/docs/site/src/content/docs/guides/screenshots.mdx
@@ -41,7 +41,7 @@ Screenshots are decoupled from the accessibility and input layers. The target wi
         shot.save_png("corner.png")?;
 
         // Pixels under an accessibility element
-        let app = App::by_name("Calculator")?;
+        let app = App::by_name("Calculator", std::time::Duration::from_secs(5))?;
         let display = app.locator("static_text[name='Result']").element()?;
         let shot = screenshot_element(&display)?;
         shot.save_png("result.png")?;

--- a/xa11y-core/src/app.rs
+++ b/xa11y-core/src/app.rs
@@ -34,7 +34,7 @@ fn role_named(role: Role, name: &str) -> Selector {
     }
 }
 
-/// Polling interval shared by all `*_with_timeout` lookups.
+/// Polling interval shared by all timeout-bearing lookups.
 const LOOKUP_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Run `attempt` repeatedly until it succeeds or `timeout` elapses, treating
@@ -82,83 +82,66 @@ impl App {
     /// singleton provider. Use this variant when you need to supply a specific
     /// provider (e.g. a mock in unit tests).
     ///
-    /// Returns [`Error::PermissionDenied`] if the platform provider was created
-    /// without required permissions.
-    pub fn by_name_with(provider: Arc<dyn Provider>, name: &str) -> Result<Self> {
-        // Try application role first (Linux/macOS), then window role (Windows —
-        // UIA has no Application node at the top level).
-        //
-        // Selectors are built directly from the AST so app names containing
-        // `"`, `]`, or other characters significant in the selector grammar
-        // don't break or require escaping.
-        //
-        // `find_elements` returns `Ok(vec![])` for "no match" and reserves
-        // `Err(_)` for real failures (permission denied, platform errors,
-        // malformed selectors). We only fall through on an empty result —
-        // real errors must propagate so callers can distinguish "app not
-        // found" from "accessibility is broken".
-        let app_selector = role_named(Role::Application, name);
-        let results = provider.find_elements(None, &app_selector, Some(1), Some(0))?;
-        if let Some(data) = results.into_iter().next() {
-            return Ok(Self::from_data(provider, data));
-        }
-        let win_selector = role_named(Role::Window, name);
-        let results = provider.find_elements(None, &win_selector, Some(1), Some(0))?;
-        let data = results
-            .into_iter()
-            .next()
-            .ok_or_else(|| Error::SelectorNotMatched {
-                selector: format!(r#"application[name="{}"]"#, name),
-            })?;
-        Ok(Self::from_data(provider, data))
-    }
-
-    /// Like [`by_name_with`](Self::by_name_with), but polls until the app
-    /// appears or `timeout` elapses.
-    ///
-    /// Useful when the app may not yet be registered with the platform
-    /// accessibility API (e.g. just-launched test apps). Only
+    /// Polls the accessibility API until the app appears or `timeout` elapses.
+    /// `Duration::ZERO` performs exactly one attempt (no waiting). Only
     /// [`Error::SelectorNotMatched`] triggers a retry; other errors
     /// (permission, parse, platform) short-circuit immediately.
-    ///
-    /// `Duration::ZERO` is equivalent to [`by_name_with`](Self::by_name_with).
-    pub fn by_name_with_timeout(
+    pub fn by_name_with(
         provider: Arc<dyn Provider>,
         name: &str,
         timeout: Duration,
     ) -> Result<Self> {
-        poll_lookup(timeout, || Self::by_name_with(Arc::clone(&provider), name))
+        poll_lookup(timeout, || {
+            // Try application role first (Linux/macOS), then window role
+            // (Windows — UIA has no Application node at the top level).
+            //
+            // Selectors are built directly from the AST so app names
+            // containing `"`, `]`, or other characters significant in the
+            // selector grammar don't break or require escaping.
+            //
+            // `find_elements` returns `Ok(vec![])` for "no match" and
+            // reserves `Err(_)` for real failures (permission denied,
+            // platform errors, malformed selectors). We only fall through on
+            // an empty result — real errors must propagate so callers can
+            // distinguish "app not found" from "accessibility is broken".
+            let app_selector = role_named(Role::Application, name);
+            let results = provider.find_elements(None, &app_selector, Some(1), Some(0))?;
+            if let Some(data) = results.into_iter().next() {
+                return Ok(Self::from_data(Arc::clone(&provider), data));
+            }
+            let win_selector = role_named(Role::Window, name);
+            let results = provider.find_elements(None, &win_selector, Some(1), Some(0))?;
+            let data = results
+                .into_iter()
+                .next()
+                .ok_or_else(|| Error::SelectorNotMatched {
+                    selector: format!(r#"application[name="{}"]"#, name),
+                })?;
+            Ok(Self::from_data(Arc::clone(&provider), data))
+        })
     }
 
     /// Find an application by process ID, using an explicit provider.
     ///
     /// Prefer `App::by_pid` from the `xa11y` crate which uses the global
-    /// singleton provider.
-    pub fn by_pid_with(provider: Arc<dyn Provider>, pid: u32) -> Result<Self> {
-        // Try application role first, then window role (Windows fallback).
-        // Propagate real errors; only fall through when the role yielded
-        // no matching element.
-        for role in ["application", "window"] {
-            let selector = Selector::parse(role)?;
-            let results = provider.find_elements(None, &selector, None, Some(0))?;
-            if let Some(data) = results.into_iter().find(|d| d.pid == Some(pid)) {
-                return Ok(Self::from_data(provider, data));
+    /// singleton provider. See [`by_name_with`](Self::by_name_with) for the
+    /// timeout / polling semantics.
+    pub fn by_pid_with(provider: Arc<dyn Provider>, pid: u32, timeout: Duration) -> Result<Self> {
+        poll_lookup(timeout, || {
+            // Try application role first, then window role (Windows
+            // fallback). Propagate real errors; only fall through when the
+            // role yielded no matching element.
+            for role in ["application", "window"] {
+                let selector = Selector::parse(role)?;
+                let results = provider.find_elements(None, &selector, None, Some(0))?;
+                if let Some(data) = results.into_iter().find(|d| d.pid == Some(pid)) {
+                    return Ok(Self::from_data(Arc::clone(&provider), data));
+                }
             }
-        }
-        Err(Error::SelectorNotMatched {
-            selector: format!("application with pid={}", pid),
+            Err(Error::SelectorNotMatched {
+                selector: format!("application with pid={}", pid),
+            })
         })
-    }
-
-    /// Like [`by_pid_with`](Self::by_pid_with), but polls until the app
-    /// appears or `timeout` elapses. See [`by_name_with_timeout`](Self::by_name_with_timeout)
-    /// for the retry semantics.
-    pub fn by_pid_with_timeout(
-        provider: Arc<dyn Provider>,
-        pid: u32,
-        timeout: Duration,
-    ) -> Result<Self> {
-        poll_lookup(timeout, || Self::by_pid_with(Arc::clone(&provider), pid))
     }
 
     /// List all running applications, using an explicit provider.
@@ -251,8 +234,9 @@ mod tests {
 
     #[test]
     fn role_named_preserves_literal_name_with_special_chars() {
-        // Regression for a selector-injection bug: `App::by_name_with` used
-        // `format!(r#"application[name="{}"]"#, name)` without escaping, so a
+        // Regression for a selector-injection bug: an earlier `by_name`
+        // implementation used `format!(r#"application[name="{}"]"#, name)`
+        // without escaping, so a
         // name containing `"` terminated the attribute value early and either
         // failed to parse or matched the wrong element. The AST-based builder
         // stores the literal name in the filter value.

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -16,9 +16,10 @@ use crate::selector::Selector;
 ///
 /// # Example
 /// ```ignore
+/// # use std::time::Duration;
 /// # use xa11y::*;
 /// # fn example() -> Result<()> {
-/// let app = App::by_name("MyApp")?;
+/// let app = App::by_name("MyApp", Duration::from_secs(5))?;
 /// let save_btn = app.locator(r#"button[name="Save"]"#);
 /// save_btn.press()?;
 /// # Ok(())

--- a/xa11y-js/__test__/unit/app-lookup-options.test.js
+++ b/xa11y-js/__test__/unit/app-lookup-options.test.js
@@ -1,0 +1,108 @@
+// Tests for the `App.byName` / `App.byPid` options forwarding.
+//
+// The actual polling behavior (default 5s, `timeout: 0` as single-attempt,
+// retry semantics) is covered by the Rust unit tests in
+// `xa11y/tests/unit_test.rs`. These tests cover the JS-binding-specific
+// concern: that `options` reaches the native binding unchanged, including
+// the case where the caller omits it entirely (so the native-side default
+// kicks in).
+//
+// Uses the same `require.cache` stub trick as `app-factories.test.js` —
+// substitute `./native.js` before requiring `./index.js`, so the wrapper
+// captures our stub and we can observe what it forwards.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// ── Stub native bindings ───────────────────────────────────────────────────
+
+class NativeAppStub {
+  static __byNameLastArgs;
+  static __byPidLastArgs;
+
+  static async byName(name, options) {
+    NativeAppStub.__byNameLastArgs = { name, options };
+    return new NativeAppStub();
+  }
+  static async byPid(pid, options) {
+    NativeAppStub.__byPidLastArgs = { pid, options };
+    return new NativeAppStub();
+  }
+
+  async subscribe() {
+    return new NativeSubscriptionStub();
+  }
+}
+
+class NativeSubscriptionStub {
+  start() {}
+  drain() {
+    return [];
+  }
+  close() {}
+}
+
+const path = require('node:path');
+const nativePath = require.resolve('../../native.js');
+require.cache[nativePath] = {
+  id: nativePath,
+  filename: nativePath,
+  loaded: true,
+  path: path.dirname(nativePath),
+  exports: {
+    App: NativeAppStub,
+    Element: class {},
+    Event: class {},
+    Locator: class {},
+    _NativeSubscription: NativeSubscriptionStub,
+    NativeSubscription: NativeSubscriptionStub,
+    _makeTestLocator: () => {},
+    _makeDisconnectedSubscription: () => new NativeSubscriptionStub(),
+    locator: () => {},
+  },
+};
+
+const { App } = require('../../index.js');
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test('App.byName forwards options unchanged to native', async () => {
+  await App.byName('Calc', { timeout: 1500 });
+  assert.deepEqual(NativeAppStub.__byNameLastArgs, {
+    name: 'Calc',
+    options: { timeout: 1500 },
+  });
+});
+
+test('App.byName forwards timeout: 0 (no-wait sentinel) unchanged', async () => {
+  await App.byName('Calc', { timeout: 0 });
+  assert.deepEqual(NativeAppStub.__byNameLastArgs, {
+    name: 'Calc',
+    options: { timeout: 0 },
+  });
+});
+
+test('App.byName forwards undefined options when caller omits them', async () => {
+  // The default 5s lives in the native binding (see DEFAULT_LOOKUP_TIMEOUT
+  // in xa11y-js/src/app.rs) — the wrapper must NOT supply a default,
+  // otherwise the native default becomes unreachable.
+  await App.byName('Calc');
+  assert.equal(NativeAppStub.__byNameLastArgs.name, 'Calc');
+  assert.equal(NativeAppStub.__byNameLastArgs.options, undefined);
+});
+
+test('App.byPid forwards options unchanged to native', async () => {
+  await App.byPid(4242, { timeout: 2500 });
+  assert.deepEqual(NativeAppStub.__byPidLastArgs, {
+    pid: 4242,
+    options: { timeout: 2500 },
+  });
+});
+
+test('App.byPid forwards undefined options when caller omits them', async () => {
+  await App.byPid(7777);
+  assert.equal(NativeAppStub.__byPidLastArgs.pid, 7777);
+  assert.equal(NativeAppStub.__byPidLastArgs.options, undefined);
+});

--- a/xa11y-js/index.d.ts
+++ b/xa11y-js/index.d.ts
@@ -46,9 +46,9 @@ export interface SubscribeOptions {
 export interface AppLookupOptions {
   /**
    * Poll the accessibility API until the app appears, up to this many
-   * milliseconds. Useful when the app may not yet be registered (e.g.
-   * just-launched). Only "not found" errors trigger a retry; permission
-   * errors and the like fail fast. Defaults to no polling (single attempt).
+   * milliseconds. Defaults to 5000 (5 seconds) — pass `0` for a single
+   * attempt with no waiting. Only "not found" errors trigger a retry;
+   * permission errors and the like fail fast.
    */
   timeout?: number;
 }

--- a/xa11y-js/src/app.rs
+++ b/xa11y-js/src/app.rs
@@ -37,9 +37,9 @@ impl App {
 /// Options for `App.byName` / `App.byPid`.
 #[napi(object)]
 pub struct AppLookupOptions {
-    /// If set, poll the accessibility API until the app appears or this
-    /// many milliseconds elapse. Useful when the app may not yet be
-    /// registered (e.g. just-launched). Only "not found" errors trigger a
+    /// Poll the accessibility API until the app appears or this many
+    /// milliseconds elapse. Defaults to 5000 (5 seconds) — pass `0` for a
+    /// single attempt with no waiting. Only "not found" errors trigger a
     /// retry; other errors fail fast.
     pub timeout: Option<u32>,
 }
@@ -48,10 +48,11 @@ pub struct AppLookupOptions {
 impl App {
     /// Find an application by exact name.
     ///
-    /// Pass `options.timeout` (ms) to poll the accessibility API until the
-    /// app appears. Useful when the app may not yet be registered (e.g.
-    /// just-launched). Only "not found" errors trigger a retry; permission
-    /// errors and the like fail fast.
+    /// Polls the accessibility API until the app appears or
+    /// `options.timeout` (ms) elapses. Defaults to 5000 (5 seconds) —
+    /// pass `{ timeout: 0 }` for a single attempt with no waiting. Only
+    /// "not found" errors trigger a retry; permission errors and the like
+    /// fail fast.
     ///
     /// Rejects with `PermissionDeniedError` if accessibility is not enabled,
     /// or `SelectorNotMatchedError` if no matching app is found.
@@ -128,11 +129,15 @@ impl App {
 
 // ── Tasks ──────────────────────────────────────────────────────────────
 
+/// 5-second default chosen to match the auto-wait timeout used elsewhere in
+/// the API (e.g. `Locator.wait_attached`).
+const DEFAULT_LOOKUP_TIMEOUT: Duration = Duration::from_millis(5000);
+
 fn timeout_from(options: Option<AppLookupOptions>) -> Duration {
-    options
-        .and_then(|o| o.timeout)
-        .map(|ms| Duration::from_millis(ms.into()))
-        .unwrap_or(Duration::ZERO)
+    match options.and_then(|o| o.timeout) {
+        Some(ms) => Duration::from_millis(ms.into()),
+        None => DEFAULT_LOOKUP_TIMEOUT,
+    }
 }
 
 pub struct FindByNameTask {
@@ -146,7 +151,7 @@ impl Task for FindByNameTask {
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         let provider = crate::provider()?;
-        xa11y::App::by_name_with_timeout(provider, &self.name, self.timeout).map_err(map_err)
+        xa11y::App::by_name_with(provider, &self.name, self.timeout).map_err(map_err)
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
@@ -165,7 +170,7 @@ impl Task for FindByPidTask {
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         let provider = crate::provider()?;
-        xa11y::App::by_pid_with_timeout(provider, self.pid, self.timeout).map_err(map_err)
+        xa11y::App::by_pid_with(provider, self.pid, self.timeout).map_err(map_err)
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -126,16 +126,16 @@ class App:
     @property
     def pid(self) -> int | None: ...
     @staticmethod
-    def by_name(name: str, *, timeout: float | None = None) -> App:
+    def by_name(name: str, *, timeout: float = 5.0) -> App:
         """Find an application by exact name.
 
-        If ``timeout`` is set (seconds), poll the accessibility API until the
-        app appears or the timeout elapses. Useful when the app may not yet
-        be registered (e.g. just-launched). Only "not found" errors trigger a
+        Polls the accessibility API until the app appears or ``timeout``
+        (seconds) elapses. Defaults to 5 seconds — pass ``timeout=0`` for a
+        single attempt with no waiting. Only "not found" errors trigger a
         retry; other errors fail fast.
         """
     @staticmethod
-    def by_pid(pid: int, *, timeout: float | None = None) -> App:
+    def by_pid(pid: int, *, timeout: float = 5.0) -> App:
         """Find an application by process ID. See ``by_name`` for ``timeout``."""
     @staticmethod
     def list() -> list[App]:

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -974,16 +974,16 @@ impl Subscription {
 
 /// A running application — the entry point for accessibility queries.
 ///
-/// Convert an optional `timeout` in seconds (as exposed to Python) to a
-/// [`Duration`]. `None` and zero both mean "no polling, single attempt".
-/// Negative or non-finite values raise `ValueError`.
-fn timeout_from(timeout: Option<f64>) -> PyResult<Duration> {
-    match timeout {
-        None => Ok(Duration::ZERO),
-        Some(t) if t.is_finite() && t >= 0.0 => Ok(Duration::from_secs_f64(t)),
-        Some(t) => Err(PyValueError::new_err(format!(
-            "timeout must be a non-negative number of seconds, got {t}"
-        ))),
+/// Convert a `timeout` in seconds (as exposed to Python) to a [`Duration`].
+/// Zero means "no polling, single attempt". Negative or non-finite values
+/// raise `ValueError`.
+fn timeout_from(timeout: f64) -> PyResult<Duration> {
+    if timeout.is_finite() && timeout >= 0.0 {
+        Ok(Duration::from_secs_f64(timeout))
+    } else {
+        Err(PyValueError::new_err(format!(
+            "timeout must be a non-negative number of seconds, got {timeout}"
+        )))
     }
 }
 
@@ -1003,17 +1003,19 @@ struct App {
 impl App {
     /// Find an application by exact name.
     ///
-    /// If `timeout` is set (in seconds), poll the accessibility API until the
-    /// app appears or the timeout elapses. Useful when the app may not yet
-    /// be registered (e.g. just-launched). Only "not found" errors trigger a
-    /// retry; other errors fail fast.
+    /// Polls the accessibility API until the app appears or `timeout`
+    /// (in seconds) elapses. Defaults to 5 seconds — pass `timeout=0`
+    /// for a single attempt with no waiting. Only "not found" errors
+    /// trigger a retry; other errors fail fast.
     #[staticmethod]
-    #[pyo3(signature = (name, *, timeout=None))]
-    fn by_name(py: Python<'_>, name: &str, timeout: Option<f64>) -> PyResult<Self> {
-        let provider = get_provider()?;
+    #[pyo3(signature = (name, *, timeout=5.0))]
+    fn by_name(py: Python<'_>, name: &str, timeout: f64) -> PyResult<Self> {
+        // Validate `timeout` before touching the provider so callers get a
+        // crisp `ValueError` regardless of whether accessibility is set up.
         let timeout = timeout_from(timeout)?;
+        let provider = get_provider()?;
         let app = py
-            .allow_threads(move || xa11y::App::by_name_with_timeout(provider, name, timeout))
+            .allow_threads(move || xa11y::App::by_name_with(provider, name, timeout))
             .map_err(to_py_err)?;
         Ok(Self::from_core(app))
     }
@@ -1022,12 +1024,12 @@ impl App {
     ///
     /// See [`by_name`] for `timeout` semantics.
     #[staticmethod]
-    #[pyo3(signature = (pid, *, timeout=None))]
-    fn by_pid(py: Python<'_>, pid: u32, timeout: Option<f64>) -> PyResult<Self> {
-        let provider = get_provider()?;
+    #[pyo3(signature = (pid, *, timeout=5.0))]
+    fn by_pid(py: Python<'_>, pid: u32, timeout: f64) -> PyResult<Self> {
         let timeout = timeout_from(timeout)?;
+        let provider = get_provider()?;
         let app = py
-            .allow_threads(move || xa11y::App::by_pid_with_timeout(provider, pid, timeout))
+            .allow_threads(move || xa11y::App::by_pid_with(provider, pid, timeout))
             .map_err(to_py_err)?;
         Ok(Self::from_core(app))
     }

--- a/xa11y-python/tests/test_app_lookup.py
+++ b/xa11y-python/tests/test_app_lookup.py
@@ -1,0 +1,51 @@
+"""Tests for the `App.by_name` / `App.by_pid` binding surface.
+
+The actual polling behavior is covered by the Rust unit tests in
+`xa11y/tests/unit_test.rs` (`by_name_with_polls_until_app_appears`,
+`by_name_with_zero_timeout_is_single_attempt`, etc). These tests cover the
+Python-binding-specific concerns: keyword argument plumbing and timeout
+validation — which fires before the provider is touched, so the tests work
+on CI runners that have no AT-SPI session.
+"""
+
+import pytest
+import xa11y
+
+
+def test_by_name_rejects_negative_timeout():
+    with pytest.raises(ValueError, match="non-negative"):
+        xa11y.App.by_name("ignored", timeout=-1.0)
+
+
+def test_by_pid_rejects_negative_timeout():
+    with pytest.raises(ValueError, match="non-negative"):
+        xa11y.App.by_pid(0, timeout=-0.5)
+
+
+def test_by_name_rejects_nan_timeout():
+    with pytest.raises(ValueError, match="non-negative"):
+        xa11y.App.by_name("ignored", timeout=float("nan"))
+
+
+def test_by_name_rejects_infinite_timeout():
+    with pytest.raises(ValueError, match="non-negative"):
+        xa11y.App.by_name("ignored", timeout=float("inf"))
+
+
+def test_by_name_timeout_is_keyword_only():
+    # The `*` in `#[pyo3(signature = (name, *, timeout=5.0))]` makes `timeout`
+    # keyword-only. Passing positionally must raise TypeError.
+    with pytest.raises(TypeError):
+        xa11y.App.by_name("ignored", -1.0)
+
+
+def test_by_name_zero_timeout_validates():
+    # 0.0 is a valid non-negative value — must not raise ValueError. (The
+    # downstream lookup may still raise, but not for the timeout argument.)
+    try:
+        xa11y.App.by_name("__xa11y_no_such_app_for_test__", timeout=0.0)
+    except ValueError:
+        pytest.fail("timeout=0.0 must be accepted as a no-wait sentinel")
+    except xa11y.XA11yError:
+        # Any xa11y-level error is fine — proves the call reached the lookup.
+        pass

--- a/xa11y/README.md
+++ b/xa11y/README.md
@@ -16,9 +16,13 @@ Cross-platform accessibility library for reading and interacting with accessibil
 
 ```rust
 use xa11y::*;
+use std::time::Duration;
 
 fn main() -> Result<()> {
-    let safari = App::by_name("Safari")?;
+    // `by_name` polls for up to the given timeout. Useful when the app
+    // may not yet be registered with the a11y API. Pass `Duration::ZERO`
+    // for a single attempt with no waiting.
+    let safari = App::by_name("Safari", Duration::from_secs(5))?;
 
     // Find elements with CSS-like selectors
     let buttons = safari.locator("button[name='Submit']").elements()?;

--- a/xa11y/fuzz/fuzz_targets/tree_ops.rs
+++ b/xa11y/fuzz/fuzz_targets/tree_ops.rs
@@ -15,6 +15,7 @@
 mod mock;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
@@ -102,11 +103,12 @@ fuzz_target!(|input: FuzzInput| {
 
     // ── 4. App::by_name_with — exercises name-embedding in selector string ────
     //    Names containing '"' produce invalid selector strings; the method must
-    //    return Err, not panic.
-    let _ = App::by_name_with(Arc::clone(&provider), &input.app_name);
+    //    return Err, not panic. Fuzzing wants a single attempt per input —
+    //    `Duration::ZERO` skips the polling loop.
+    let _ = App::by_name_with(Arc::clone(&provider), &input.app_name, Duration::ZERO);
 
     // ── 5. App::by_pid_with ───────────────────────────────────────────────────
-    let _ = App::by_pid_with(Arc::clone(&provider), input.pid);
+    let _ = App::by_pid_with(Arc::clone(&provider), input.pid, Duration::ZERO);
 
     // ── 6. App::list_with → children, locator, serde ─────────────────────────
     let Ok(apps) = App::list_with(Arc::clone(&provider)) else {

--- a/xa11y/src/cli.rs
+++ b/xa11y/src/cli.rs
@@ -296,9 +296,9 @@ pub(crate) fn parse_button(raw: &str) -> Result<MouseButton> {
 
 pub(crate) fn resolve_app(opts: &Opts) -> Result<App> {
     if let Some(name) = &opts.app {
-        App::by_name(name)
+        App::by_name(name, std::time::Duration::ZERO)
     } else if let Some(pid) = opts.pid {
-        App::by_pid(pid)
+        App::by_pid(pid, std::time::Duration::ZERO)
     } else {
         Err(Error::Platform {
             code: -1,

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -6,9 +6,10 @@
 //! # Quick Start
 //!
 //! ```no_run
+//! use std::time::Duration;
 //! use xa11y::*;
 //!
-//! let app = App::by_name("Safari").expect("App not found");
+//! let app = App::by_name("Safari", Duration::from_secs(5)).expect("App not found");
 //!
 //! for child in app.children().unwrap() {
 //!     println!("{}: {:?}", child.role, child.name);
@@ -50,7 +51,7 @@ pub use xa11y_core::mock;
 #[doc(hidden)]
 pub mod cli;
 
-// Re-export the extension trait so `use xa11y::*` enables `App::by_name("Safari")`.
+// Re-export the extension trait so `use xa11y::*` enables `App::by_name(...)`.
 pub use app_ext::AppExt;
 
 // ── Internal singleton ──────────────────────────────────────────────────────
@@ -229,41 +230,33 @@ mod app_ext {
     ///
     /// # Example
     /// ```no_run
+    /// use std::time::Duration;
     /// use xa11y::*;
     ///
-    /// let app = App::by_name("Safari")?;
+    /// let app = App::by_name("Safari", Duration::from_secs(5))?;
     /// # Ok::<(), xa11y::Error>(())
     /// ```
     pub trait AppExt: Sized {
-        /// Find an application by exact name using the global singleton provider.
-        fn by_name(name: &str) -> Result<Self>;
-        /// Find an application by exact name, polling until it appears or
-        /// `timeout` elapses. See [`App::by_name_with_timeout`].
-        fn by_name_timeout(name: &str, timeout: Duration) -> Result<Self>;
-        /// Find an application by process ID using the global singleton provider.
-        fn by_pid(pid: u32) -> Result<Self>;
-        /// Find an application by process ID, polling until it appears or
-        /// `timeout` elapses. See [`App::by_pid_with_timeout`].
-        fn by_pid_timeout(pid: u32, timeout: Duration) -> Result<Self>;
+        /// Find an application by exact name using the global singleton
+        /// provider, polling until it appears or `timeout` elapses. Pass
+        /// `Duration::ZERO` for a single attempt with no waiting. See
+        /// [`App::by_name_with`] for retry semantics.
+        fn by_name(name: &str, timeout: Duration) -> Result<Self>;
+        /// Find an application by process ID using the global singleton
+        /// provider, polling until it appears or `timeout` elapses. See
+        /// [`by_name`](Self::by_name) for retry semantics.
+        fn by_pid(pid: u32, timeout: Duration) -> Result<Self>;
         /// List all running applications using the global singleton provider.
         fn list() -> Result<Vec<Self>>;
     }
 
     impl AppExt for App {
-        fn by_name(name: &str) -> Result<Self> {
-            App::by_name_with(provider()?, name)
+        fn by_name(name: &str, timeout: Duration) -> Result<Self> {
+            App::by_name_with(provider()?, name, timeout)
         }
 
-        fn by_name_timeout(name: &str, timeout: Duration) -> Result<Self> {
-            App::by_name_with_timeout(provider()?, name, timeout)
-        }
-
-        fn by_pid(pid: u32) -> Result<Self> {
-            App::by_pid_with(provider()?, pid)
-        }
-
-        fn by_pid_timeout(pid: u32, timeout: Duration) -> Result<Self> {
-            App::by_pid_with_timeout(provider()?, pid, timeout)
+        fn by_pid(pid: u32, timeout: Duration) -> Result<Self> {
+            App::by_pid_with(provider()?, pid, timeout)
         }
 
         fn list() -> Result<Vec<Self>> {

--- a/xa11y/tests/integ/actions.rs
+++ b/xa11y/tests/integ/actions.rs
@@ -393,7 +393,7 @@ mod tests {
     #[test]
     #[ignore]
     fn error_app_not_found() {
-        let result = App::by_name("nonexistent_app_12345");
+        let result = App::by_name("nonexistent_app_12345", std::time::Duration::ZERO);
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -33,12 +33,12 @@ pub fn app_root() -> App {
     // On Linux/macOS, AT-SPI and AX report the process name ("xa11y-test-app").
     // On Windows, UIA reports the window title ("xa11y Test App").
     // Two candidate names to interleave, so we keep the manual loop (a
-    // single `by_name_timeout` per name would block on the wrong name for
-    // its full timeout before trying the right one).
+    // single `by_name` with a long timeout per name would block on the
+    // wrong name for its full timeout before trying the right one).
     let names = ["xa11y-test-app", "xa11y Test App"];
     for attempt in 0..3 {
         for name in &names {
-            if let Ok(app) = App::by_name(name) {
+            if let Ok(app) = App::by_name(name, std::time::Duration::ZERO) {
                 return app;
             }
         }

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -4,6 +4,7 @@
 //! permissions, using a mock provider with in-memory element data.
 
 use std::sync::Arc;
+use std::time::Duration;
 use xa11y::*;
 
 // ── Mock Provider ──
@@ -373,7 +374,7 @@ fn sample_provider() -> Arc<MockProvider> {
 
 fn sample_app() -> App {
     let p = sample_provider();
-    App::by_name_with(p as Arc<dyn Provider>, "Test App").unwrap()
+    App::by_name_with(p as Arc<dyn Provider>, "Test App", Duration::ZERO).unwrap()
 }
 
 fn sample_root() -> Element {
@@ -802,7 +803,12 @@ fn locator_basic_query() {
 #[test]
 fn locator_press_dispatches_action() {
     let p = sample_provider();
-    let app = App::by_name_with(Arc::clone(&p) as Arc<dyn Provider>, "Test App").unwrap();
+    let app = App::by_name_with(
+        Arc::clone(&p) as Arc<dyn Provider>,
+        "Test App",
+        Duration::ZERO,
+    )
+    .unwrap();
     let loc = app.locator(r#"window button[name="Submit"]"#);
     loc.press().unwrap();
     let (handle, action) = p.last_action.lock().unwrap().clone().unwrap();
@@ -918,7 +924,7 @@ fn locator_descendant_through_nested_groups() {
         nodes,
         last_action: std::sync::Mutex::new(None),
     });
-    let app = App::by_name_with(provider as Arc<dyn Provider>, "Test App").unwrap();
+    let app = App::by_name_with(provider as Arc<dyn Provider>, "Test App", Duration::ZERO).unwrap();
 
     let loc = app.locator(r#"group[name="Outer"] static_text[name="TestFarm"]"#);
     assert!(
@@ -1103,7 +1109,7 @@ impl Provider for MultiAppMockProvider {
 #[test]
 fn find_application_by_name_from_root() {
     let p = multi_app_provider();
-    let app = App::by_name_with(p as Arc<dyn Provider>, "App2").unwrap();
+    let app = App::by_name_with(p as Arc<dyn Provider>, "App2", Duration::ZERO).unwrap();
     assert_eq!(app.data.role, Role::Application);
     assert_eq!(app.name, "App2");
     assert_eq!(app.pid, Some(200));
@@ -1142,7 +1148,7 @@ fn find_button_across_apps() {
 #[test]
 fn find_with_limit_stops_early() {
     let p = multi_app_provider();
-    let app1 = App::by_name_with(p as Arc<dyn Provider>, "App1").unwrap();
+    let app1 = App::by_name_with(p as Arc<dyn Provider>, "App1", Duration::ZERO).unwrap();
     let first = app1.locator("button").first().element().unwrap();
     assert_eq!(first.name.as_deref(), Some("Btn1"));
 }
@@ -1151,7 +1157,7 @@ fn find_with_limit_stops_early() {
 fn find_multi_segment_across_apps() {
     // "window > button" — find buttons that are direct children of windows in App2
     let p = multi_app_provider();
-    let app2 = App::by_name_with(p as Arc<dyn Provider>, "App2").unwrap();
+    let app2 = App::by_name_with(p as Arc<dyn Provider>, "App2", Duration::ZERO).unwrap();
     let results = app2.locator("window > button").elements().unwrap();
     assert_eq!(results.len(), 2); // Btn2, Btn3
 }
@@ -1159,7 +1165,7 @@ fn find_multi_segment_across_apps() {
 #[test]
 fn app_locator_scopes_search() {
     let p = multi_app_provider();
-    let app2 = App::by_name_with(p as Arc<dyn Provider>, "App2").unwrap();
+    let app2 = App::by_name_with(p as Arc<dyn Provider>, "App2", Duration::ZERO).unwrap();
     // Scoped locator should only find buttons within App2
     let buttons = app2.locator("button").elements().unwrap();
     assert_eq!(buttons.len(), 2); // Btn2, Btn3
@@ -1169,7 +1175,7 @@ fn app_locator_scopes_search() {
 #[test]
 fn app_locator_does_not_find_sibling_app_elements() {
     let p = multi_app_provider();
-    let app1 = App::by_name_with(p as Arc<dyn Provider>, "App1").unwrap();
+    let app1 = App::by_name_with(p as Arc<dyn Provider>, "App1", Duration::ZERO).unwrap();
     // App1 only has Btn1
     let buttons = app1.locator("button").elements().unwrap();
     assert_eq!(buttons.len(), 1);
@@ -1179,7 +1185,7 @@ fn app_locator_does_not_find_sibling_app_elements() {
 #[test]
 fn locator_count_matches_elements_len() {
     let p = multi_app_provider();
-    let app1 = App::by_name_with(p as Arc<dyn Provider>, "App1").unwrap();
+    let app1 = App::by_name_with(p as Arc<dyn Provider>, "App1", Duration::ZERO).unwrap();
     let loc = app1.locator("button");
     assert_eq!(loc.count().unwrap(), loc.elements().unwrap().len());
 }
@@ -1187,7 +1193,7 @@ fn locator_count_matches_elements_len() {
 #[test]
 fn app_by_name_not_found() {
     let p = multi_app_provider();
-    let result = App::by_name_with(p as Arc<dyn Provider>, "NoSuchApp");
+    let result = App::by_name_with(p as Arc<dyn Provider>, "NoSuchApp", Duration::ZERO);
     assert!(result.is_err());
 }
 
@@ -1203,7 +1209,7 @@ fn locator_nth_out_of_range() {
 #[test]
 fn element_children_of_leaf_is_empty() {
     let p = multi_app_provider();
-    let app1 = App::by_name_with(p as Arc<dyn Provider>, "App1").unwrap();
+    let app1 = App::by_name_with(p as Arc<dyn Provider>, "App1", Duration::ZERO).unwrap();
     let btn = app1.locator("button").first().element().unwrap();
     assert!(btn.children().unwrap().is_empty());
 }
@@ -1224,7 +1230,7 @@ fn element_parent_of_top_level_is_none() {
 #[test]
 fn element_parent_navigates_up() {
     let p = multi_app_provider();
-    let app2 = App::by_name_with(p as Arc<dyn Provider>, "App2").unwrap();
+    let app2 = App::by_name_with(p as Arc<dyn Provider>, "App2", Duration::ZERO).unwrap();
     let btn = app2.locator(r#"button[name="Btn2"]"#).element().unwrap();
     let parent = btn.parent().unwrap().unwrap();
     assert_eq!(parent.role, Role::Window);
@@ -1235,10 +1241,12 @@ fn element_parent_navigates_up() {
 fn handle_preserved_through_find() {
     // Verify that handle IDs survive the find_elements pipeline
     let p = multi_app_provider();
-    let app1 = App::by_name_with(Arc::clone(&p) as Arc<dyn Provider>, "App1").unwrap();
+    let app1 =
+        App::by_name_with(Arc::clone(&p) as Arc<dyn Provider>, "App1", Duration::ZERO).unwrap();
     // handle should be non-default (we set it to the node index)
     assert_eq!(app1.data.handle, 0); // App1 is node index 0
-    let app2 = App::by_name_with(Arc::clone(&p) as Arc<dyn Provider>, "App2").unwrap();
+    let app2 =
+        App::by_name_with(Arc::clone(&p) as Arc<dyn Provider>, "App2", Duration::ZERO).unwrap();
     let btn = app2.locator(r#"button[name="Btn2"]"#).element().unwrap();
     assert_eq!(btn.handle, 5); // Btn2 is node index 5
 }
@@ -1357,14 +1365,14 @@ impl Provider for DelayedProvider {
 }
 
 #[test]
-fn by_name_with_timeout_polls_until_app_appears() {
+fn by_name_with_polls_until_app_appears() {
     let inner = multi_app_provider();
     // `by_name_with` issues two root lookups per attempt (application
     // selector, then window selector). Failing the first 3 root calls means
     // the first attempt fails entirely and the second attempt succeeds on
     // its first selector.
     let p = DelayedProvider::new(inner, 3);
-    let app = App::by_name_with_timeout(
+    let app = App::by_name_with(
         Arc::clone(&p) as Arc<dyn Provider>,
         "App1",
         std::time::Duration::from_secs(2),
@@ -1379,10 +1387,10 @@ fn by_name_with_timeout_polls_until_app_appears() {
 }
 
 #[test]
-fn by_name_with_timeout_zero_is_single_attempt() {
+fn by_name_with_zero_timeout_is_single_attempt() {
     let inner = multi_app_provider();
     let p = DelayedProvider::new(inner, 100); // never succeeds during the test
-    let result = App::by_name_with_timeout(
+    let result = App::by_name_with(
         Arc::clone(&p) as Arc<dyn Provider>,
         "App1",
         std::time::Duration::ZERO,
@@ -1397,11 +1405,11 @@ fn by_name_with_timeout_zero_is_single_attempt() {
 }
 
 #[test]
-fn by_name_with_timeout_short_circuits_on_non_retryable_error() {
+fn by_name_with_short_circuits_on_non_retryable_error() {
     let inner = multi_app_provider();
     let p = DelayedProvider::always_fail_permission(inner);
     let start = std::time::Instant::now();
-    let result = App::by_name_with_timeout(
+    let result = App::by_name_with(
         Arc::clone(&p) as Arc<dyn Provider>,
         "App1",
         std::time::Duration::from_secs(10),
@@ -1415,11 +1423,11 @@ fn by_name_with_timeout_short_circuits_on_non_retryable_error() {
 }
 
 #[test]
-fn by_pid_with_timeout_polls_until_app_appears() {
+fn by_pid_with_polls_until_app_appears() {
     let inner = multi_app_provider();
     let p = DelayedProvider::new(inner, 3);
     // App1 has pid 100 in multi_app_provider.
-    let app = App::by_pid_with_timeout(
+    let app = App::by_pid_with(
         Arc::clone(&p) as Arc<dyn Provider>,
         100,
         std::time::Duration::from_secs(2),


### PR DESCRIPTION
## Summary

- Collapse `App.by_name` (no wait) and `App.by_name_timeout` into a single entry point that always takes a polling timeout. Same for `by_pid`. Pass `0` (Python/JS) or `Duration::ZERO` (Rust) to skip waiting.
- Default timeout: **5 s** in Python / JS — matches the auto-wait baseline used elsewhere (e.g. `Locator.wait_attached`). Rust requires an explicit `Duration` (no optional args).
- Validate `timeout` in the Python binding **before** touching the global provider so `ValueError` fires regardless of accessibility-permission state.
- Update quick-start / overview / README Rust examples to the new signature.

## Why this closes #190

#190 asked for an `App.launch(name, …)` helper to absorb the `open -a` + poll-until-ready boilerplate every test author hand-writes. The pain point is real, but `App.launch()` ends up doing four jobs (spawn, wait-for-handle, wait-for-ready, own-the-process). After discussion in the issue thread, this PR takes the smaller-primitives route:

- **Handle race ("process exists, a11y not ready yet")** — now covered by `App.by_name(name)` polling for the default 5 s.
- **Window-not-registered race** — already covered by `Locator.wait_attached(...)`.
- **Cross-platform launch primitive / macOS `open -a` -600 race / process ownership** — intentionally out of scope. `subprocess.Popen` already owns processes; the launch race is a separate problem worth solving in a focused helper, not by growing `App` into a process manager.

The original 10-line boilerplate from the issue collapses to three lines:

```python
subprocess.run(["open", "-a", "Calculator"], check=True)
app = xa11y.App.by_name("Calculator")   # default 5 s wait
app.locator('button[name="0"]').wait_attached(timeout=5.0)
```

## API changes (breaking)

| Surface | Before | After |
|---|---|---|
| Rust `App::by_name` (extension) | `by_name(&str)` + `by_name_timeout(&str, Duration)` | `by_name(&str, Duration)` |
| Rust `App::by_pid` (extension) | `by_pid(u32)` + `by_pid_timeout(u32, Duration)` | `by_pid(u32, Duration)` |
| Rust `App::by_name_with` (core) | `by_name_with(provider, &str)` + `by_name_with_timeout(provider, &str, Duration)` | `by_name_with(provider, &str, Duration)` |
| Python `App.by_name` | `by_name(name, *, timeout=None)` (None = no wait) | `by_name(name, *, timeout=5.0)` (0 = no wait) |
| JS `App.byName` | `byName(name, { timeout? })` (default no wait) | `byName(name, { timeout? })` (default 5000 ms) |

## Test plan

- [x] Rust: existing `by_name_with_polls_until_app_appears` / `..._zero_timeout_is_single_attempt` / `..._short_circuits_on_non_retryable_error` / `by_pid_with_polls_until_app_appears` (renamed to drop `_timeout` suffix) — `cargo test --workspace` green locally.
- [x] Rust clippy / fmt / sync-readmes / bindings-parity all clean locally.
- [x] Python: new `xa11y-python/tests/test_app_lookup.py` covers `ValueError` for negative / NaN / inf timeout, keyword-only enforcement, and `timeout=0` acceptance. Validation runs before provider creation so the tests work on CI runners without AT-SPI.
- [x] JS: new `xa11y-js/__test__/unit/app-lookup-options.test.js` covers options propagation (incl. `timeout: 0`) and asserts the wrapper does **not** supply its own default — so the native-side 5 s default stays reachable.
- [ ] CI green across Linux / macOS / Windows / Python / JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)