### PR TITLE
test(compat): poll for OK button in test_element_tree_snapshot

### DIFF
--- a/tests/suites/python/test_compat.py
+++ b/tests/suites/python/test_compat.py
@@ -457,8 +457,22 @@ def test_dialog_role(app, app_config):
 
 def test_element_tree_snapshot(app, app_config):
     """Element.tree() returns a dict snapshot with the expected shape."""
+    import time
+
     ok_name = app_config["ok_button_name"]
-    btn = app.locator(f'button[name="{ok_name}"]').element()
+    # Locator.element() resolves once with no auto-wait; on Windows the UIA
+    # tree can be transiently unsettled after a prior test closes a dialog,
+    # so poll briefly to keep this test focused on Element.tree() rather
+    # than on its own selector resolution timing.
+    deadline = time.monotonic() + 5.0
+    while True:
+        try:
+            btn = app.locator(f'button[name="{ok_name}"]').element()
+            break
+        except xa11y.SelectorNotMatchedError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.05)
     node = btn.tree(max_depth=0)
     assert node["role"] == "button"
     assert node["name"] == ok_name


### PR DESCRIPTION
## Summary

- Fixes a Windows-only flake where `test_element_tree_snapshot` fails with `SelectorNotMatchedError: No element matched: button[name=\"OK\"]`.
- Root cause: `Locator.element()` resolves once with no auto-wait. The preceding `test_dialog_role` closes a non-modal QDialog whose UIA tree update can take longer than its 100 ms teardown sleep on Windows. During that gap the main window's OK button is transiently un-findable. The next test (~36 ms later) finds it fine, confirming the timing-window hypothesis.
- The test is specifically about `Element.tree()`; selector resolution is just plumbing, so a brief poll keeps the test focused on what it's testing.
- CI history confirms intermittent: passed on 61311ba (added) and a122337, failed on bbf280c / 18876b4 / 3f3d4c8 / 662f13f / 211cc61 — not a regression introduced by any single commit.

## Test plan

- [ ] CI Windows Qt integ run goes green
- [ ] No regression on other platforms (Linux/macOS Qt, GTK, Cocoa, Tauri, Electron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)