### PR TITLE
fix(selector): dedup multi-clause groups by tree path, not handle

### DIFF
--- a/xa11y-core/src/app.rs
+++ b/xa11y-core/src/app.rs
@@ -6,33 +6,6 @@ use crate::error::{Error, Result};
 use crate::event_provider::Subscription;
 use crate::locator::Locator;
 use crate::provider::Provider;
-use crate::role::Role;
-use crate::selector::{
-    AttrFilter, Combinator, MatchOp, RoleMatch, Selector, SelectorSegment, SimpleSelector,
-};
-
-/// Build a single-segment selector that matches `role` with an exact-name filter.
-///
-/// Constructed directly from the selector AST rather than via string
-/// interpolation, so an application name containing characters that are
-/// special in the selector grammar (`"`, `]`, `\`) still produces a
-/// well-formed selector that matches the literal name.
-fn role_named(role: Role, name: &str) -> Selector {
-    Selector {
-        segments: vec![SelectorSegment {
-            combinator: Combinator::Root,
-            simple: SimpleSelector {
-                role: Some(RoleMatch::Normalized(role)),
-                filters: vec![AttrFilter {
-                    attr: "name".to_string(),
-                    op: MatchOp::Exact,
-                    value: name.to_string(),
-                }],
-                nth: None,
-            },
-        }],
-    }
-}
 
 /// Polling interval shared by all timeout-bearing lookups.
 const LOOKUP_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -92,28 +65,21 @@ impl App {
         timeout: Duration,
     ) -> Result<Self> {
         poll_lookup(timeout, || {
-            // Try application role first (Linux/macOS), then window role
-            // (Windows — UIA has no Application node at the top level).
+            // Discovery is platform-specific (CGWindowList on macOS, AT-SPI
+            // registry on Linux, UIA desktop root on Windows) and returns
+            // top-level apps as `role=Application` everywhere except Windows,
+            // which reports `role=Window`. The role detail no longer matters
+            // here — `list_apps()` is the canonical enumeration primitive
+            // and we filter by name in Rust, so app names containing `"`,
+            // `]`, or other characters significant in the selector grammar
+            // don't need escaping.
             //
-            // Selectors are built directly from the AST so app names
-            // containing `"`, `]`, or other characters significant in the
-            // selector grammar don't break or require escaping.
-            //
-            // `find_elements` returns `Ok(vec![])` for "no match" and
-            // reserves `Err(_)` for real failures (permission denied,
-            // platform errors, malformed selectors). We only fall through on
-            // an empty result — real errors must propagate so callers can
-            // distinguish "app not found" from "accessibility is broken".
-            let app_selector = role_named(Role::Application, name);
-            let results = provider.find_elements(None, &app_selector, Some(1), Some(0))?;
-            if let Some(data) = results.into_iter().next() {
-                return Ok(Self::from_data(Arc::clone(&provider), data));
-            }
-            let win_selector = role_named(Role::Window, name);
-            let results = provider.find_elements(None, &win_selector, Some(1), Some(0))?;
-            let data = results
+            // Errors from `list_apps()` propagate so callers can distinguish
+            // "app not found" from "accessibility is broken".
+            let apps = provider.list_apps()?;
+            let data = apps
                 .into_iter()
-                .next()
+                .find(|d| d.name.as_deref() == Some(name))
                 .ok_or_else(|| Error::SelectorNotMatched {
                     selector: format!(r#"application[name="{}"]"#, name),
                 })?;
@@ -128,19 +94,14 @@ impl App {
     /// timeout / polling semantics.
     pub fn by_pid_with(provider: Arc<dyn Provider>, pid: u32, timeout: Duration) -> Result<Self> {
         poll_lookup(timeout, || {
-            // Try application role first, then window role (Windows
-            // fallback). Propagate real errors; only fall through when the
-            // role yielded no matching element.
-            for role in ["application", "window"] {
-                let selector = Selector::parse(role)?;
-                let results = provider.find_elements(None, &selector, None, Some(0))?;
-                if let Some(data) = results.into_iter().find(|d| d.pid == Some(pid)) {
-                    return Ok(Self::from_data(Arc::clone(&provider), data));
-                }
-            }
-            Err(Error::SelectorNotMatched {
-                selector: format!("application with pid={}", pid),
-            })
+            let apps = provider.list_apps()?;
+            let data = apps
+                .into_iter()
+                .find(|d| d.pid == Some(pid))
+                .ok_or_else(|| Error::SelectorNotMatched {
+                    selector: format!("application with pid={}", pid),
+                })?;
+            Ok(Self::from_data(Arc::clone(&provider), data))
         })
     }
 
@@ -149,26 +110,15 @@ impl App {
     /// Prefer `App::list` from the `xa11y` crate which uses the global
     /// singleton provider.
     pub fn list_with(provider: Arc<dyn Provider>) -> Result<Vec<Self>> {
-        // Collect application role elements (Linux/macOS), then add window
-        // role elements (Windows fallback) for any not already found by PID.
-        // Real errors from either lookup propagate to the caller.
-        let mut apps = Vec::new();
-        let mut seen_pids = std::collections::HashSet::new();
-
-        for role in ["application", "window"] {
-            let selector = Selector::parse(role)?;
-            let results = provider.find_elements(None, &selector, None, Some(0))?;
-            for d in results {
-                if let Some(pid) = d.pid {
-                    if !seen_pids.insert(pid) {
-                        continue; // already found via application role
-                    }
-                }
-                apps.push(Self::from_data(Arc::clone(&provider), d));
-            }
-        }
-
-        Ok(apps)
+        // `list_apps()` is the platform-specific discovery primitive — it
+        // already handles the per-OS app/window split (Linux/macOS return
+        // `Application` elements; Windows returns top-level `Window`
+        // elements), so we just wrap each entry.
+        let datas = provider.list_apps()?;
+        Ok(datas
+            .into_iter()
+            .map(|d| Self::from_data(Arc::clone(&provider), d))
+            .collect())
     }
 
     fn from_data(provider: Arc<dyn Provider>, data: ElementData) -> Self {
@@ -258,8 +208,7 @@ impl std::fmt::Debug for App {
 mod tests {
     use super::*;
     use crate::mock::build_provider;
-    use crate::selector::{matches_simple, Combinator};
-    use serde_json::json;
+    use crate::role::Role;
 
     fn mock_app() -> App {
         let provider: Arc<dyn Provider> = build_provider();
@@ -320,49 +269,5 @@ mod tests {
         let el = app.as_element();
         assert_eq!(el.data().role, Role::Application);
         assert_eq!(el.data().name.as_deref(), Some("TestApp"));
-    }
-
-    #[test]
-    fn role_named_preserves_literal_name_with_special_chars() {
-        // Regression for a selector-injection bug: an earlier `by_name`
-        // implementation used `format!(r#"application[name="{}"]"#, name)`
-        // without escaping, so a
-        // name containing `"` terminated the attribute value early and either
-        // failed to parse or matched the wrong element. The AST-based builder
-        // stores the literal name in the filter value.
-        let name = r#"My "Weird" App ]["#;
-        let sel = role_named(Role::Application, name);
-        assert_eq!(sel.segments.len(), 1);
-        assert_eq!(sel.segments[0].combinator, Combinator::Root);
-        let simple = &sel.segments[0].simple;
-        assert_eq!(simple.filters.len(), 1);
-        assert_eq!(simple.filters[0].attr, "name");
-        assert_eq!(simple.filters[0].value, name);
-    }
-
-    #[test]
-    fn role_named_matches_element_with_quoted_name() {
-        // End-to-end: the constructed selector actually matches an element
-        // whose name contains the special chars. Build a minimal ElementData
-        // and verify `matches_simple`.
-        let name = r#"Name"With"Quote"#;
-        let data = ElementData {
-            role: Role::Application,
-            name: Some(name.to_string()),
-            value: None,
-            description: None,
-            bounds: None,
-            actions: vec![],
-            states: crate::element::StateSet::default(),
-            numeric_value: None,
-            min_value: None,
-            max_value: None,
-            stable_id: None,
-            pid: Some(1),
-            raw: std::collections::HashMap::from([("app_name".to_string(), json!(name))]),
-            handle: 0,
-        };
-        let sel = role_named(Role::Application, name);
-        assert!(matches_simple(&data, &sel.segments[0].simple));
     }
 }

--- a/xa11y-core/src/element.rs
+++ b/xa11y-core/src/element.rs
@@ -460,8 +460,14 @@ mod tests {
     fn find_element(provider: &Arc<MockProvider>, selector: &str) -> Element {
         let parsed = Selector::parse(selector).expect("selector must parse");
         let provider_dyn: Arc<dyn Provider> = provider.clone();
+        let root = provider_dyn
+            .list_apps()
+            .expect("list_apps must succeed")
+            .into_iter()
+            .next()
+            .expect("mock provider must expose an application root");
         let mut matches = provider_dyn
-            .find_elements(None, &parsed, Some(1), None)
+            .find_elements(&root, &parsed, Some(1), None)
             .expect("find_elements must succeed");
         let data = matches.pop().expect("selector matched no elements");
         Element::new(data, provider_dyn)

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -798,6 +798,14 @@ mod tests {
     }
 
     impl Provider for FreshHandleProvider {
+        fn list_apps(&self) -> Result<Vec<crate::element::ElementData>> {
+            // App discovery routes through `get_children(None)` here so the
+            // freshly-minted handles flow through the same rewriter that
+            // `get_children` uses — keeping the "no handle is ever reused
+            // across calls" simulation honest for the list_apps path too.
+            self.get_children(None)
+        }
+
         fn get_children(
             &self,
             parent: Option<&crate::element::ElementData>,

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -628,4 +628,217 @@ mod tests {
             "dump should fail fast, took {elapsed:?}"
         );
     }
+
+    // ── Fresh-handle regression tests ───────────────────────────────────
+    //
+    // Real platform providers (Windows/UIA, macOS/AX, Linux/AT-SPI2) allocate
+    // a fresh `handle` for every element returned by every `get_children`
+    // call — see e.g. `WindowsProvider::cache_element`. The doc-order merge
+    // for multi-clause `SelectorGroup`s used to identify elements by handle
+    // to dedup the per-clause walks against a re-walk of the tree, which
+    // missed every lookup on real providers and returned 0 results. These
+    // tests wrap the standard `MockProvider` with a per-call handle-rewriter
+    // so the failure mode is reproducible without a real platform backend.
+
+    /// Wraps a `MockProvider`-like child source and rewrites every returned
+    /// `ElementData.handle` to a fresh atomic-incremented value. A backing
+    /// map remembers what the freshly-minted handle pointed to so subsequent
+    /// `get_children(Some(parent))` calls can look up the original mock-side
+    /// handle and delegate.
+    struct FreshHandleProvider {
+        inner: Arc<crate::mock::MockProvider>,
+        next: std::sync::atomic::AtomicU64,
+        // Map from freshly-minted handle → the inner provider's stable handle.
+        rewrite: std::sync::Mutex<std::collections::HashMap<u64, u64>>,
+    }
+
+    impl FreshHandleProvider {
+        fn wrap(inner: Arc<crate::mock::MockProvider>) -> Arc<dyn Provider> {
+            Arc::new(FreshHandleProvider {
+                inner,
+                next: std::sync::atomic::AtomicU64::new(1_000_000),
+                rewrite: std::sync::Mutex::new(std::collections::HashMap::new()),
+            })
+        }
+
+        fn translate(&self, fresh: u64) -> u64 {
+            self.rewrite
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&fresh)
+                .copied()
+                // Top-level calls pass through verbatim; only freshly-minted
+                // child handles need translation back to the inner mock's
+                // stable handle.
+                .unwrap_or(fresh)
+        }
+    }
+
+    impl Provider for FreshHandleProvider {
+        fn get_children(
+            &self,
+            parent: Option<&crate::element::ElementData>,
+        ) -> Result<Vec<crate::element::ElementData>> {
+            let translated = parent.map(|p| {
+                let inner = self.translate(p.handle);
+                let mut clone = p.clone();
+                clone.handle = inner;
+                clone
+            });
+            let children = self.inner.get_children(translated.as_ref())?;
+            let mut out = Vec::with_capacity(children.len());
+            for mut child in children {
+                let inner_handle = child.handle;
+                let fresh = self.next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                self.rewrite
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(fresh, inner_handle);
+                child.handle = fresh;
+                out.push(child);
+            }
+            Ok(out)
+        }
+
+        fn get_parent(
+            &self,
+            element: &crate::element::ElementData,
+        ) -> Result<Option<crate::element::ElementData>> {
+            let mut clone = element.clone();
+            clone.handle = self.translate(element.handle);
+            self.inner.get_parent(&clone)
+        }
+
+        // Action methods: irrelevant to selector resolution — delegate verbatim.
+        fn press(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.press(e)
+        }
+        fn focus(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.focus(e)
+        }
+        fn blur(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.blur(e)
+        }
+        fn toggle(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.toggle(e)
+        }
+        fn select(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.select(e)
+        }
+        fn expand(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.expand(e)
+        }
+        fn collapse(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.collapse(e)
+        }
+        fn show_menu(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.show_menu(e)
+        }
+        fn increment(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.increment(e)
+        }
+        fn decrement(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.decrement(e)
+        }
+        fn scroll_into_view(&self, e: &crate::element::ElementData) -> Result<()> {
+            self.inner.scroll_into_view(e)
+        }
+        fn set_value(&self, e: &crate::element::ElementData, v: &str) -> Result<()> {
+            self.inner.set_value(e, v)
+        }
+        fn set_numeric_value(&self, e: &crate::element::ElementData, v: f64) -> Result<()> {
+            self.inner.set_numeric_value(e, v)
+        }
+        fn type_text(&self, e: &crate::element::ElementData, t: &str) -> Result<()> {
+            self.inner.type_text(e, t)
+        }
+        fn set_text_selection(
+            &self,
+            e: &crate::element::ElementData,
+            start: u32,
+            end: u32,
+        ) -> Result<()> {
+            self.inner.set_text_selection(e, start, end)
+        }
+        fn perform_action(&self, e: &crate::element::ElementData, action: &str) -> Result<()> {
+            self.inner.perform_action(e, action)
+        }
+        fn subscribe(
+            &self,
+            e: &crate::element::ElementData,
+        ) -> Result<crate::event_provider::Subscription> {
+            self.inner.subscribe(e)
+        }
+    }
+
+    fn root_locator_fresh_handles(selector: &str) -> Locator {
+        let inner = build_provider();
+        let provider = FreshHandleProvider::wrap(inner);
+        Locator::new(provider, None, selector)
+    }
+
+    #[test]
+    fn group_fresh_handles_elements_in_document_order() {
+        // Regression: pre-fix, this returned 0 elements because the doc-order
+        // merge looked elements up by handle in a HashMap, and the per-clause
+        // walks vs. the merge walk produced disjoint handle sets.
+        let loc = root_locator_fresh_handles("button, text_field");
+        assert_eq!(
+            names(&loc.elements().unwrap()),
+            vec!["Back", "Forward", "Search"],
+        );
+    }
+
+    #[test]
+    fn group_fresh_handles_count_matches_stable_handles() {
+        // The count via fresh-handle provider must equal the count via the
+        // stable-handle mock — both should yield 2 (Back + Forward) for a
+        // dedup-overlapping group.
+        let stable = root_locator(r#"button, [name="Back"]"#);
+        let fresh = root_locator_fresh_handles(r#"button, [name="Back"]"#);
+        assert_eq!(stable.count().unwrap(), fresh.count().unwrap());
+        assert_eq!(fresh.count().unwrap(), 2);
+    }
+
+    #[test]
+    fn group_fresh_handles_exists_true_when_any_clause_matches() {
+        let loc = root_locator_fresh_handles(r#"button[name="Nope"], slider"#);
+        assert!(loc.exists().unwrap());
+    }
+
+    #[test]
+    fn group_fresh_handles_nth_picks_across_full_union() {
+        // `.nth(2)` on `button, text_field` over the fresh-handle provider
+        // must still return "Forward" — the 2nd of [Back, Forward, Search]
+        // in document order. Pre-fix, .nth(2) returned a "selector not
+        // matched" error because the underlying group resolution returned
+        // an empty union.
+        let loc = root_locator_fresh_handles("button, text_field").nth(2);
+        let el = loc.element().unwrap();
+        assert_eq!(el.data().name.as_deref(), Some("Forward"));
+    }
+
+    #[test]
+    fn group_fresh_handles_descendant_chain_resolves() {
+        // `.descendant("button")` on the (toolbar, group) group locator,
+        // run through the fresh-handle provider. Pre-fix, this chained
+        // selector returned 0 results.
+        let loc = root_locator_fresh_handles("toolbar, group").descendant("button");
+        assert_eq!(loc.selector(), "toolbar button, group button");
+        assert_eq!(names(&loc.elements().unwrap()), vec!["Back", "Forward"]);
+    }
+
+    #[test]
+    fn group_fresh_handles_three_clauses_doc_order() {
+        // Three-clause group over a fresh-handle provider — guards the
+        // bug-fix's invariant that the BTreeMap-by-path merge handles >2
+        // clauses correctly.
+        let loc = root_locator_fresh_handles("toolbar, slider, check_box");
+        // Document order through Navigation/Content: Navigation (toolbar),
+        // then Agree (check_box), then Volume (slider).
+        assert_eq!(
+            names(&loc.elements().unwrap()),
+            vec!["Navigation", "Agree", "Volume"]
+        );
+    }
 }

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -5,7 +5,7 @@ use crate::element::{Element, ElementData};
 use crate::error::{Error, Result};
 use crate::event::ElementState;
 use crate::provider::Provider;
-use crate::selector::{chain_combinator, SelectorGroup};
+use crate::selector::{chain_combinator, matches_simple, SelectorGroup};
 
 /// A lazy element descriptor that re-resolves against a fresh accessibility
 /// tree on every operation.
@@ -123,6 +123,93 @@ impl Locator {
 
     // ── Internal resolution ─────────────────────────────────────────
 
+    /// Resolve `group` to a flat, doc-order, deduped list of matches.
+    ///
+    /// When `self.root.is_some()`, this delegates straight to
+    /// `Provider::find_elements_group`. When `self.root.is_none()`, the
+    /// `Provider` trait no longer supports a rootless search — discovery and
+    /// search are now separate primitives. We replicate the legacy
+    /// "search across all apps" semantics here:
+    ///
+    /// 1. Enumerate apps via `Provider::list_apps()`.
+    /// 2. For each app, in app-enumeration order:
+    ///    a. If any clause's first segment matches the app element itself,
+    ///    include the app (single-segment clauses) or run that clause's
+    ///    remaining segments anchored at the app (multi-segment). This
+    ///    preserves the prior semantics of `find_elements(None, …)`, where
+    ///    `get_children(None)` returned the app and a search rooted at the
+    ///    system root matched it.
+    ///    b. Run `find_elements_group(&app, group, …)` to collect descendant
+    ///    matches inside the app's subtree.
+    /// 3. Dedup by `ElementData.handle` and apply the outer limit.
+    fn resolve_group(
+        &self,
+        group: &SelectorGroup,
+        limit: Option<usize>,
+    ) -> Result<Vec<ElementData>> {
+        if let Some(root) = self.root.as_ref() {
+            return self.provider.find_elements_group(root, group, limit, None);
+        }
+
+        // Rootless: search across all apps. We can't push the outer `limit`
+        // down to each per-app call because matches from a later app would
+        // be wrongly excluded; truncate after the merge instead. (Scoped
+        // searches via the single-app fast path above still get phase-1
+        // limit pushdown inside the native backend.)
+        let apps = self.provider.list_apps()?;
+        let mut out: Vec<ElementData> = Vec::new();
+        let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for app in &apps {
+            // (2a) The app element itself may match the selector — e.g.
+            // `application` or `application button`. `find_elements_group`
+            // only emits *descendants* of its root, so we test the app
+            // against each clause separately.
+            for clause in &group.clauses {
+                let first = match clause.segments.first() {
+                    Some(s) => s,
+                    None => continue,
+                };
+                if !matches_simple(app, &first.simple) {
+                    continue;
+                }
+                if clause.segments.len() == 1 {
+                    if seen.insert(app.handle) {
+                        out.push(app.clone());
+                    }
+                    continue;
+                }
+                // Multi-segment: app is a phase-1 anchor; narrow through
+                // the remaining segments. This mirrors the
+                // `find_elements_in_tree`-style phase-1/phase-2 split, but
+                // anchored at the app rather than a candidate from a walk.
+                let max_depth_val = crate::MAX_TREE_DEPTH;
+                let narrowed = self.provider.narrow_multi_segment(
+                    vec![app.clone()],
+                    &clause.segments[1..],
+                    max_depth_val,
+                    None,
+                )?;
+                for d in narrowed {
+                    if seen.insert(d.handle) {
+                        out.push(d);
+                    }
+                }
+            }
+
+            // (2b) Descendant matches inside the app's subtree.
+            let per_app = self.provider.find_elements_group(app, group, None, None)?;
+            for d in per_app {
+                if seen.insert(d.handle) {
+                    out.push(d);
+                }
+            }
+        }
+        if let Some(l) = limit {
+            out.truncate(l);
+        }
+        Ok(out)
+    }
+
     /// Resolve the selector to a single ElementData.
     fn resolve_data(&self) -> Result<ElementData> {
         let group = SelectorGroup::parse(&self.selector)?;
@@ -135,9 +222,7 @@ impl Locator {
         } else {
             None
         };
-        let matches =
-            self.provider
-                .find_elements_group(self.root.as_ref(), &group, provider_limit, None)?;
+        let matches = self.resolve_group(&group, provider_limit)?;
         let idx = self.nth.unwrap_or(0);
         matches
             .into_iter()
@@ -161,9 +246,7 @@ impl Locator {
     /// Count matching elements.
     pub fn count(&self) -> Result<usize> {
         let group = SelectorGroup::parse(&self.selector)?;
-        let matches = self
-            .provider
-            .find_elements_group(self.root.as_ref(), &group, None, None)?;
+        let matches = self.resolve_group(&group, None)?;
         Ok(matches.len())
     }
 
@@ -176,9 +259,7 @@ impl Locator {
     /// Get all matching elements.
     pub fn elements(&self) -> Result<Vec<Element>> {
         let group = SelectorGroup::parse(&self.selector)?;
-        let matches = self
-            .provider
-            .find_elements_group(self.root.as_ref(), &group, None, None)?;
+        let matches = self.resolve_group(&group, None)?;
         Ok(matches
             .into_iter()
             .map(|d| Element::new(d, Arc::clone(&self.provider)))
@@ -563,6 +644,48 @@ mod tests {
     fn group_exists_false_when_no_clause_matches() {
         let loc = root_locator(r#"button[name="Nope"], text_field[name="AlsoNope"]"#);
         assert!(!loc.exists().unwrap());
+    }
+
+    // ── Rootless search across apps ─────────────────────────────────
+
+    #[test]
+    fn rootless_group_matches_match_app_scoped_search() {
+        // `Locator::new(provider, None, …)` enumerates apps via
+        // `list_apps()` and unions per-app searches. For a single-app
+        // mock tree, the result must equal what `App::locator(…)` would
+        // produce (modulo the `application` root which only the rootless
+        // search can match, since app-scoped searches walk descendants).
+        let provider = build_provider();
+        let provider_dyn: Arc<dyn Provider> = provider;
+        let rootless = Locator::new(provider_dyn.clone(), None, "button, text_field");
+        let app_root = provider_dyn
+            .list_apps()
+            .expect("list_apps must succeed")
+            .into_iter()
+            .next()
+            .expect("mock provider must expose an application root");
+        let scoped = Locator::new(provider_dyn, Some(app_root), "button, text_field");
+        assert_eq!(
+            names(&rootless.elements().unwrap()),
+            vec!["Back", "Forward", "Search"]
+        );
+        assert_eq!(
+            names(&rootless.elements().unwrap()),
+            names(&scoped.elements().unwrap())
+        );
+    }
+
+    #[test]
+    fn list_apps_returns_mock_application_root() {
+        // The mock provider's `list_apps` must surface the single
+        // top-level Application element — the discovery primitive that
+        // `App::list_with` / `App::by_name_with` now use.
+        let provider = build_provider();
+        let provider_dyn: Arc<dyn Provider> = provider;
+        let apps = provider_dyn.list_apps().expect("list_apps must succeed");
+        assert_eq!(apps.len(), 1, "mock tree has exactly one application");
+        assert_eq!(apps[0].role, crate::role::Role::Application);
+        assert_eq!(apps[0].name.as_deref(), Some("TestApp"));
     }
 
     // ── tree() / dump() ─────────────────────────────────────────────

--- a/xa11y-core/src/mock.rs
+++ b/xa11y-core/src/mock.rs
@@ -126,6 +126,15 @@ impl Provider for MockProvider {
         Ok(self.nodes[idx].parent.map(|i| self.nodes[i].data.clone()))
     }
 
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        // The mock tree's root is a single Application node; expose it as
+        // the lone "app" so Locator's rootless path enumerates it.
+        if self.nodes.is_empty() {
+            return Ok(vec![]);
+        }
+        Ok(vec![self.nodes[0].data.clone()])
+    }
+
     fn press(&self, el: &ElementData) -> Result<()> {
         self.record(el, "press", None)
     }

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -40,7 +40,11 @@ pub trait Provider: Send + Sync {
     /// If `limit` is `Some(n)`, stops after finding `n` matches.
     /// If `max_depth` is `Some(d)`, does not descend deeper than `d` levels.
     ///
-    /// The default implementation traverses via [`get_children`](Self::get_children).
+    /// This is a thin convenience wrapper that re-uses
+    /// [`find_elements_group`](Self::find_elements_group) with a single-clause
+    /// group. Backends do **not** override this method — they override
+    /// `find_elements_group`, and the single-clause case runs through the
+    /// same native code path as multi-clause queries.
     fn find_elements(
         &self,
         root: Option<&ElementData>,
@@ -48,25 +52,28 @@ pub trait Provider: Send + Sync {
         limit: Option<usize>,
         max_depth: Option<u32>,
     ) -> Result<Vec<ElementData>> {
-        crate::selector::find_elements_in_tree(
-            |el| self.get_children(el),
-            root,
-            selector,
-            limit,
-            max_depth,
-        )
+        let group = SelectorGroup {
+            clauses: vec![selector.clone()],
+        };
+        self.find_elements_group(root, &group, limit, max_depth)
     }
 
     /// Search for elements matching any clause of a comma-separated selector
     /// group.
     ///
-    /// Single-clause groups short-circuit to [`find_elements`](Self::find_elements)
-    /// so providers that override the optimized single-clause path keep
-    /// their fast path. Multi-clause groups bypass per-clause `find_elements`
-    /// and walk via [`get_children`](Self::get_children) with path tracking,
-    /// because the cross-clause merge must identify elements by something
-    /// stable across walks — and platform `handle` values are not (every
-    /// backend mints a fresh handle per `get_children` call).
+    /// This is the **primary search primitive** each backend should override.
+    /// A native implementation performs ONE platform-level subtree query/walk
+    /// (e.g. `FindAllBuildCache(TreeScope_Subtree)` on Windows, one DFS over
+    /// AT-SPI children on Linux, one AX walk on macOS) and evaluates every
+    /// clause inline against each visited element. This avoids the
+    /// per-clause-walk perf cliff and also keeps the cross-clause dedup
+    /// correct: because everything happens inside one call, each platform
+    /// node is visited once and platform identity is stable.
+    ///
+    /// The default implementation traverses via [`get_children`](Self::get_children)
+    /// and uses tree-path identity for cross-clause merging. It's the
+    /// fallback for backends that haven't shipped a native override yet —
+    /// the same path the test/mock provider exercises.
     fn find_elements_group(
         &self,
         root: Option<&ElementData>,
@@ -74,9 +81,6 @@ pub trait Provider: Send + Sync {
         limit: Option<usize>,
         max_depth: Option<u32>,
     ) -> Result<Vec<ElementData>> {
-        if group.clauses.len() == 1 {
-            return self.find_elements(root, &group.clauses[0], limit, max_depth);
-        }
         crate::selector::find_elements_in_tree_group(
             |el| self.get_children(el),
             root,

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -60,11 +60,13 @@ pub trait Provider: Send + Sync {
     /// Search for elements matching any clause of a comma-separated selector
     /// group.
     ///
-    /// Forwards to [`find_elements`](Self::find_elements) once per clause and
-    /// merges results into the union, deduplicated by element identity and
-    /// returned in document order. Single-clause groups short-circuit to a
-    /// straight `find_elements` call, so providers that override the
-    /// optimized single-clause path keep their fast path.
+    /// Single-clause groups short-circuit to [`find_elements`](Self::find_elements)
+    /// so providers that override the optimized single-clause path keep
+    /// their fast path. Multi-clause groups bypass per-clause `find_elements`
+    /// and walk via [`get_children`](Self::get_children) with path tracking,
+    /// because the cross-clause merge must identify elements by something
+    /// stable across walks — and platform `handle` values are not (every
+    /// backend mints a fresh handle per `get_children` call).
     fn find_elements_group(
         &self,
         root: Option<&ElementData>,
@@ -75,17 +77,10 @@ pub trait Provider: Send + Sync {
         if group.clauses.len() == 1 {
             return self.find_elements(root, &group.clauses[0], limit, max_depth);
         }
-        // Each clause goes through the provider's own (possibly optimized)
-        // `find_elements`. The merge below walks once more via
-        // `get_children` to recover document order across clauses.
-        let mut clause_results = Vec::with_capacity(group.clauses.len());
-        for clause in &group.clauses {
-            clause_results.push(self.find_elements(root, clause, None, max_depth)?);
-        }
-        crate::selector::merge_clause_results_in_document_order(
+        crate::selector::find_elements_in_tree_group(
             |el| self.get_children(el),
             root,
-            clause_results,
+            group,
             limit,
             max_depth,
         )

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -33,21 +33,20 @@ pub trait Provider: Send + Sync {
 
     /// Enumerate top-level applications visible to this provider.
     ///
-    /// Backends should return one `ElementData` per application — typically
-    /// with `role=Application`, but Windows returns `role=Window` for
-    /// top-level HWNDs because UIA exposes applications as their top-level
-    /// window. This is the dedicated discovery primitive: it replaces the
-    /// previous `find_elements(None, application_selector, .., depth=0)`
-    /// idiom and lets each backend batch the platform-specific enumeration
-    /// (CGWindowList on macOS, the AT-SPI registry on Linux, UIA's desktop
-    /// root on Windows) in one place.
+    /// Backends return one `ElementData` per application — typically with
+    /// `role=Application`, but Windows returns `role=Window` for top-level
+    /// HWNDs because UIA exposes applications as their top-level window.
+    /// This is the dedicated discovery primitive: it replaces the previous
+    /// `find_elements(None, application_selector, .., depth=0)` idiom and
+    /// lets each backend batch the platform-specific enumeration (CGWindowList
+    /// on macOS, the AT-SPI registry on Linux, UIA's desktop root on Windows)
+    /// in one place.
     ///
-    /// The default impl delegates to `get_children(None)` so out-of-tree
-    /// providers (and the mock) continue to work without an explicit
-    /// override.
-    fn list_apps(&self) -> Result<Vec<ElementData>> {
-        self.get_children(None)
-    }
+    /// Required: every `Provider` implements this explicitly. There's no
+    /// default impl — discovery and subtree search have different cost
+    /// profiles, and silently routing app discovery through `get_children`
+    /// would hide the difference from implementors.
+    fn list_apps(&self) -> Result<Vec<ElementData>>;
 
     /// Search for elements matching a selector.
     ///

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -31,12 +31,31 @@ pub trait Provider: Send + Sync {
     /// Returns `None` for top-level (application) elements.
     fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>>;
 
+    /// Enumerate top-level applications visible to this provider.
+    ///
+    /// Backends should return one `ElementData` per application — typically
+    /// with `role=Application`, but Windows returns `role=Window` for
+    /// top-level HWNDs because UIA exposes applications as their top-level
+    /// window. This is the dedicated discovery primitive: it replaces the
+    /// previous `find_elements(None, application_selector, .., depth=0)`
+    /// idiom and lets each backend batch the platform-specific enumeration
+    /// (CGWindowList on macOS, the AT-SPI registry on Linux, UIA's desktop
+    /// root on Windows) in one place.
+    ///
+    /// The default impl delegates to `get_children(None)` so out-of-tree
+    /// providers (and the mock) continue to work without an explicit
+    /// override.
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        self.get_children(None)
+    }
+
     /// Search for elements matching a selector.
     ///
     /// The selector is already parsed by the core — providers match against it
     /// during traversal and can prune subtrees that can't match.
     ///
-    /// If `root` is `None`, searches from the system root (all applications).
+    /// `root` is the subtree root to search under (always present; use
+    /// [`list_apps`](Self::list_apps) to discover application roots first).
     /// If `limit` is `Some(n)`, stops after finding `n` matches.
     /// If `max_depth` is `Some(d)`, does not descend deeper than `d` levels.
     ///
@@ -47,7 +66,7 @@ pub trait Provider: Send + Sync {
     /// same native code path as multi-clause queries.
     fn find_elements(
         &self,
-        root: Option<&ElementData>,
+        root: &ElementData,
         selector: &Selector,
         limit: Option<usize>,
         max_depth: Option<u32>,
@@ -59,7 +78,7 @@ pub trait Provider: Send + Sync {
     }
 
     /// Search for elements matching any clause of a comma-separated selector
-    /// group.
+    /// group, scoped to `root`'s subtree.
     ///
     /// This is the **primary search primitive** each backend should override.
     /// A native implementation performs ONE platform-level subtree query/walk
@@ -70,20 +89,25 @@ pub trait Provider: Send + Sync {
     /// correct: because everything happens inside one call, each platform
     /// node is visited once and platform identity is stable.
     ///
+    /// `root` is non-optional: app discovery now goes through
+    /// [`list_apps`](Self::list_apps) and any rootless multi-app search is
+    /// performed by the caller (e.g. `Locator`) by enumerating apps and
+    /// invoking this method per app.
+    ///
     /// The default implementation traverses via [`get_children`](Self::get_children)
     /// and uses tree-path identity for cross-clause merging. It's the
     /// fallback for backends that haven't shipped a native override yet —
     /// the same path the test/mock provider exercises.
     fn find_elements_group(
         &self,
-        root: Option<&ElementData>,
+        root: &ElementData,
         group: &SelectorGroup,
         limit: Option<usize>,
         max_depth: Option<u32>,
     ) -> Result<Vec<ElementData>> {
         crate::selector::find_elements_in_tree_group(
             |el| self.get_children(el),
-            root,
+            Some(root),
             group,
             limit,
             max_depth,
@@ -118,12 +142,8 @@ pub trait Provider: Send + Sync {
                                 simple: segment.simple.clone(),
                             }],
                         };
-                        let mut sub_results = self.find_elements(
-                            Some(candidate),
-                            &sub_selector,
-                            None,
-                            Some(max_depth),
-                        )?;
+                        let mut sub_results =
+                            self.find_elements(candidate, &sub_selector, None, Some(max_depth))?;
                         next_candidates.append(&mut sub_results);
                     }
                     Combinator::Root => unreachable!(),
@@ -235,9 +255,12 @@ impl<T: Provider + ?Sized> Provider for &T {
     fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {
         (**self).get_parent(element)
     }
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        (**self).list_apps()
+    }
     fn find_elements(
         &self,
-        root: Option<&ElementData>,
+        root: &ElementData,
         selector: &Selector,
         limit: Option<usize>,
         max_depth: Option<u32>,
@@ -246,7 +269,7 @@ impl<T: Provider + ?Sized> Provider for &T {
     }
     fn find_elements_group(
         &self,
-        root: Option<&ElementData>,
+        root: &ElementData,
         group: &SelectorGroup,
         limit: Option<usize>,
         max_depth: Option<u32>,

--- a/xa11y-core/src/selector.rs
+++ b/xa11y-core/src/selector.rs
@@ -20,7 +20,7 @@
 //! union of each clause's matches, deduplicated by element identity and
 //! returned in document order. See [`SelectorGroup`].
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use crate::element::{ElementData, Toggled};
 use crate::error::{Error, Result};
@@ -700,15 +700,17 @@ pub fn find_elements_in_tree(
 /// Multi-clause variant of [`find_elements_in_tree`].
 ///
 /// Runs each clause in `group` independently, then returns the **union** of
-/// matches in **document order**, deduplicated by `ElementData.handle`. A
-/// single-clause group is forwarded straight to `find_elements_in_tree` with
-/// no extra traversal.
+/// matches in **document order**, deduplicated by tree position. A single-
+/// clause group is forwarded straight to `find_elements_in_tree` with no
+/// extra work.
 ///
-/// For multi-clause groups this performs one traversal per clause plus a
-/// second pass over the tree to recover document order (each clause's own
-/// result list is in DFS order, but DFS positions across clauses aren't
-/// comparable without a re-walk). The second walk short-circuits as soon as
-/// `limit` is hit or the entire union has been emitted.
+/// Identity for dedup and ordering is the path-from-root (sequence of child
+/// indices). This is the only identifier that's stable across multiple
+/// `get_children_fn` walks — `ElementData.handle` is *not*, because every
+/// real platform backend (Windows/UIA, macOS/AX, Linux/AT-SPI2) allocates a
+/// fresh handle on each `cache_element` call, so the same logical node sees
+/// disjoint handle values across the per-clause walks. Identifying by path
+/// keeps the union correct without requiring providers to stabilise handles.
 pub fn find_elements_in_tree_group<F>(
     get_children_fn: F,
     root: Option<&ElementData>,
@@ -723,121 +725,181 @@ where
         return find_elements_in_tree(get_children_fn, root, &group.clauses[0], limit, max_depth);
     }
 
-    // Run each clause independently. Re-borrow the closure for each inner
-    // call so the outer `get_children_fn` can still be used for the
-    // document-order merge below — `&F` implements `Fn` when `F` does, so
-    // we hand a shared borrow to `find_elements_in_tree` without moving the
-    // value.
+    // Run each clause via the path-tracking walker. The per-clause results
+    // are (path, snapshot) pairs where `path` is the sequence of child
+    // indices from `root` to the matched node — stable across walks because
+    // it's derived purely from `get_children_fn`'s iteration order, not from
+    // any platform-allocated identity.
     let f = &get_children_fn;
-    let mut clause_results = Vec::with_capacity(group.clauses.len());
+    let mut by_path: std::collections::BTreeMap<Vec<u32>, ElementData> =
+        std::collections::BTreeMap::new();
     for clause in &group.clauses {
-        clause_results.push(find_elements_in_tree(f, root, clause, None, max_depth)?);
+        let clause_results = find_elements_in_tree_with_paths(f, root, clause, max_depth)?;
+        for (path, data) in clause_results {
+            // First clause that matched at this path wins the snapshot —
+            // matches `find_elements_in_tree`'s first-write-wins on the
+            // single-clause path, and means later clauses' state-drifted
+            // re-reads of the same node don't shadow earlier ones.
+            by_path.entry(path).or_insert(data);
+        }
     }
-    merge_clause_results_in_document_order(get_children_fn, root, clause_results, limit, max_depth)
+
+    // BTreeMap iteration is sorted by key. Comparing `Vec<u32>` paths
+    // lexicographically is the same as document order from DFS traversal,
+    // so this is the cheapest way to recover the cross-clause merge order.
+    let mut out: Vec<ElementData> = by_path.into_values().collect();
+    if let Some(l) = limit {
+        out.truncate(l);
+    }
+    Ok(out)
 }
 
-/// Merge per-clause result lists into the union, deduped by element
-/// identity, in document order.
+/// Path-tracking variant of [`find_elements_in_tree`].
 ///
-/// Each input vec is one clause's matches (in any order — typically DFS
-/// from that clause's own traversal). The merge walks the tree once via
-/// `get_children_fn`, emitting any element whose handle appears in the
-/// union, stopping early when `limit` is satisfied or every union member
-/// has been emitted.
+/// Mirrors `find_elements_in_tree`'s phase-1 + phase-2 structure exactly,
+/// but every result carries the sequence of child indices from `root` to
+/// the matched node. The path is the canonical document-order identifier:
+/// stable across walks of the same `get_children_fn` and orderable
+/// lexicographically.
 ///
-/// `ElementData` snapshots are taken from the clause results (not the
-/// traversal), so the returned elements carry the attribute state the
-/// matcher actually saw — important if attributes drift between the
-/// per-clause walk and the merge walk.
-pub fn merge_clause_results_in_document_order<F>(
+/// Used by [`find_elements_in_tree_group`] to merge per-clause matches
+/// without relying on platform-allocated `handle` stability.
+pub fn find_elements_in_tree_with_paths<F>(
     get_children_fn: F,
     root: Option<&ElementData>,
-    clause_results: Vec<Vec<ElementData>>,
-    limit: Option<usize>,
+    selector: &Selector,
     max_depth: Option<u32>,
-) -> Result<Vec<ElementData>>
+) -> Result<Vec<(Vec<u32>, ElementData)>>
 where
     F: Fn(Option<&ElementData>) -> Result<Vec<ElementData>>,
 {
-    let mut snapshots: HashMap<u64, ElementData> = HashMap::new();
-    for results in clause_results {
-        for e in results {
-            snapshots.entry(e.handle).or_insert(e);
-        }
-    }
-    if snapshots.is_empty() {
+    if selector.segments.is_empty() {
         return Ok(vec![]);
     }
 
     let max_depth = max_depth.unwrap_or(crate::MAX_TREE_DEPTH);
-    let mut session = DocOrderEmit {
-        snapshots: &snapshots,
-        emitted: HashSet::new(),
-        out: Vec::with_capacity(snapshots.len().min(limit.unwrap_or(usize::MAX))),
-        max_depth,
-        limit,
+    let first = &selector.segments[0].simple;
+
+    // Phase 1: collect all matches for the first segment (DFS from root).
+    let phase1_depth = if root.is_none()
+        && matches!(
+            first.role,
+            Some(RoleMatch::Normalized(crate::role::Role::Application))
+        ) {
+        0
+    } else {
+        max_depth
     };
-    emit_in_document_order(&get_children_fn, root, &mut session, 0)?;
-    Ok(session.out)
+
+    let mut candidates: Vec<(Vec<u32>, ElementData)> = Vec::new();
+    let mut path_scratch = Vec::new();
+    collect_matching_with_paths(
+        &get_children_fn,
+        root,
+        first,
+        0,
+        phase1_depth,
+        &mut path_scratch,
+        &mut candidates,
+    )?;
+    apply_nth_paths(&mut candidates, first.nth);
+
+    // Phase 2: narrow through remaining segments. Each phase-2 descendant's
+    // path extends its phase-1 ancestor's path — so the resulting paths are
+    // still rooted at the original `root`.
+    for segment in &selector.segments[1..] {
+        let mut next: Vec<(Vec<u32>, ElementData)> = Vec::new();
+        for (cand_path, candidate) in &candidates {
+            match segment.combinator {
+                Combinator::Child => {
+                    let children = get_children_fn(Some(candidate))?;
+                    for (i, child) in children.into_iter().enumerate() {
+                        if matches_simple(&child, &segment.simple) {
+                            let mut p = cand_path.clone();
+                            p.push(i as u32);
+                            next.push((p, child));
+                        }
+                    }
+                }
+                Combinator::Descendant => {
+                    let mut sub: Vec<(Vec<u32>, ElementData)> = Vec::new();
+                    let mut sub_path = Vec::new();
+                    collect_matching_with_paths(
+                        &get_children_fn,
+                        Some(candidate),
+                        &segment.simple,
+                        0,
+                        max_depth,
+                        &mut sub_path,
+                        &mut sub,
+                    )?;
+                    for (sp, se) in sub {
+                        let mut p = cand_path.clone();
+                        p.extend(sp);
+                        next.push((p, se));
+                    }
+                }
+                Combinator::Root => unreachable!(),
+            }
+        }
+        // Dedup by path, preserving order — same shape as
+        // `find_elements_in_tree`'s handle-based dedup but stable across
+        // walks because paths are derived from traversal order.
+        let mut seen = HashSet::new();
+        next.retain(|(p, _)| seen.insert(p.clone()));
+        candidates = next;
+        apply_nth_paths(&mut candidates, segment.simple.nth);
+    }
+
+    Ok(candidates)
 }
 
-/// Per-call state bundled together so [`emit_in_document_order`] stays
-/// under the `too_many_arguments` clippy threshold and so the read-only
-/// (`snapshots`, `max_depth`, `limit`) and write (`emitted`, `out`) halves
-/// of the walk live in one place.
-struct DocOrderEmit<'a> {
-    snapshots: &'a HashMap<u64, ElementData>,
-    emitted: HashSet<u64>,
-    out: Vec<ElementData>,
-    max_depth: u32,
-    limit: Option<usize>,
-}
-
-impl DocOrderEmit<'_> {
-    /// True if we've hit `limit` (when set).
-    fn at_limit(&self) -> bool {
-        self.limit.is_some_and(|l| self.out.len() >= l)
+/// `apply_nth` for path-tagged candidates. Identical 1-based semantics to
+/// the plain version, including the "fewer-than-N → empty" rule.
+fn apply_nth_paths(candidates: &mut Vec<(Vec<u32>, ElementData)>, nth: Option<usize>) {
+    let Some(n) = nth else { return };
+    if n <= candidates.len() {
+        let kept = candidates.remove(n - 1);
+        candidates.clear();
+        candidates.push(kept);
+    } else {
+        candidates.clear();
     }
 }
 
-/// DFS-walk the tree and emit each handle in `session.snapshots` exactly
-/// once, in document order, stopping once `limit` is hit or every handle
-/// has been emitted.
-fn emit_in_document_order(
+/// DFS variant of [`collect_matching`] that tags each match with its path
+/// (sequence of child indices from the original walk root).
+///
+/// `path` is a scratch buffer pushed/popped at each level so the caller can
+/// share one allocation across the whole walk.
+fn collect_matching_with_paths(
     get_children_fn: &impl Fn(Option<&ElementData>) -> Result<Vec<ElementData>>,
     root: Option<&ElementData>,
-    session: &mut DocOrderEmit<'_>,
+    simple: &SimpleSelector,
     depth: u32,
+    max_depth: u32,
+    path: &mut Vec<u32>,
+    results: &mut Vec<(Vec<u32>, ElementData)>,
 ) -> Result<()> {
-    if depth > session.max_depth {
-        return Ok(());
-    }
-    if session.at_limit() {
-        return Ok(());
-    }
-    if session.emitted.len() == session.snapshots.len() {
-        // Every winning handle has been emitted — no need to keep walking.
+    if depth > max_depth {
         return Ok(());
     }
     let children = get_children_fn(root)?;
-    for child in children {
-        if let Some(snap) = session.snapshots.get(&child.handle) {
-            // A handle that appears multiple times in the tree (rare, but
-            // some Qt providers expose the same node via different parents)
-            // is still emitted only once — `emitted` tracks that.
-            if session.emitted.insert(child.handle) {
-                // Prefer the snapshot captured by clause matching — it
-                // carries the attribute state the matcher actually saw.
-                session.out.push(snap.clone());
-                if session.at_limit() {
-                    return Ok(());
-                }
-            }
+    for (i, child) in children.into_iter().enumerate() {
+        path.push(i as u32);
+        if matches_simple(&child, simple) {
+            results.push((path.clone(), child.clone()));
         }
-        emit_in_document_order(get_children_fn, Some(&child), session, depth + 1)?;
-        if session.at_limit() {
-            return Ok(());
-        }
+        collect_matching_with_paths(
+            get_children_fn,
+            Some(&child),
+            simple,
+            depth + 1,
+            max_depth,
+            path,
+            results,
+        )?;
+        path.pop();
     }
     Ok(())
 }
@@ -1886,5 +1948,451 @@ mod tests {
             find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
                 .unwrap();
         assert!(results.is_empty());
+    }
+
+    /// `get_children` closure that mimics how real platform providers behave:
+    /// each call allocates a fresh handle for every returned element, even for
+    /// the same logical node. The Windows, macOS, and Linux backends all do
+    /// this (each `cache_element` bumps a `NEXT_HANDLE` atomic), so two walks
+    /// of the same tree see entirely disjoint handle values for the same
+    /// nodes.
+    ///
+    /// The fixture identifies parents internally by name (stable across calls)
+    /// while the returned `ElementData.handle` is freshly minted every time —
+    /// this is exactly the shape that surfaced as "comma selector returned 0
+    /// results when it should have matched" in real usage.
+    fn fresh_handle_get_children(
+        tree: &[GroupRow],
+    ) -> impl Fn(Option<&ElementData>) -> Result<Vec<ElementData>> + '_ {
+        let next = std::cell::RefCell::new(1_000_000u64);
+        // Map from freshly-minted handle → stable row name, so subsequent calls
+        // can find the parent's row by handle even though row.handle ≠ the
+        // freshly-minted handle we previously returned.
+        let by_handle: std::cell::RefCell<std::collections::HashMap<u64, &'static str>> =
+            std::cell::RefCell::new(std::collections::HashMap::new());
+
+        move |parent: Option<&ElementData>| -> Result<Vec<ElementData>> {
+            let parent_row_handle = match parent {
+                None => None,
+                Some(p) => {
+                    let name = by_handle.borrow().get(&p.handle).copied().or_else(|| {
+                        tree.iter()
+                            .find(|r| Some(r.name) == p.name.as_deref())
+                            .map(|r| r.name)
+                    });
+                    name.and_then(|n| tree.iter().find(|r| r.name == n).map(|r| r.handle))
+                }
+            };
+            let mut out = Vec::new();
+            for row in tree.iter().filter(|r| r.parent == parent_row_handle) {
+                let fresh = {
+                    let mut n = next.borrow_mut();
+                    let v = *n;
+                    *n += 1;
+                    v
+                };
+                by_handle.borrow_mut().insert(fresh, row.name);
+                out.push(ElementData {
+                    role: row.role,
+                    name: Some(row.name.to_string()),
+                    value: None,
+                    description: None,
+                    bounds: None,
+                    actions: vec![],
+                    states: crate::element::StateSet::default(),
+                    numeric_value: None,
+                    min_value: None,
+                    max_value: None,
+                    stable_id: None,
+                    pid: Some(1),
+                    raw: std::collections::HashMap::new(),
+                    handle: fresh,
+                });
+            }
+            Ok(out)
+        }
+    }
+
+    #[test]
+    fn group_match_works_with_fresh_handles_per_walk() {
+        // Regression: the doc-order merge previously identified clause-match
+        // results by `ElementData.handle` and re-walked the tree to recover
+        // document order, looking up visited nodes by that same handle. On
+        // every real platform backend `get_children` allocates a fresh handle
+        // for each returned element on every call, so the re-walk's handles
+        // never matched the per-clause walks' handles — the lookup missed
+        // every time and the function returned 0 results.
+        //
+        // This test pins the fix: a fresh-handle `get_children` (one new
+        // handle per element per call) must still yield the full document-
+        // order union.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse("button, text_field").unwrap();
+        let results =
+            find_elements_in_tree_group(fresh_handle_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        assert_eq!(
+            names(&results),
+            vec!["Clear", "Search", "Save", "Cancel", "Password"],
+            "comma selector must work when get_children allocates fresh handles",
+        );
+    }
+
+    #[test]
+    fn group_match_fresh_handles_combinator_per_clause() {
+        // Same fresh-handle regression for multi-segment clauses: `toolbar
+        // button, dialog button` runs two clauses, each with a Descendant
+        // combinator. Pre-fix, this returned 0 results on real providers.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse("toolbar button, dialog button").unwrap();
+        let results =
+            find_elements_in_tree_group(fresh_handle_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        assert_eq!(names(&results), vec!["Clear", "Save", "Cancel"]);
+    }
+
+    #[test]
+    fn group_match_fresh_handles_overlapping_clauses_dedup() {
+        // Fresh-handle dedup: two clauses both match the same node. The
+        // result must include it exactly once, even though each clause walk
+        // mints a different handle for it.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse(r#"button[name="Clear"], button[name*="lea"]"#).unwrap();
+        let results =
+            find_elements_in_tree_group(fresh_handle_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        assert_eq!(names(&results), vec!["Clear"]);
+    }
+
+    #[test]
+    fn group_match_fresh_handles_limit_truncates_in_document_order() {
+        // Limit must still apply in document order, not in clause order.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse("button, text_field").unwrap();
+        let results = find_elements_in_tree_group(
+            fresh_handle_get_children(&tree),
+            None,
+            &group,
+            Some(2),
+            None,
+        )
+        .unwrap();
+        assert_eq!(names(&results), vec!["Clear", "Search"]);
+    }
+
+    // ── SelectorGroup parsing — additional edge cases ──────────────────────
+
+    #[test]
+    fn split_top_level_commas_unicode_around_commas() {
+        // Multi-byte chars adjacent to commas must not throw off the byte
+        // accounting — `split_top_level_commas` iterates `chars()` so this
+        // is just a sanity check that the contract holds for non-ASCII.
+        assert_eq!(
+            split_top_level_commas("café,naïve"),
+            vec!["café".to_string(), "naïve".to_string()],
+        );
+    }
+
+    #[test]
+    fn split_top_level_commas_nested_quotes() {
+        // A single-quoted value containing a double quote, followed by a
+        // double-quoted value containing a single quote — quotes must close
+        // against their own delimiter, not the opposite type.
+        assert_eq!(
+            split_top_level_commas(r#"[name='a"b,c'], [name="x'y,z"]"#),
+            vec![
+                r#"[name='a"b,c']"#.to_string(),
+                r#" [name="x'y,z"]"#.to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn parse_group_attribute_only_clauses() {
+        // Clauses with no role (attribute filters only) must parse correctly
+        // on both sides of the comma.
+        let group = SelectorGroup::parse(r#"[name="A"], [name="B"]"#).unwrap();
+        assert_eq!(group.clauses.len(), 2);
+        assert!(group.clauses[0].segments[0].simple.role.is_none());
+        assert!(group.clauses[1].segments[0].simple.role.is_none());
+        assert_eq!(group.clauses[0].segments[0].simple.filters[0].value, "A");
+        assert_eq!(group.clauses[1].segments[0].simple.filters[0].value, "B");
+    }
+
+    #[test]
+    fn parse_group_role_only_then_attribute_only() {
+        // Mixing role-only and attribute-only clauses: each clause must
+        // parse independently.
+        let group = SelectorGroup::parse(r#"button, [name="X"]"#).unwrap();
+        assert_eq!(group.clauses.len(), 2);
+        assert!(matches!(
+            group.clauses[0].segments[0].simple.role,
+            Some(RoleMatch::Normalized(Role::Button))
+        ));
+        assert!(group.clauses[1].segments[0].simple.role.is_none());
+    }
+
+    #[test]
+    fn parse_group_multiple_quoted_commas_in_one_clause() {
+        // Two attribute filters in the same clause, both containing commas.
+        // The clause must not be split, and both values must survive parsing.
+        let group =
+            SelectorGroup::parse(r#"button[name="a,b"][description="x,y"], slider"#).unwrap();
+        assert_eq!(group.clauses.len(), 2);
+        assert_eq!(group.clauses[0].segments[0].simple.filters.len(), 2);
+        assert_eq!(group.clauses[0].segments[0].simple.filters[0].value, "a,b");
+        assert_eq!(group.clauses[0].segments[0].simple.filters[1].value, "x,y");
+        assert!(matches!(
+            group.clauses[1].segments[0].simple.role,
+            Some(RoleMatch::Normalized(Role::Slider))
+        ));
+    }
+
+    #[test]
+    fn parse_group_nth_per_clause() {
+        // `:nth(N)` is per-clause; both clauses must parse with their own
+        // nth values.
+        let group = SelectorGroup::parse("button:nth(1), text_field:nth(2)").unwrap();
+        assert_eq!(group.clauses.len(), 2);
+        assert_eq!(group.clauses[0].segments[0].simple.nth, Some(1));
+        assert_eq!(group.clauses[1].segments[0].simple.nth, Some(2));
+    }
+
+    #[test]
+    fn parse_group_unterminated_quote_propagates_error() {
+        // An unterminated quoted value inside one clause must surface as a
+        // parse error from that clause — the unterminated string makes
+        // `split_top_level_commas` swallow the rest of the input as one
+        // tail clause, which then fails `Selector::parse`.
+        let err = SelectorGroup::parse(r#"button, [name="oops"#);
+        assert!(err.is_err(), "unterminated quote must error: {err:?}");
+    }
+
+    #[test]
+    fn parse_group_trailing_whitespace_is_tolerated() {
+        // Surrounding whitespace on the whole input is trimmed; per-clause
+        // whitespace also trims. None of this should produce empty clauses.
+        let group = SelectorGroup::parse("   button  ,   text_field   ").unwrap();
+        assert_eq!(group.clauses.len(), 2);
+        assert!(matches!(
+            group.clauses[0].segments[0].simple.role,
+            Some(RoleMatch::Normalized(Role::Button))
+        ));
+        assert!(matches!(
+            group.clauses[1].segments[0].simple.role,
+            Some(RoleMatch::Normalized(Role::TextField))
+        ));
+    }
+
+    #[test]
+    fn chain_combinator_handles_trailing_whitespace() {
+        // `chain_combinator` must trim each clause when stitching, so trailing
+        // whitespace from prior chaining doesn't leak into the produced
+        // selector string and break later parses.
+        assert_eq!(chain_combinator("a , b ", " ", " c "), "a c, b c");
+    }
+
+    #[test]
+    fn chain_combinator_preserves_attribute_filters_in_groups() {
+        // Attribute filters survive the round-trip through chain_combinator
+        // — important because Locator::descendant / child use this when
+        // chaining off a group locator that has filters.
+        assert_eq!(
+            chain_combinator(r#"button[name="A"], button[name="B"]"#, " ", "label"),
+            r#"button[name="A"] label, button[name="B"] label"#,
+        );
+    }
+
+    #[test]
+    fn chain_combinator_round_trips_through_parser() {
+        // chain_combinator's docs promise its output re-parses as a
+        // SelectorGroup. Test that contract end-to-end so regressions in
+        // either side surface immediately.
+        let cases = &[
+            ("a, b", " ", "c"),
+            ("a, b", " > ", "c, d"),
+            (r#"[name="a,b"]"#, " ", "c"),
+            ("toolbar, group", " > ", r#"button[name="OK"]"#),
+        ];
+        for (existing, comb, suffix) in cases {
+            let stitched = chain_combinator(existing, comb, suffix);
+            SelectorGroup::parse(&stitched).unwrap_or_else(|e| {
+                panic!("chain_combinator output {stitched:?} must re-parse, got {e:?}")
+            });
+        }
+    }
+
+    // ── find_elements_in_tree_group — additional matching cases ────────────
+
+    #[test]
+    fn group_match_three_clauses_doc_order() {
+        // Three clauses, each matching a different role. Result must
+        // interleave by document position across all three.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse("toolbar, dialog, button").unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        // DFS order: T(toolbar), Clear(button), Save(button), D(dialog), Cancel(button).
+        assert_eq!(names(&results), vec!["T", "Clear", "Save", "D", "Cancel"]);
+    }
+
+    #[test]
+    fn group_match_attribute_only_clauses_against_tree() {
+        // Attribute-only clauses (no role) — both clauses must traverse the
+        // full tree and match by attribute alone.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse(r#"[name="Clear"], [name="Password"]"#).unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        assert_eq!(names(&results), vec!["Clear", "Password"]);
+    }
+
+    #[test]
+    fn group_match_with_scoped_root() {
+        // Scope the search to the toolbar subtree. Only descendants of the
+        // toolbar match — the dialog branch must be excluded entirely, even
+        // for clauses that would match nodes there at the root level.
+        let tree = group_fixture();
+        let toolbar = ElementData {
+            role: Role::Toolbar,
+            name: Some("T".to_string()),
+            value: None,
+            description: None,
+            bounds: None,
+            actions: vec![],
+            states: crate::element::StateSet::default(),
+            numeric_value: None,
+            min_value: None,
+            max_value: None,
+            stable_id: None,
+            pid: Some(1),
+            raw: std::collections::HashMap::new(),
+            handle: 1,
+        };
+        let group = SelectorGroup::parse("button, text_field").unwrap();
+        let results = find_elements_in_tree_group(
+            group_get_children(&tree),
+            Some(&toolbar),
+            &group,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            names(&results),
+            vec!["Clear", "Search", "Save"],
+            "scoped search must exclude dialog-subtree matches",
+        );
+    }
+
+    #[test]
+    fn group_match_max_depth_zero_returns_top_level_only() {
+        // max_depth=0 means we visit children of root but not grandchildren.
+        // From system root, this yields only the application node.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse("application, toolbar").unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, Some(0))
+                .unwrap();
+        // Only "root" (application) is at depth 0 here; toolbar is deeper.
+        assert_eq!(names(&results), vec!["root"]);
+    }
+
+    #[test]
+    fn group_match_empty_group_clauses_returns_empty() {
+        // Defensive: a group whose every clause has zero matches yields an
+        // empty Vec, never an error.
+        let tree = group_fixture();
+        let group =
+            SelectorGroup::parse(r#"button[name="ZZZ"], dialog[name="QQQ"], slider"#).unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        assert!(results.is_empty());
+    }
+
+    // ── find_elements_in_tree_with_paths — path identity contract ──────────
+
+    #[test]
+    fn paths_match_dfs_indices_from_root() {
+        // Paths are the sole stable identity used to dedup multi-clause
+        // groups. Lock the contract: a single-segment clause matching `button`
+        // against the fixture must produce paths that correspond to the
+        // DFS-position of each match.
+        //
+        // Tree (DFS):
+        //   root(0) → toolbar(1) → Clear(2), Search(3), Save(4)
+        //          → dialog(5)  → Cancel(6), Password(7)
+        // Buttons live at:
+        //   Clear  = root/toolbar[0]/button[0] → path [0, 0, 0]
+        //   Save   = root/toolbar[0]/button[2] → path [0, 0, 2]
+        //   Cancel = root/dialog[1]/button[0]  → path [0, 1, 0]
+        let tree = group_fixture();
+        let sel = Selector::parse("button").unwrap();
+        let paths_and_data =
+            find_elements_in_tree_with_paths(group_get_children(&tree), None, &sel, None).unwrap();
+        let just_paths: Vec<Vec<u32>> = paths_and_data.iter().map(|(p, _)| p.clone()).collect();
+        let just_names: Vec<String> = paths_and_data
+            .iter()
+            .map(|(_, e)| e.name.clone().unwrap_or_default())
+            .collect();
+        assert_eq!(just_names, vec!["Clear", "Save", "Cancel"]);
+        assert_eq!(
+            just_paths,
+            vec![vec![0, 0, 0], vec![0, 0, 2], vec![0, 1, 0]],
+        );
+    }
+
+    #[test]
+    fn paths_are_stable_across_repeated_walks() {
+        // Running the same selector twice through `find_elements_in_tree_with_paths`
+        // must produce identical paths — this is the invariant the doc-order
+        // merge depends on. (The mock here uses stable handles, but the
+        // assertion is about path stability, which holds regardless of handle
+        // semantics.)
+        let tree = group_fixture();
+        let sel = Selector::parse("button").unwrap();
+        let a =
+            find_elements_in_tree_with_paths(group_get_children(&tree), None, &sel, None).unwrap();
+        let b =
+            find_elements_in_tree_with_paths(group_get_children(&tree), None, &sel, None).unwrap();
+        let a_paths: Vec<Vec<u32>> = a.iter().map(|(p, _)| p.clone()).collect();
+        let b_paths: Vec<Vec<u32>> = b.iter().map(|(p, _)| p.clone()).collect();
+        assert_eq!(a_paths, b_paths, "paths must be stable across walks");
+        assert_eq!(a_paths.len(), 3, "expected 3 button matches in fixture");
+    }
+
+    #[test]
+    fn paths_with_combinator_chain_extend_through_phase2() {
+        // For multi-segment selectors, the phase-2 path must extend the
+        // phase-1 candidate's path with the descendants' offsets. A
+        // `toolbar > button` selector should produce paths rooted in the
+        // toolbar's path, not in the button's local walk.
+        let tree = group_fixture();
+        let sel = Selector::parse("toolbar > button").unwrap();
+        let results =
+            find_elements_in_tree_with_paths(group_get_children(&tree), None, &sel, None).unwrap();
+        let paths: Vec<Vec<u32>> = results.iter().map(|(p, _)| p.clone()).collect();
+        // Toolbar is at root/[0]/[0] (path [0,0]); its button children at
+        // offsets 0 and 2 (Clear, Save). So:
+        //   Clear → [0, 0, 0]
+        //   Save  → [0, 0, 2]
+        assert_eq!(paths, vec![vec![0, 0, 0], vec![0, 0, 2]]);
+    }
+
+    #[test]
+    fn group_match_clause_with_no_role_and_filter() {
+        // A clause that's just `[name*="..."]` (no role) — exercised against
+        // the tree to confirm filter-only matching is intact in groups.
+        let tree = group_fixture();
+        let group = SelectorGroup::parse(r#"[name*="ear"], [name*="ass"]"#).unwrap();
+        let results =
+            find_elements_in_tree_group(group_get_children(&tree), None, &group, None, None)
+                .unwrap();
+        // "Clear" (contains "ear"), "Search" (contains "ear"), "Password"
+        // (contains "ass"). Doc order: Clear, Search, Password.
+        assert_eq!(names(&results), vec!["Clear", "Search", "Password"]);
     }
 }

--- a/xa11y-fuzz/src/bin/provider_fuzz.rs
+++ b/xa11y-fuzz/src/bin/provider_fuzz.rs
@@ -181,12 +181,16 @@ mod provider_fuzz {
             if self.app_element.is_some() {
                 return;
             }
-            let sel = Selector::parse(r#"application[name*="xa11y"]"#).unwrap();
-            match self.provider.find_elements(None, &sel, Some(1), None) {
-                Ok(matches) if !matches.is_empty() => {
-                    self.app_element = Some(matches.into_iter().next().unwrap());
-                }
-                Ok(_) => self.log("ensure_app: no match"),
+            // App discovery now goes through `list_apps()`; filter by name
+            // substring in Rust.
+            match self.provider.list_apps() {
+                Ok(apps) => match apps
+                    .into_iter()
+                    .find(|d| d.name.as_deref().is_some_and(|n| n.contains("xa11y")))
+                {
+                    Some(app) => self.app_element = Some(app),
+                    None => self.log("ensure_app: no match"),
+                },
                 Err(e) => self.log(&format!("ensure_app failed: {}", e)),
             }
         }
@@ -240,7 +244,13 @@ mod provider_fuzz {
 
     fn op_find_elements(state: &mut FuzzState) {
         state.ensure_app();
-        let app = state.app_element.clone();
+        // `find_elements` now requires a non-optional root; scope the
+        // search to the test app's subtree. If the app isn't available
+        // (caller hasn't launched it yet), skip this op.
+        let app = match state.app_element.clone() {
+            Some(a) => a,
+            None => return,
+        };
         let selector_str = random_selector(&mut state.rng);
         state.log(&format!("find_elements(\"{}\")", selector_str));
         let selector = match Selector::parse(&selector_str) {
@@ -252,7 +262,7 @@ mod provider_fuzz {
         };
         match state
             .provider
-            .find_elements(app.as_ref(), &selector, Some(10), None)
+            .find_elements(&app, &selector, Some(10), None)
         {
             Ok(results) => {
                 state.log(&format!("  -> {} matches", results.len()));
@@ -278,10 +288,7 @@ mod provider_fuzz {
 
         // Find some elements to act on
         let sel = Selector::parse("button").unwrap();
-        let elements = match state
-            .provider
-            .find_elements(Some(&app), &sel, Some(20), None)
-        {
+        let elements = match state.provider.find_elements(&app, &sel, Some(20), None) {
             Ok(e) => e,
             Err(_) => return,
         };
@@ -354,12 +361,14 @@ mod provider_fuzz {
         // Provider creation checks permissions (fails early if denied).
         let provider = create_provider().expect("Failed to create provider");
 
-        // Find the test app
-        let sel = Selector::parse(r#"application[name*="xa11y"]"#).unwrap();
+        // Find the test app via `list_apps()` + name-substring filter.
         let mut app_element = None;
         for attempt in 0..10 {
-            if let Ok(matches) = provider.find_elements(None, &sel, Some(1), None) {
-                if let Some(app) = matches.into_iter().next() {
+            if let Ok(apps) = provider.list_apps() {
+                if let Some(app) = apps
+                    .into_iter()
+                    .find(|d| d.name.as_deref().is_some_and(|n| n.contains("xa11y")))
+                {
                     eprintln!(
                         "Test app:   {} (PID {:?})",
                         app.name.as_deref().unwrap_or("?"),

--- a/xa11y-js/Cargo.lock
+++ b/xa11y-js/Cargo.lock
@@ -1557,7 +1557,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xa11y"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "xa11y-core",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "png",
  "serde",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-js"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-linux"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "evdev",
  "png",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-macos"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "cc",
  "core-foundation",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-windows"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "windows",

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -5,9 +5,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use rayon::prelude::*;
-use xa11y_core::selector::{Combinator, SelectorSegment};
 use xa11y_core::{
-    ElementData, Error, Provider, Rect, Result, Role, Selector, StateSet, Subscription, Toggled,
+    ElementData, Error, Provider, Rect, Result, Role, StateSet, Subscription, Toggled,
 };
 use zbus::blocking::{Connection, Proxy};
 
@@ -1109,34 +1108,11 @@ impl LinuxProvider {
         true
     }
 
-    /// DFS collect AccessibleRefs matching a SimpleSelector without building
-    /// full ElementData. Only the attributes required by the selector are
-    /// fetched for each candidate.
-    ///
-    /// Children at each level are processed in parallel via rayon.
-    fn collect_matching_refs(
-        &self,
-        parent: &AccessibleRef,
-        simple: &xa11y_core::selector::SimpleSelector,
-        depth: u32,
-        max_depth: u32,
-        limit: Option<usize>,
-    ) -> Result<Vec<AccessibleRef>> {
-        // Group-of-one delegates to the multi-clause variant, then drops the
-        // clause index. This keeps a single matcher path through the walk so
-        // single- and multi-clause queries trace identically.
-        let one = [simple];
-        let group_results =
-            self.collect_matching_refs_group(parent, &one, depth, max_depth, limit)?;
-        Ok(group_results.into_iter().map(|(_, r)| r).collect())
-    }
-
-    /// Multi-clause variant of [`collect_matching_refs`]: ONE DFS over the
-    /// subtree, evaluating each clause's first SimpleSelector against every
-    /// visited node. Emits `(clause_idx, AccessibleRef)` pairs in document
-    /// order; a node that matches multiple clauses is emitted once per
-    /// matching clause (the merge step in `find_elements_group` collapses
-    /// these by `(bus_name, path)` identity).
+    /// ONE DFS over the subtree, evaluating each clause's first SimpleSelector
+    /// against every visited node. Emits `(clause_idx, AccessibleRef)` pairs
+    /// in document order; a node that matches multiple clauses is emitted
+    /// once per matching clause (the merge step in `find_elements_group`
+    /// collapses these by `(bus_name, path)` identity).
     ///
     /// This is the "push-down to the platform query per group" core: a
     /// selector group like `button, text_field` traverses the AT-SPI tree
@@ -1265,167 +1241,6 @@ impl LinuxProvider {
         Ok(results)
     }
 
-    /// Single-clause fast path: the original pre-group `find_elements` impl.
-    /// Kept as an inherent method so `find_elements_group` can dispatch to
-    /// it for `clauses.len() == 1` without wrapping through the trait
-    /// method (which would just re-allocate a single-clause `SelectorGroup`).
-    fn find_elements_single(
-        &self,
-        root: Option<&ElementData>,
-        selector: &Selector,
-        limit: Option<usize>,
-        max_depth: Option<u32>,
-    ) -> Result<Vec<ElementData>> {
-        if selector.segments.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
-
-        // Phase 1: lightweight ref-based search for first segment.
-        // Only the attributes the selector needs are fetched per candidate.
-        let first = &selector.segments[0].simple;
-
-        let phase1_limit = if selector.segments.len() == 1 {
-            limit
-        } else {
-            None
-        };
-        let phase1_limit = match (phase1_limit, first.nth) {
-            (Some(l), Some(n)) => Some(l.max(n)),
-            (_, Some(n)) => Some(n),
-            (l, None) => l,
-        };
-
-        // Applications are always direct children of the registry root
-        let phase1_depth = if root.is_none()
-            && matches!(
-                first.role,
-                Some(xa11y_core::selector::RoleMatch::Normalized(
-                    Role::Application
-                ))
-            ) {
-            0
-        } else {
-            max_depth_val
-        };
-
-        let start_ref = match root {
-            None => AccessibleRef {
-                bus_name: "org.a11y.atspi.Registry".to_string(),
-                path: "/org/a11y/atspi/accessible/root".to_string(),
-            },
-            Some(el) => self.get_cached(el.handle)?,
-        };
-
-        let mut matching_refs =
-            self.collect_matching_refs(&start_ref, first, 0, phase1_depth, phase1_limit)?;
-
-        let pid_from_root = root.and_then(|r| r.pid);
-
-        // Single-segment: build ElementData only for matches, apply nth/limit
-        if selector.segments.len() == 1 {
-            if let Some(nth) = first.nth {
-                if nth <= matching_refs.len() {
-                    let aref = &matching_refs[nth - 1];
-                    let pid = if root.is_none() {
-                        self.get_app_pid(aref)
-                            .or_else(|| self.get_dbus_pid(&aref.bus_name))
-                    } else {
-                        pid_from_root
-                    };
-                    return Ok(vec![self.build_element_data(aref, pid)]);
-                } else {
-                    return Ok(vec![]);
-                }
-            }
-
-            if let Some(limit) = limit {
-                matching_refs.truncate(limit);
-            }
-
-            let is_root_search = root.is_none();
-            return Ok(matching_refs
-                .par_iter()
-                .map(|aref| {
-                    let pid = if is_root_search {
-                        self.get_app_pid(aref)
-                            .or_else(|| self.get_dbus_pid(&aref.bus_name))
-                    } else {
-                        pid_from_root
-                    };
-                    self.build_element_data(aref, pid)
-                })
-                .collect());
-        }
-
-        // Multi-segment: build ElementData for phase 1 matches, then narrow
-        // using standard matching on the (small) candidate set.
-        let is_root_search = root.is_none();
-        let mut candidates: Vec<ElementData> = matching_refs
-            .par_iter()
-            .map(|aref| {
-                let pid = if is_root_search {
-                    self.get_app_pid(aref)
-                        .or_else(|| self.get_dbus_pid(&aref.bus_name))
-                } else {
-                    pid_from_root
-                };
-                self.build_element_data(aref, pid)
-            })
-            .collect();
-
-        for segment in &selector.segments[1..] {
-            let mut next_candidates = Vec::new();
-            for candidate in &candidates {
-                match segment.combinator {
-                    Combinator::Child => {
-                        let children = self.get_children(Some(candidate))?;
-                        for child in children {
-                            if xa11y_core::selector::matches_simple(&child, &segment.simple) {
-                                next_candidates.push(child);
-                            }
-                        }
-                    }
-                    Combinator::Descendant => {
-                        let sub_selector = Selector {
-                            segments: vec![SelectorSegment {
-                                combinator: Combinator::Root,
-                                simple: segment.simple.clone(),
-                            }],
-                        };
-                        let mut sub_results = xa11y_core::selector::find_elements_in_tree(
-                            |el| self.get_children(el),
-                            Some(candidate),
-                            &sub_selector,
-                            None,
-                            Some(max_depth_val),
-                        )?;
-                        next_candidates.append(&mut sub_results);
-                    }
-                    Combinator::Root => unreachable!(),
-                }
-            }
-            let mut seen = HashSet::new();
-            next_candidates.retain(|e| seen.insert(e.handle));
-            candidates = next_candidates;
-        }
-
-        // Apply :nth on last segment
-        if let Some(nth) = selector.segments.last().and_then(|s| s.simple.nth) {
-            if nth <= candidates.len() {
-                candidates = vec![candidates.remove(nth - 1)];
-            } else {
-                candidates.clear();
-            }
-        }
-
-        if let Some(limit) = limit {
-            candidates.truncate(limit);
-        }
-
-        Ok(candidates)
-    }
 }
 
 impl Provider for LinuxProvider {
@@ -1525,28 +1340,20 @@ impl Provider for LinuxProvider {
         if group.clauses.is_empty() {
             return Ok(vec![]);
         }
-        // Single-clause groups take a non-trivial fast path (the original
-        // `find_elements` impl) — separated for readability and so per-clause
-        // optimizations (phase-1 limit short-circuit) don't have to coexist
-        // with the multi-clause cross-merge logic.
-        if group.clauses.len() == 1 {
-            return self.find_elements_single(root, &group.clauses[0], limit, max_depth);
+        // Reject any clause with zero segments early — `clause.segments[0]`
+        // below would otherwise panic.
+        if group.clauses.iter().any(|c| c.segments.is_empty()) {
+            return Ok(vec![]);
         }
 
-        // Multi-clause: ONE AT-SPI walk that evaluates every clause's first
-        // SimpleSelector against each visited node, then per-clause phase-2
-        // narrowing on the small candidate sets that fall out. Dedup uses
+        // ONE AT-SPI walk that evaluates every clause's first SimpleSelector
+        // against each visited node, then per-clause phase-2 narrowing on
+        // the small candidate sets that fall out. Dedup uses
         // `(bus_name, path)` — the only AT-SPI identifier that's stable
-        // across the per-clause narrowings (handles are minted fresh on each
-        // `build_element_data` call).
+        // across the per-clause narrowings (handles are minted fresh on
+        // each `build_element_data` call).
         let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
 
-        // If ANY clause's first segment is `application`, we need the full
-        // tree depth (because the walk starts at the registry and an
-        // `application`-only clause expects depth=0). The conservative
-        // choice is `max_depth_val` for the whole walk; the
-        // `application`-as-first-segment optimization only fires for
-        // single-clause queries.
         let firsts: Vec<&xa11y_core::selector::SimpleSelector> = group
             .clauses
             .iter()
@@ -1561,10 +1368,55 @@ impl Provider for LinuxProvider {
             Some(el) => self.get_cached(el.handle)?,
         };
 
-        // No per-walk limit: phase-1 hits for clause N might come before
-        // clause M's in doc order, so we need the union before truncating.
+        // ── Single-clause optimizations ───────────────────────────
+        // Two N=1-only optimizations are hoisted from the legacy
+        // `find_elements_single` body:
+        //
+        //   1. **Phase-1 limit short-circuit**: when there's exactly one
+        //      clause, propagate the user's `limit` (adjusted for `:nth`)
+        //      to the AT-SPI walk so e.g. `app.locator("button").first()`
+        //      stops at the first match. With multiple clauses, phase-1
+        //      hits for clause N might come before clause M's in doc
+        //      order, so we need the union before truncating. (Critical
+        //      on Electron-scale apps where this prevents 50k-node walks.)
+        //
+        //   2. **App-search depth shortcut**: when there's exactly one
+        //      clause AND `root.is_none()` AND the clause's first segment
+        //      matches `Role::Application`, applications are always
+        //      direct children of the registry root, so phase-1 depth is
+        //      0. Multi-clause groups can mix `application` with non-app
+        //      clauses, which need the full walk.
+        let (phase1_limit, phase1_depth) = if group.clauses.len() == 1 {
+            let clause = &group.clauses[0];
+            let first = firsts[0];
+            let outer = if clause.segments.len() == 1 {
+                limit
+            } else {
+                None
+            };
+            let p1_limit = match (outer, first.nth) {
+                (Some(l), Some(n)) => Some(l.max(n)),
+                (_, Some(n)) => Some(n),
+                (l, None) => l,
+            };
+            let p1_depth = if root.is_none()
+                && matches!(
+                    first.role,
+                    Some(xa11y_core::selector::RoleMatch::Normalized(
+                        Role::Application
+                    ))
+                ) {
+                0
+            } else {
+                max_depth_val
+            };
+            (p1_limit, p1_depth)
+        } else {
+            (None, max_depth_val)
+        };
+
         let phase1: Vec<(usize, AccessibleRef)> =
-            self.collect_matching_refs_group(&start_ref, &firsts, 0, max_depth_val, None)?;
+            self.collect_matching_refs_group(&start_ref, &firsts, 0, phase1_depth, phase1_limit)?;
 
         let pid_from_root = root.and_then(|r| r.pid);
         let is_root_search = root.is_none();
@@ -1659,21 +1511,6 @@ impl Provider for LinuxProvider {
             out.truncate(l);
         }
         Ok(out)
-    }
-
-    fn find_elements(
-        &self,
-        root: Option<&ElementData>,
-        selector: &Selector,
-        limit: Option<usize>,
-        max_depth: Option<u32>,
-    ) -> Result<Vec<ElementData>> {
-        // Route through the group primitive so the optimization shape is
-        // identical for single- and multi-clause queries (one phase-1 walk
-        // either way). The trait's default `find_elements` wraps into a
-        // single-clause group, but overriding here avoids the extra
-        // allocation when `find_elements` is called directly from `App` etc.
-        self.find_elements_single(root, selector, limit, max_depth)
     }
 
     fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1240,45 +1240,15 @@ impl LinuxProvider {
         }
         Ok(results)
     }
-
 }
 
 impl Provider for LinuxProvider {
     fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
         match element {
             None => {
-                // Top-level: list all AT-SPI application elements
-                let registry = AccessibleRef {
-                    bus_name: "org.a11y.atspi.Registry".to_string(),
-                    path: "/org/a11y/atspi/accessible/root".to_string(),
-                };
-                let children = self.get_atspi_children(&registry)?;
-
-                // Filter valid children first, then build in parallel
-                let valid: Vec<(&AccessibleRef, String)> = children
-                    .iter()
-                    .filter(|c| c.path != "/org/a11y/atspi/null")
-                    .filter_map(|c| {
-                        let name = self.get_name(c).unwrap_or_default();
-                        if name.is_empty() {
-                            None
-                        } else {
-                            Some((c, name))
-                        }
-                    })
-                    .collect();
-
-                let results: Vec<ElementData> = valid
-                    .par_iter()
-                    .map(|(child, app_name)| {
-                        let pid = self.get_app_pid(child);
-                        let mut data = self.build_element_data(child, pid);
-                        data.name = Some(app_name.clone());
-                        data
-                    })
-                    .collect();
-
-                Ok(results)
+                // Top-level: delegate to `list_apps()`, the canonical
+                // discovery primitive.
+                self.list_apps()
             }
             Some(element_data) => {
                 let aref = self.get_cached(element_data.handle)?;
@@ -1332,7 +1302,7 @@ impl Provider for LinuxProvider {
 
     fn find_elements_group(
         &self,
-        root: Option<&ElementData>,
+        root: &ElementData,
         group: &xa11y_core::selector::SelectorGroup,
         limit: Option<usize>,
         max_depth: Option<u32>,
@@ -1352,6 +1322,9 @@ impl Provider for LinuxProvider {
         // `(bus_name, path)` — the only AT-SPI identifier that's stable
         // across the per-clause narrowings (handles are minted fresh on
         // each `build_element_data` call).
+        //
+        // App discovery is handled separately by `list_apps()` — `root` is
+        // always present here.
         let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
 
         let firsts: Vec<&xa11y_core::selector::SimpleSelector> = group
@@ -1360,33 +1333,17 @@ impl Provider for LinuxProvider {
             .map(|c| &c.segments[0].simple)
             .collect();
 
-        let start_ref = match root {
-            None => AccessibleRef {
-                bus_name: "org.a11y.atspi.Registry".to_string(),
-                path: "/org/a11y/atspi/accessible/root".to_string(),
-            },
-            Some(el) => self.get_cached(el.handle)?,
-        };
+        let start_ref = self.get_cached(root.handle)?;
 
-        // ── Single-clause optimizations ───────────────────────────
-        // Two N=1-only optimizations are hoisted from the legacy
-        // `find_elements_single` body:
-        //
-        //   1. **Phase-1 limit short-circuit**: when there's exactly one
-        //      clause, propagate the user's `limit` (adjusted for `:nth`)
-        //      to the AT-SPI walk so e.g. `app.locator("button").first()`
-        //      stops at the first match. With multiple clauses, phase-1
-        //      hits for clause N might come before clause M's in doc
-        //      order, so we need the union before truncating. (Critical
-        //      on Electron-scale apps where this prevents 50k-node walks.)
-        //
-        //   2. **App-search depth shortcut**: when there's exactly one
-        //      clause AND `root.is_none()` AND the clause's first segment
-        //      matches `Role::Application`, applications are always
-        //      direct children of the registry root, so phase-1 depth is
-        //      0. Multi-clause groups can mix `application` with non-app
-        //      clauses, which need the full walk.
-        let (phase1_limit, phase1_depth) = if group.clauses.len() == 1 {
+        // ── Phase-1 limit short-circuit ───────────────────────────
+        // When there's exactly one clause, propagate the user's `limit`
+        // (adjusted for `:nth`) to the AT-SPI walk so e.g.
+        // `app.locator("button").first()` stops at the first match. With
+        // multiple clauses, phase-1 hits for clause N might come before
+        // clause M's in doc order, so we need the union before truncating.
+        // (Critical on Electron-scale apps where this prevents 50k-node
+        // walks.)
+        let phase1_limit = if group.clauses.len() == 1 {
             let clause = &group.clauses[0];
             let first = firsts[0];
             let outer = if clause.segments.len() == 1 {
@@ -1394,32 +1351,19 @@ impl Provider for LinuxProvider {
             } else {
                 None
             };
-            let p1_limit = match (outer, first.nth) {
+            match (outer, first.nth) {
                 (Some(l), Some(n)) => Some(l.max(n)),
                 (_, Some(n)) => Some(n),
                 (l, None) => l,
-            };
-            let p1_depth = if root.is_none()
-                && matches!(
-                    first.role,
-                    Some(xa11y_core::selector::RoleMatch::Normalized(
-                        Role::Application
-                    ))
-                ) {
-                0
-            } else {
-                max_depth_val
-            };
-            (p1_limit, p1_depth)
+            }
         } else {
-            (None, max_depth_val)
+            None
         };
 
         let phase1: Vec<(usize, AccessibleRef)> =
-            self.collect_matching_refs_group(&start_ref, &firsts, 0, phase1_depth, phase1_limit)?;
+            self.collect_matching_refs_group(&start_ref, &firsts, 0, max_depth_val, phase1_limit)?;
 
-        let pid_from_root = root.and_then(|r| r.pid);
-        let is_root_search = root.is_none();
+        let pid_from_root = root.pid;
 
         // Bucket phase-1 hits by clause so each clause's tail can narrow
         // independently. `walk_pos` preserves the doc-order rank from the
@@ -1447,13 +1391,10 @@ impl Provider for LinuxProvider {
             let phase1_data: Vec<(usize, ElementData)> = hits
                 .par_iter()
                 .map(|(pos, aref)| {
-                    let pid = if is_root_search {
-                        self.get_app_pid(aref)
-                            .or_else(|| self.get_dbus_pid(&aref.bus_name))
-                    } else {
-                        pid_from_root
-                    };
-                    (*pos, self.build_element_data(aref, pid))
+                    // `root` is always present now, so the PID comes from
+                    // the root element. No need to re-resolve via
+                    // `get_app_pid` / `get_dbus_pid`.
+                    (*pos, self.build_element_data(aref, pid_from_root))
                 })
                 .collect();
 
@@ -1522,6 +1463,46 @@ impl Provider for LinuxProvider {
             }
             None => Ok(None),
         }
+    }
+
+    /// Enumerate top-level applications by listing direct children of the
+    /// AT-SPI registry root — every running accessibility-enabled app
+    /// registers a child accessible there. Apps with empty names are
+    /// filtered out (toolkits sometimes register transient/system
+    /// accessibles before the real app appears). PID resolution uses the
+    /// AT-SPI `Application` interface, falling back to the D-Bus owner.
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        let registry = AccessibleRef {
+            bus_name: "org.a11y.atspi.Registry".to_string(),
+            path: "/org/a11y/atspi/accessible/root".to_string(),
+        };
+        let children = self.get_atspi_children(&registry)?;
+
+        // Filter valid children first, then build in parallel
+        let valid: Vec<(&AccessibleRef, String)> = children
+            .iter()
+            .filter(|c| c.path != "/org/a11y/atspi/null")
+            .filter_map(|c| {
+                let name = self.get_name(c).unwrap_or_default();
+                if name.is_empty() {
+                    None
+                } else {
+                    Some((c, name))
+                }
+            })
+            .collect();
+
+        let results: Vec<ElementData> = valid
+            .par_iter()
+            .map(|(child, app_name)| {
+                let pid = self.get_app_pid(child);
+                let mut data = self.build_element_data(child, pid);
+                data.name = Some(app_name.clone());
+                data
+            })
+            .collect();
+
+        Ok(results)
     }
 
     fn press(&self, element: &ElementData) -> Result<()> {

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1122,6 +1122,33 @@ impl LinuxProvider {
         max_depth: u32,
         limit: Option<usize>,
     ) -> Result<Vec<AccessibleRef>> {
+        // Group-of-one delegates to the multi-clause variant, then drops the
+        // clause index. This keeps a single matcher path through the walk so
+        // single- and multi-clause queries trace identically.
+        let one = [simple];
+        let group_results =
+            self.collect_matching_refs_group(parent, &one, depth, max_depth, limit)?;
+        Ok(group_results.into_iter().map(|(_, r)| r).collect())
+    }
+
+    /// Multi-clause variant of [`collect_matching_refs`]: ONE DFS over the
+    /// subtree, evaluating each clause's first SimpleSelector against every
+    /// visited node. Emits `(clause_idx, AccessibleRef)` pairs in document
+    /// order; a node that matches multiple clauses is emitted once per
+    /// matching clause (the merge step in `find_elements_group` collapses
+    /// these by `(bus_name, path)` identity).
+    ///
+    /// This is the "push-down to the platform query per group" core: a
+    /// selector group like `button, text_field` traverses the AT-SPI tree
+    /// exactly once regardless of clause count, instead of N separate walks.
+    fn collect_matching_refs_group(
+        &self,
+        parent: &AccessibleRef,
+        clauses: &[&xa11y_core::selector::SimpleSelector],
+        depth: u32,
+        max_depth: u32,
+        limit: Option<usize>,
+    ) -> Result<Vec<(usize, AccessibleRef)>> {
         if depth > max_depth {
             return Ok(vec![]);
         }
@@ -1174,7 +1201,11 @@ impl LinuxProvider {
             self.check_chromium_a11y_enabled(parent, None)?;
         }
 
-        // Process each child subtree in parallel: check match + recurse.
+        // Process each child subtree in parallel: check match against every
+        // clause + recurse. Tagging each match with `clause_idx` lets the
+        // caller route phase-2 narrowing to the right clause without
+        // re-running the first-segment match.
+        //
         // We deliberately swallow transient sibling errors here — a single
         // flaky D-Bus call on one child shouldn't fail the whole locator
         // query (the rest of this file is similarly tolerant via
@@ -1182,14 +1213,20 @@ impl LinuxProvider {
         // transient error: it's the signal that a Chromium renderer bridge
         // isn't initialised, and callers need to see it. So we propagate
         // that variant specifically and keep tolerating everything else.
-        let per_child: Vec<(Vec<AccessibleRef>, Option<Error>)> = to_search
+        // Per-child batches: matches collected during that child's subtree
+        // walk, plus the first AccessibilityNotEnabled error (if any).
+        type ChildBatch = (Vec<(usize, AccessibleRef)>, Option<Error>);
+        let per_child: Vec<ChildBatch> = to_search
             .par_iter()
             .map(|child| {
-                let mut child_results = Vec::new();
-                if self.matches_ref(child, simple) {
-                    child_results.push(child.clone());
+                let mut child_results: Vec<(usize, AccessibleRef)> = Vec::new();
+                for (idx, simple) in clauses.iter().enumerate() {
+                    if self.matches_ref(child, simple) {
+                        child_results.push((idx, child.clone()));
+                    }
                 }
-                match self.collect_matching_refs(child, simple, depth + 1, max_depth, limit) {
+                match self.collect_matching_refs_group(child, clauses, depth + 1, max_depth, limit)
+                {
                     Ok(sub) => {
                         child_results.extend(sub);
                         (child_results, None)
@@ -1204,6 +1241,13 @@ impl LinuxProvider {
         // error seen wins — any child subtree raising it means the whole
         // query is untrustworthy, so surface it rather than return partial
         // data.
+        //
+        // Note: `limit` is the *caller's* outer limit; for a multi-clause
+        // group it must not be applied per-clause (a low-priority clause's
+        // hit could come before a high-priority clause's in doc order, so
+        // truncating mid-walk would drop legitimate matches). Callers pass
+        // `None` for multi-clause queries and apply the limit after the
+        // cross-clause merge.
         let mut results = Vec::new();
         for (batch, maybe_err) in per_child {
             if let Some(err) = maybe_err {
@@ -1220,96 +1264,12 @@ impl LinuxProvider {
         }
         Ok(results)
     }
-}
 
-impl Provider for LinuxProvider {
-    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
-        match element {
-            None => {
-                // Top-level: list all AT-SPI application elements
-                let registry = AccessibleRef {
-                    bus_name: "org.a11y.atspi.Registry".to_string(),
-                    path: "/org/a11y/atspi/accessible/root".to_string(),
-                };
-                let children = self.get_atspi_children(&registry)?;
-
-                // Filter valid children first, then build in parallel
-                let valid: Vec<(&AccessibleRef, String)> = children
-                    .iter()
-                    .filter(|c| c.path != "/org/a11y/atspi/null")
-                    .filter_map(|c| {
-                        let name = self.get_name(c).unwrap_or_default();
-                        if name.is_empty() {
-                            None
-                        } else {
-                            Some((c, name))
-                        }
-                    })
-                    .collect();
-
-                let results: Vec<ElementData> = valid
-                    .par_iter()
-                    .map(|(child, app_name)| {
-                        let pid = self.get_app_pid(child);
-                        let mut data = self.build_element_data(child, pid);
-                        data.name = Some(app_name.clone());
-                        data
-                    })
-                    .collect();
-
-                Ok(results)
-            }
-            Some(element_data) => {
-                let aref = self.get_cached(element_data.handle)?;
-                let children = self.get_atspi_children(&aref).unwrap_or_default();
-                let pid = element_data.pid;
-
-                // Pre-filter invalid refs and flatten nested application nodes,
-                // collecting the concrete refs to build in parallel.
-                let mut to_build: Vec<AccessibleRef> = Vec::new();
-                for child_ref in &children {
-                    if child_ref.path == "/org/a11y/atspi/null"
-                        || child_ref.bus_name.is_empty()
-                        || child_ref.path.is_empty()
-                    {
-                        continue;
-                    }
-                    let child_role = self.get_role_name(child_ref).unwrap_or_default();
-                    if child_role == "application" {
-                        let grandchildren = self.get_atspi_children(child_ref).unwrap_or_default();
-                        for gc_ref in grandchildren {
-                            if gc_ref.path == "/org/a11y/atspi/null"
-                                || gc_ref.bus_name.is_empty()
-                                || gc_ref.path.is_empty()
-                            {
-                                continue;
-                            }
-                            let gc_role = self.get_role_name(&gc_ref).unwrap_or_default();
-                            if gc_role == "application" {
-                                continue;
-                            }
-                            to_build.push(gc_ref);
-                        }
-                        continue;
-                    }
-                    to_build.push(child_ref.clone());
-                }
-
-                if to_build.is_empty() {
-                    self.check_chromium_a11y_enabled(&aref, Some(element_data.role))?;
-                }
-
-                let results: Vec<ElementData> = to_build
-                    .par_iter()
-                    .map(|r| self.build_element_data(r, pid))
-                    .collect();
-
-                Ok(results)
-            }
-        }
-    }
-
-    fn find_elements(
+    /// Single-clause fast path: the original pre-group `find_elements` impl.
+    /// Kept as an inherent method so `find_elements_group` can dispatch to
+    /// it for `clauses.len() == 1` without wrapping through the trait
+    /// method (which would just re-allocate a single-clause `SelectorGroup`).
+    fn find_elements_single(
         &self,
         root: Option<&ElementData>,
         selector: &Selector,
@@ -1465,6 +1425,255 @@ impl Provider for LinuxProvider {
         }
 
         Ok(candidates)
+    }
+}
+
+impl Provider for LinuxProvider {
+    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
+        match element {
+            None => {
+                // Top-level: list all AT-SPI application elements
+                let registry = AccessibleRef {
+                    bus_name: "org.a11y.atspi.Registry".to_string(),
+                    path: "/org/a11y/atspi/accessible/root".to_string(),
+                };
+                let children = self.get_atspi_children(&registry)?;
+
+                // Filter valid children first, then build in parallel
+                let valid: Vec<(&AccessibleRef, String)> = children
+                    .iter()
+                    .filter(|c| c.path != "/org/a11y/atspi/null")
+                    .filter_map(|c| {
+                        let name = self.get_name(c).unwrap_or_default();
+                        if name.is_empty() {
+                            None
+                        } else {
+                            Some((c, name))
+                        }
+                    })
+                    .collect();
+
+                let results: Vec<ElementData> = valid
+                    .par_iter()
+                    .map(|(child, app_name)| {
+                        let pid = self.get_app_pid(child);
+                        let mut data = self.build_element_data(child, pid);
+                        data.name = Some(app_name.clone());
+                        data
+                    })
+                    .collect();
+
+                Ok(results)
+            }
+            Some(element_data) => {
+                let aref = self.get_cached(element_data.handle)?;
+                let children = self.get_atspi_children(&aref).unwrap_or_default();
+                let pid = element_data.pid;
+
+                // Pre-filter invalid refs and flatten nested application nodes,
+                // collecting the concrete refs to build in parallel.
+                let mut to_build: Vec<AccessibleRef> = Vec::new();
+                for child_ref in &children {
+                    if child_ref.path == "/org/a11y/atspi/null"
+                        || child_ref.bus_name.is_empty()
+                        || child_ref.path.is_empty()
+                    {
+                        continue;
+                    }
+                    let child_role = self.get_role_name(child_ref).unwrap_or_default();
+                    if child_role == "application" {
+                        let grandchildren = self.get_atspi_children(child_ref).unwrap_or_default();
+                        for gc_ref in grandchildren {
+                            if gc_ref.path == "/org/a11y/atspi/null"
+                                || gc_ref.bus_name.is_empty()
+                                || gc_ref.path.is_empty()
+                            {
+                                continue;
+                            }
+                            let gc_role = self.get_role_name(&gc_ref).unwrap_or_default();
+                            if gc_role == "application" {
+                                continue;
+                            }
+                            to_build.push(gc_ref);
+                        }
+                        continue;
+                    }
+                    to_build.push(child_ref.clone());
+                }
+
+                if to_build.is_empty() {
+                    self.check_chromium_a11y_enabled(&aref, Some(element_data.role))?;
+                }
+
+                let results: Vec<ElementData> = to_build
+                    .par_iter()
+                    .map(|r| self.build_element_data(r, pid))
+                    .collect();
+
+                Ok(results)
+            }
+        }
+    }
+
+    fn find_elements_group(
+        &self,
+        root: Option<&ElementData>,
+        group: &xa11y_core::selector::SelectorGroup,
+        limit: Option<usize>,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ElementData>> {
+        if group.clauses.is_empty() {
+            return Ok(vec![]);
+        }
+        // Single-clause groups take a non-trivial fast path (the original
+        // `find_elements` impl) — separated for readability and so per-clause
+        // optimizations (phase-1 limit short-circuit) don't have to coexist
+        // with the multi-clause cross-merge logic.
+        if group.clauses.len() == 1 {
+            return self.find_elements_single(root, &group.clauses[0], limit, max_depth);
+        }
+
+        // Multi-clause: ONE AT-SPI walk that evaluates every clause's first
+        // SimpleSelector against each visited node, then per-clause phase-2
+        // narrowing on the small candidate sets that fall out. Dedup uses
+        // `(bus_name, path)` — the only AT-SPI identifier that's stable
+        // across the per-clause narrowings (handles are minted fresh on each
+        // `build_element_data` call).
+        let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
+
+        // If ANY clause's first segment is `application`, we need the full
+        // tree depth (because the walk starts at the registry and an
+        // `application`-only clause expects depth=0). The conservative
+        // choice is `max_depth_val` for the whole walk; the
+        // `application`-as-first-segment optimization only fires for
+        // single-clause queries.
+        let firsts: Vec<&xa11y_core::selector::SimpleSelector> = group
+            .clauses
+            .iter()
+            .map(|c| &c.segments[0].simple)
+            .collect();
+
+        let start_ref = match root {
+            None => AccessibleRef {
+                bus_name: "org.a11y.atspi.Registry".to_string(),
+                path: "/org/a11y/atspi/accessible/root".to_string(),
+            },
+            Some(el) => self.get_cached(el.handle)?,
+        };
+
+        // No per-walk limit: phase-1 hits for clause N might come before
+        // clause M's in doc order, so we need the union before truncating.
+        let phase1: Vec<(usize, AccessibleRef)> =
+            self.collect_matching_refs_group(&start_ref, &firsts, 0, max_depth_val, None)?;
+
+        let pid_from_root = root.and_then(|r| r.pid);
+        let is_root_search = root.is_none();
+
+        // Bucket phase-1 hits by clause so each clause's tail can narrow
+        // independently. `walk_pos` preserves the doc-order rank from the
+        // single walk for the final merge.
+        let mut by_clause: Vec<Vec<(usize, AccessibleRef)>> =
+            (0..group.clauses.len()).map(|_| Vec::new()).collect();
+        for (walk_pos, (clause_idx, aref)) in phase1.into_iter().enumerate() {
+            by_clause[clause_idx].push((walk_pos, aref));
+        }
+
+        // For each clause, build ElementData for its phase-1 hits, then
+        // narrow through any trailing segments. Single-segment clauses
+        // skip phase 2 entirely.
+        //
+        // Each narrowed result keeps a (walk_pos, ElementData) pair: the
+        // walk_pos of its phase-1 ancestor is the doc-order anchor we use
+        // to merge across clauses at the end.
+        let mut merged: Vec<(usize, ElementData)> = Vec::new();
+        for (clause_idx, hits) in by_clause.into_iter().enumerate() {
+            if hits.is_empty() {
+                continue;
+            }
+            let clause = &group.clauses[clause_idx];
+            // Build ElementData for this clause's phase-1 hits in parallel.
+            let phase1_data: Vec<(usize, ElementData)> = hits
+                .par_iter()
+                .map(|(pos, aref)| {
+                    let pid = if is_root_search {
+                        self.get_app_pid(aref)
+                            .or_else(|| self.get_dbus_pid(&aref.bus_name))
+                    } else {
+                        pid_from_root
+                    };
+                    (*pos, self.build_element_data(aref, pid))
+                })
+                .collect();
+
+            if clause.segments.len() == 1 {
+                // Apply :nth on the first segment (per-clause, then merged).
+                let mut candidates = phase1_data;
+                if let Some(nth) = clause.segments[0].simple.nth {
+                    if nth <= candidates.len() {
+                        let kept = candidates.remove(nth - 1);
+                        candidates.clear();
+                        candidates.push(kept);
+                    } else {
+                        candidates.clear();
+                    }
+                }
+                merged.extend(candidates);
+                continue;
+            }
+
+            // Multi-segment narrowing: re-use the trait helper. Each
+            // narrowed result is anchored at the phase-1 ancestor's
+            // walk_pos so the final sort puts it in doc order against
+            // other clauses.
+            for (anchor_pos, head) in phase1_data {
+                let narrowed = self.narrow_multi_segment(
+                    vec![head],
+                    &clause.segments[1..],
+                    max_depth_val,
+                    None,
+                )?;
+                for n in narrowed {
+                    merged.push((anchor_pos, n));
+                }
+            }
+        }
+
+        // Doc-order merge: stable sort by walk position. Within the same
+        // walk position multiple clauses can have emitted the same node —
+        // dedup by AT-SPI identity (`(bus_name, path)`) keeps the first.
+        merged.sort_by_key(|(pos, _)| *pos);
+        let mut seen: HashSet<(String, String)> = HashSet::new();
+        let mut out: Vec<ElementData> = Vec::with_capacity(merged.len());
+        for (_, data) in merged {
+            // Use the cached AccessibleRef for identity, not the (handle).
+            // Handle is freshly minted per `build_element_data` call so it
+            // would never collide here.
+            if let Ok(aref) = self.get_cached(data.handle) {
+                if !seen.insert((aref.bus_name.clone(), aref.path.clone())) {
+                    continue;
+                }
+            }
+            out.push(data);
+        }
+        if let Some(l) = limit {
+            out.truncate(l);
+        }
+        Ok(out)
+    }
+
+    fn find_elements(
+        &self,
+        root: Option<&ElementData>,
+        selector: &Selector,
+        limit: Option<usize>,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ElementData>> {
+        // Route through the group primitive so the optimization shape is
+        // identical for single- and multi-clause queries (one phase-1 walk
+        // either way). The trait's default `find_elements` wraps into a
+        // single-clause group, but overriding here avoids the extra
+        // allocation when `find_elements` is called directly from `App` etc.
+        self.find_elements_single(root, selector, limit, max_depth)
     }
 
     fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {

--- a/xa11y-linux/src/stub.rs
+++ b/xa11y-linux/src/stub.rs
@@ -91,6 +91,10 @@ impl Provider for LinuxProvider {
         Err(unavailable())
     }
 
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        Err(unavailable())
+    }
+
     fn press(&self, _: &ElementData) -> Result<()> {
         Err(unavailable())
     }

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -13,8 +13,10 @@ use rayon::prelude::*;
 
 use xa11y_core::{
     CancelHandle, ElementData, Error, Event, EventKind, EventReceiver, Provider, Rect, Result,
-    Role, Selector, StateFlag, StateSet, Subscription, Toggled,
+    Role, StateFlag, StateSet, Subscription, Toggled,
 };
+#[cfg(test)]
+use xa11y_core::Selector;
 
 // ── FFI Declarations ──────────────────────────────────────────────────────────
 
@@ -1651,47 +1653,20 @@ impl MacOSProvider {
         )
     }
 
-    /// Parallel DFS collecting AXElements matching a SimpleSelector without
-    /// building full ElementData. At each level, children are processed in
-    /// parallel using rayon — each child's role check and recursive subtree
-    /// search happen concurrently across threads.
-    #[allow(clippy::too_many_arguments)] // recursive DFS with parent context
-    fn collect_matching_ax(
-        &self,
-        parent: &AXElement,
-        parent_role: Role,
-        parent_name: Option<&str>,
-        simple: &SimpleSelector,
-        depth: u32,
-        max_depth: u32,
-        limit: Option<usize>,
-    ) -> Vec<AXElement> {
-        // Single-clause delegates to the group walker, then drops the clause
-        // index. Keeps the AX walk in exactly one code path.
-        let clauses = [simple];
-        let group = self.collect_matching_ax_group(
-            parent,
-            parent_role,
-            parent_name,
-            &clauses,
-            depth,
-            max_depth,
-            limit,
-        );
-        group.into_iter().map(|(_, ax)| ax).collect()
-    }
-
-    /// Multi-clause variant of [`collect_matching_ax`]: ONE AX walk over the
-    /// subtree, evaluating every clause's first SimpleSelector against each
-    /// visited element. Emits `(clause_idx, AXElement)` pairs in document
-    /// order. An element that matches multiple clauses is emitted once per
-    /// matching clause — the caller deduplicates by `AXUIElement` pointer
-    /// identity at merge time.
+    /// Parallel DFS over the AX subtree, evaluating every clause's first
+    /// `SimpleSelector` against each visited element. Emits
+    /// `(clause_idx, AXElement)` pairs in document order. An element that
+    /// matches multiple clauses is emitted once per matching clause — the
+    /// caller deduplicates by `AXUIElement` pointer identity at merge time.
+    ///
+    /// At each level, children are processed in parallel using rayon —
+    /// each child's role check and recursive subtree search happen
+    /// concurrently across threads.
     ///
     /// `limit` here is the *outer* limit; for groups with more than one
     /// clause it must be passed as `None` because cross-clause doc-order
     /// can promote later-clause hits ahead of earlier ones.
-    #[allow(clippy::too_many_arguments)] // mirrors `collect_matching_ax` shape
+    #[allow(clippy::too_many_arguments)] // recursive DFS with parent context
     fn collect_matching_ax_group(
         &self,
         parent: &AXElement,
@@ -1768,157 +1743,6 @@ impl MacOSProvider {
         results
     }
 
-    /// Single-clause fast path: the original pre-group `find_elements` impl.
-    /// Kept as an inherent method so `find_elements_group` can dispatch to
-    /// it for `clauses.len() == 1` without wrapping through the trait
-    /// method (which would re-allocate a single-clause `SelectorGroup`).
-    fn find_elements_single(
-        &self,
-        root: Option<&ElementData>,
-        selector: &Selector,
-        limit: Option<usize>,
-        max_depth: Option<u32>,
-    ) -> Result<Vec<ElementData>> {
-        if selector.segments.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
-
-        // Phase 1: lightweight AXElement-based search for first segment.
-        // Only the attributes the selector needs are fetched per candidate.
-        let first = &selector.segments[0].simple;
-
-        let phase1_limit = if selector.segments.len() == 1 {
-            limit
-        } else {
-            None
-        };
-        let phase1_limit = match (phase1_limit, first.nth) {
-            (Some(l), Some(n)) => Some(l.max(n)),
-            (_, Some(n)) => Some(n),
-            (l, None) => l,
-        };
-
-        let root_data = match root {
-            Some(el) => el,
-            None => {
-                // Searching from system root for applications. Use
-                // CGWindowList (no AX calls) to filter apps by name, then
-                // only build full ElementData for matches.
-                if matches!(
-                    first.role,
-                    Some(xa11y_core::selector::RoleMatch::Normalized(
-                        Role::Application
-                    ))
-                ) {
-                    let apps = Self::list_gui_apps();
-                    let mut matching: Vec<ElementData> = Vec::new();
-                    for (pid, app_name) in &apps {
-                        // Check name filters against CGWindowList name
-                        let name_matches = first.filters.iter().all(|f| {
-                            if f.attr != "name" {
-                                return true; // non-name filters checked after build
-                            }
-                            match_op(&f.op, &f.value, Some(app_name.as_str()))
-                        });
-                        if !name_matches {
-                            continue;
-                        }
-
-                        let app_element =
-                            AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
-                        if app_element.is_null() {
-                            continue;
-                        }
-                        let mut data = self.build_element_data(&app_element, Some(*pid as u32));
-                        data.name = Some(app_name.clone());
-                        matching.push(data);
-
-                        if let Some(limit) = phase1_limit {
-                            if matching.len() >= limit {
-                                break;
-                            }
-                        }
-                    }
-
-                    // Apply :nth
-                    if let Some(nth) = first.nth {
-                        if nth <= matching.len() {
-                            matching = vec![matching.remove(nth - 1)];
-                        } else {
-                            matching.clear();
-                        }
-                    }
-
-                    if selector.segments.len() == 1 {
-                        if let Some(limit) = limit {
-                            matching.truncate(limit);
-                        }
-                        return Ok(matching);
-                    }
-
-                    return self.narrow_multi_segment(
-                        matching,
-                        &selector.segments[1..],
-                        max_depth_val,
-                        limit,
-                    );
-                }
-
-                // Non-application root search — fall back to default impl.
-                return xa11y_core::selector::find_elements_in_tree(
-                    |el| self.get_children(el),
-                    root,
-                    selector,
-                    limit,
-                    max_depth,
-                );
-            }
-        };
-
-        let root_ax = self.get_cached(root_data.handle)?;
-
-        let mut matching_ax = self.collect_matching_ax(
-            &root_ax,
-            root_data.role,
-            root_data.name.as_deref(),
-            first,
-            0,
-            max_depth_val,
-            phase1_limit,
-        );
-
-        // Single-segment: build ElementData only for matches, apply nth/limit
-        if selector.segments.len() == 1 {
-            if let Some(nth) = first.nth {
-                if nth <= matching_ax.len() {
-                    let ax = &matching_ax[nth - 1];
-                    return Ok(vec![self.build_element_data(ax, root_data.pid)]);
-                } else {
-                    return Ok(vec![]);
-                }
-            }
-
-            if let Some(limit) = limit {
-                matching_ax.truncate(limit);
-            }
-
-            return Ok(matching_ax
-                .iter()
-                .map(|ax| self.build_element_data(ax, root_data.pid))
-                .collect());
-        }
-
-        // Multi-segment: build ElementData for phase 1 matches, then narrow
-        // using standard matching on the (small) candidate set.
-        let candidates: Vec<ElementData> = matching_ax
-            .iter()
-            .map(|ax| self.build_element_data(ax, root_data.pid))
-            .collect();
-
-        self.narrow_multi_segment(candidates, &selector.segments[1..], max_depth_val, limit)
-    }
 }
 
 impl Provider for MacOSProvider {
@@ -1965,21 +1789,6 @@ impl Provider for MacOSProvider {
         }
     }
 
-    fn find_elements(
-        &self,
-        root: Option<&ElementData>,
-        selector: &Selector,
-        limit: Option<usize>,
-        max_depth: Option<u32>,
-    ) -> Result<Vec<ElementData>> {
-        // Route through the per-backend single-clause helper rather than
-        // wrapping into a `SelectorGroup` first — the trait's default
-        // `find_elements` does the wrap, but providing this override
-        // skips the redundant allocation when callers (e.g. `App::list`)
-        // already have a bare `Selector`.
-        self.find_elements_single(root, selector, limit, max_depth)
-    }
-
     fn find_elements_group(
         &self,
         root: Option<&ElementData>,
@@ -1990,25 +1799,110 @@ impl Provider for MacOSProvider {
         if group.clauses.is_empty() {
             return Ok(vec![]);
         }
-        if group.clauses.len() == 1 {
-            return self.find_elements_single(root, &group.clauses[0], limit, max_depth);
+        // Reject any clause with zero segments early — `clause.segments[0]`
+        // below would otherwise panic.
+        if group.clauses.iter().any(|c| c.segments.is_empty()) {
+            return Ok(vec![]);
         }
 
-        // Multi-clause: ONE AX walk that evaluates every clause's first
-        // SimpleSelector inline. Each match is tagged with its clause index;
-        // per-clause phase-2 narrowing follows. The cross-clause merge
-        // deduplicates by AXUIElement pointer identity — that's the only
-        // identifier stable across narrowings within a single call (handles
-        // are minted fresh on every `build_element_data`).
+        // ONE AX walk that evaluates every clause's first SimpleSelector
+        // inline. Each match is tagged with its clause index; per-clause
+        // phase-2 narrowing follows. The cross-clause merge deduplicates by
+        // AXUIElement pointer identity — that's the only identifier stable
+        // across narrowings within a single call (handles are minted fresh
+        // on every `build_element_data`).
         let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
 
-        // The root-of-system + `application` shortcut from the single-clause
-        // path doesn't generalise here (mixing `application` with non-app
-        // clauses needs the full AX walk anyway), so for now system-root
-        // multi-clause queries fall through to the default tree-walking
-        // implementation. This still goes through ONE walk per query (the
-        // default `find_elements_in_tree_group`), it just doesn't get the
-        // CGWindowList optimization.
+        // ── N=1 CGWindowList shortcut ────────────────────────────
+        // Single clause + system root + first segment matches
+        // `Role::Application`: skip the AX walk entirely and use
+        // CGWindowList (no AX calls) to enumerate apps, then build full
+        // ElementData only for matches. Multi-clause groups can mix
+        // `application` with non-app clauses, which would still need the
+        // full AX walk — so this shortcut intentionally only fires for
+        // N=1.
+        if group.clauses.len() == 1 && root.is_none() {
+            let clause = &group.clauses[0];
+            let first = &clause.segments[0].simple;
+            if matches!(
+                first.role,
+                Some(xa11y_core::selector::RoleMatch::Normalized(
+                    Role::Application
+                ))
+            ) {
+                // N=1 phase-1 limit: propagate the user's `limit` (adjusted
+                // for `:nth`) so the iteration stops at the first match.
+                let outer = if clause.segments.len() == 1 {
+                    limit
+                } else {
+                    None
+                };
+                let phase1_limit = match (outer, first.nth) {
+                    (Some(l), Some(n)) => Some(l.max(n)),
+                    (_, Some(n)) => Some(n),
+                    (l, None) => l,
+                };
+
+                let apps = Self::list_gui_apps();
+                let mut matching: Vec<ElementData> = Vec::new();
+                for (pid, app_name) in &apps {
+                    // Check name filters against CGWindowList name
+                    let name_matches = first.filters.iter().all(|f| {
+                        if f.attr != "name" {
+                            return true; // non-name filters checked after build
+                        }
+                        match_op(&f.op, &f.value, Some(app_name.as_str()))
+                    });
+                    if !name_matches {
+                        continue;
+                    }
+
+                    let app_element =
+                        AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
+                    if app_element.is_null() {
+                        continue;
+                    }
+                    let mut data = self.build_element_data(&app_element, Some(*pid as u32));
+                    data.name = Some(app_name.clone());
+                    matching.push(data);
+
+                    if let Some(cap) = phase1_limit {
+                        if matching.len() >= cap {
+                            break;
+                        }
+                    }
+                }
+
+                // Apply :nth
+                if let Some(nth) = first.nth {
+                    if nth <= matching.len() {
+                        matching = vec![matching.remove(nth - 1)];
+                    } else {
+                        matching.clear();
+                    }
+                }
+
+                if clause.segments.len() == 1 {
+                    if let Some(l) = limit {
+                        matching.truncate(l);
+                    }
+                    return Ok(matching);
+                }
+
+                return self.narrow_multi_segment(
+                    matching,
+                    &clause.segments[1..],
+                    max_depth_val,
+                    limit,
+                );
+            }
+        }
+
+        // Non-application root or multi-clause at the system root: the
+        // CGWindowList shortcut doesn't generalise (mixing `application`
+        // with non-app clauses needs the full AX walk anyway), so fall
+        // through to the default tree-walking implementation. This still
+        // goes through ONE walk per query.
         let root_data = match root {
             Some(el) => el,
             None => {
@@ -2030,8 +1924,29 @@ impl Provider for MacOSProvider {
             .map(|c| &c.segments[0].simple)
             .collect();
 
-        // One AX walk for the whole group; no phase-1 limit (see comment in
-        // Linux impl) — the merge needs the full union before applying limit.
+        // N=1 phase-1 limit short-circuit: when there's exactly one clause,
+        // propagate the user's `limit` (adjusted for `:nth`) to the AX walk
+        // so e.g. `app.locator("button").first()` stops at the first match.
+        // For N>=2, phase-1 must collect the full union before truncating
+        // because cross-clause doc-order can promote later-clause hits
+        // ahead of earlier ones.
+        let phase1_walk_limit = if group.clauses.len() == 1 {
+            let clause = &group.clauses[0];
+            let first = firsts[0];
+            let outer = if clause.segments.len() == 1 {
+                limit
+            } else {
+                None
+            };
+            match (outer, first.nth) {
+                (Some(l), Some(n)) => Some(l.max(n)),
+                (_, Some(n)) => Some(n),
+                (l, None) => l,
+            }
+        } else {
+            None
+        };
+
         let phase1: Vec<(usize, AXElement)> = self.collect_matching_ax_group(
             &root_ax,
             root_data.role,
@@ -2039,7 +1954,7 @@ impl Provider for MacOSProvider {
             &firsts,
             0,
             max_depth_val,
-            None,
+            phase1_walk_limit,
         );
 
         // Bucket phase-1 hits by clause + their doc-order walk position.

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -1666,17 +1666,53 @@ impl MacOSProvider {
         max_depth: u32,
         limit: Option<usize>,
     ) -> Vec<AXElement> {
+        // Single-clause delegates to the group walker, then drops the clause
+        // index. Keeps the AX walk in exactly one code path.
+        let clauses = [simple];
+        let group = self.collect_matching_ax_group(
+            parent,
+            parent_role,
+            parent_name,
+            &clauses,
+            depth,
+            max_depth,
+            limit,
+        );
+        group.into_iter().map(|(_, ax)| ax).collect()
+    }
+
+    /// Multi-clause variant of [`collect_matching_ax`]: ONE AX walk over the
+    /// subtree, evaluating every clause's first SimpleSelector against each
+    /// visited element. Emits `(clause_idx, AXElement)` pairs in document
+    /// order. An element that matches multiple clauses is emitted once per
+    /// matching clause — the caller deduplicates by `AXUIElement` pointer
+    /// identity at merge time.
+    ///
+    /// `limit` here is the *outer* limit; for groups with more than one
+    /// clause it must be passed as `None` because cross-clause doc-order
+    /// can promote later-clause hits ahead of earlier ones.
+    #[allow(clippy::too_many_arguments)] // mirrors `collect_matching_ax` shape
+    fn collect_matching_ax_group(
+        &self,
+        parent: &AXElement,
+        parent_role: Role,
+        parent_name: Option<&str>,
+        clauses: &[&SimpleSelector],
+        depth: u32,
+        max_depth: u32,
+        limit: Option<usize>,
+    ) -> Vec<(usize, AXElement)> {
         if depth > max_depth {
             return vec![];
         }
 
         let children = ax_children(parent.as_ptr());
 
-        // Process children in parallel: check match + recurse.
-        let per_child_results: Vec<Vec<AXElement>> = children
+        // Process children in parallel: check each clause + recurse.
+        let per_child_results: Vec<Vec<(usize, AXElement)>> = children
             .par_iter()
             .map(|child| {
-                let mut child_results = Vec::new();
+                let mut child_results: Vec<(usize, AXElement)> = Vec::new();
 
                 // Fetch role+subrole once — used for filter, match, and recursion.
                 let role_str = ax_string(child.as_ptr(), "AXRole").unwrap_or_default();
@@ -1694,17 +1730,19 @@ impl MacOSProvider {
 
                 let child_role = map_ax_role(&role_str, subrole_str.as_deref());
 
-                if matches_ax_with_role(child.as_ptr(), simple, Some(child_role)) {
-                    child_results.push(child.clone());
+                for (idx, simple) in clauses.iter().enumerate() {
+                    if matches_ax_with_role(child.as_ptr(), simple, Some(child_role)) {
+                        child_results.push((idx, child.clone()));
+                    }
                 }
 
                 // Recurse into subtree.
                 let child_name = ax_string(child.as_ptr(), "AXTitle");
-                let sub = self.collect_matching_ax(
+                let sub = self.collect_matching_ax_group(
                     child,
                     child_role,
                     child_name.as_deref(),
-                    simple,
+                    clauses,
                     depth + 1,
                     max_depth,
                     limit,
@@ -1729,53 +1767,12 @@ impl MacOSProvider {
         }
         results
     }
-}
 
-impl Provider for MacOSProvider {
-    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
-        match element {
-            None => {
-                // Top-level: list all GUI apps as application elements
-                let apps = Self::list_gui_apps();
-                let mut results = Vec::new();
-                for (pid, app_name) in &apps {
-                    let app_element =
-                        AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
-                    if app_element.is_null() {
-                        continue;
-                    }
-                    let mut data = self.build_element_data(&app_element, Some(*pid as u32));
-                    // Override name with the CGWindowList name (more reliable)
-                    data.name = Some(app_name.clone());
-                    results.push(data);
-                }
-                Ok(results)
-            }
-            Some(element_data) => {
-                let ax = self.get_cached(element_data.handle)?;
-                let role = element_data.role;
-                let name = element_data.name.as_deref();
-
-                let ax_children_list = ax_children(ax.as_ptr());
-
-                // Filter first (cheap string checks), then build ElementData
-                // in parallel (each build_element_data is an IPC round-trip).
-                let filtered: Vec<&AXElement> = ax_children_list
-                    .iter()
-                    .filter(|child| !Self::should_filter_child(role, name, child))
-                    .collect();
-
-                let results: Vec<ElementData> = filtered
-                    .par_iter()
-                    .map(|child| self.build_element_data(child, element_data.pid))
-                    .collect();
-
-                Ok(results)
-            }
-        }
-    }
-
-    fn find_elements(
+    /// Single-clause fast path: the original pre-group `find_elements` impl.
+    /// Kept as an inherent method so `find_elements_group` can dispatch to
+    /// it for `clauses.len() == 1` without wrapping through the trait
+    /// method (which would re-allocate a single-clause `SelectorGroup`).
+    fn find_elements_single(
         &self,
         root: Option<&ElementData>,
         selector: &Selector,
@@ -1921,6 +1918,214 @@ impl Provider for MacOSProvider {
             .collect();
 
         self.narrow_multi_segment(candidates, &selector.segments[1..], max_depth_val, limit)
+    }
+}
+
+impl Provider for MacOSProvider {
+    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
+        match element {
+            None => {
+                // Top-level: list all GUI apps as application elements
+                let apps = Self::list_gui_apps();
+                let mut results = Vec::new();
+                for (pid, app_name) in &apps {
+                    let app_element =
+                        AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
+                    if app_element.is_null() {
+                        continue;
+                    }
+                    let mut data = self.build_element_data(&app_element, Some(*pid as u32));
+                    // Override name with the CGWindowList name (more reliable)
+                    data.name = Some(app_name.clone());
+                    results.push(data);
+                }
+                Ok(results)
+            }
+            Some(element_data) => {
+                let ax = self.get_cached(element_data.handle)?;
+                let role = element_data.role;
+                let name = element_data.name.as_deref();
+
+                let ax_children_list = ax_children(ax.as_ptr());
+
+                // Filter first (cheap string checks), then build ElementData
+                // in parallel (each build_element_data is an IPC round-trip).
+                let filtered: Vec<&AXElement> = ax_children_list
+                    .iter()
+                    .filter(|child| !Self::should_filter_child(role, name, child))
+                    .collect();
+
+                let results: Vec<ElementData> = filtered
+                    .par_iter()
+                    .map(|child| self.build_element_data(child, element_data.pid))
+                    .collect();
+
+                Ok(results)
+            }
+        }
+    }
+
+    fn find_elements(
+        &self,
+        root: Option<&ElementData>,
+        selector: &Selector,
+        limit: Option<usize>,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ElementData>> {
+        // Route through the per-backend single-clause helper rather than
+        // wrapping into a `SelectorGroup` first — the trait's default
+        // `find_elements` does the wrap, but providing this override
+        // skips the redundant allocation when callers (e.g. `App::list`)
+        // already have a bare `Selector`.
+        self.find_elements_single(root, selector, limit, max_depth)
+    }
+
+    fn find_elements_group(
+        &self,
+        root: Option<&ElementData>,
+        group: &xa11y_core::selector::SelectorGroup,
+        limit: Option<usize>,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ElementData>> {
+        if group.clauses.is_empty() {
+            return Ok(vec![]);
+        }
+        if group.clauses.len() == 1 {
+            return self.find_elements_single(root, &group.clauses[0], limit, max_depth);
+        }
+
+        // Multi-clause: ONE AX walk that evaluates every clause's first
+        // SimpleSelector inline. Each match is tagged with its clause index;
+        // per-clause phase-2 narrowing follows. The cross-clause merge
+        // deduplicates by AXUIElement pointer identity — that's the only
+        // identifier stable across narrowings within a single call (handles
+        // are minted fresh on every `build_element_data`).
+        let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
+
+        // The root-of-system + `application` shortcut from the single-clause
+        // path doesn't generalise here (mixing `application` with non-app
+        // clauses needs the full AX walk anyway), so for now system-root
+        // multi-clause queries fall through to the default tree-walking
+        // implementation. This still goes through ONE walk per query (the
+        // default `find_elements_in_tree_group`), it just doesn't get the
+        // CGWindowList optimization.
+        let root_data = match root {
+            Some(el) => el,
+            None => {
+                return xa11y_core::selector::find_elements_in_tree_group(
+                    |el| self.get_children(el),
+                    root,
+                    group,
+                    limit,
+                    max_depth,
+                );
+            }
+        };
+
+        let root_ax = self.get_cached(root_data.handle)?;
+
+        let firsts: Vec<&SimpleSelector> = group
+            .clauses
+            .iter()
+            .map(|c| &c.segments[0].simple)
+            .collect();
+
+        // One AX walk for the whole group; no phase-1 limit (see comment in
+        // Linux impl) — the merge needs the full union before applying limit.
+        let phase1: Vec<(usize, AXElement)> = self.collect_matching_ax_group(
+            &root_ax,
+            root_data.role,
+            root_data.name.as_deref(),
+            &firsts,
+            0,
+            max_depth_val,
+            None,
+        );
+
+        // Bucket phase-1 hits by clause + their doc-order walk position.
+        let mut by_clause: Vec<Vec<(usize, AXElement)>> =
+            (0..group.clauses.len()).map(|_| Vec::new()).collect();
+        for (walk_pos, (clause_idx, ax)) in phase1.into_iter().enumerate() {
+            by_clause[clause_idx].push((walk_pos, ax));
+        }
+
+        let mut merged: Vec<(usize, AXUIElementRef, ElementData)> = Vec::new();
+        for (clause_idx, hits) in by_clause.into_iter().enumerate() {
+            if hits.is_empty() {
+                continue;
+            }
+            let clause = &group.clauses[clause_idx];
+            let first = &clause.segments[0].simple;
+
+            // Build ElementData for this clause's phase-1 hits.
+            let mut phase1_data: Vec<(usize, AXUIElementRef, ElementData)> = hits
+                .iter()
+                .map(|(pos, ax)| {
+                    (
+                        *pos,
+                        ax.as_ptr(),
+                        self.build_element_data(ax, root_data.pid),
+                    )
+                })
+                .collect();
+
+            if clause.segments.len() == 1 {
+                // Per-clause `:nth` and limit handling — but we can't apply
+                // outer limit here (cross-clause merge can re-order).
+                if let Some(nth) = first.nth {
+                    if nth <= phase1_data.len() {
+                        let kept = phase1_data.remove(nth - 1);
+                        phase1_data.clear();
+                        phase1_data.push(kept);
+                    } else {
+                        phase1_data.clear();
+                    }
+                }
+                merged.extend(phase1_data);
+                continue;
+            }
+
+            // Multi-segment narrowing per clause. We anchor each narrowed
+            // descendant at its phase-1 ancestor's walk_pos so the doc-order
+            // sort puts cross-clause results in the right global order.
+            for (anchor_pos, _anchor_ptr, head) in phase1_data {
+                let narrowed = self.narrow_multi_segment(
+                    vec![head],
+                    &clause.segments[1..],
+                    max_depth_val,
+                    None,
+                )?;
+                for n in narrowed {
+                    // Anchor identity is for dedup vs other clauses' phase-1
+                    // hits; for phase-2 outputs we use the narrowed element's
+                    // own AXUIElement pointer (resolved via the cache).
+                    let ptr = self
+                        .get_cached(n.handle)
+                        .map(|ax| ax.as_ptr())
+                        .unwrap_or(std::ptr::null());
+                    merged.push((anchor_pos, ptr, n));
+                }
+            }
+        }
+
+        // Stable sort by walk position keeps doc-order; dedup by
+        // AXUIElement pointer identity ensures `X, X` collapses correctly.
+        merged.sort_by_key(|(pos, _, _)| *pos);
+        let mut seen: HashSet<usize> = HashSet::new();
+        let mut out: Vec<ElementData> = Vec::with_capacity(merged.len());
+        for (_, ptr, data) in merged {
+            // Null pointers (resolution failures) can't be sensibly deduped;
+            // treat each null as its own key so we keep the element.
+            let key = ptr as usize;
+            if key != 0 && !seen.insert(key) {
+                continue;
+            }
+            out.push(data);
+        }
+        if let Some(l) = limit {
+            out.truncate(l);
+        }
+        Ok(out)
     }
 
     fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -11,12 +11,12 @@ use core_foundation::number::CFNumber;
 use core_foundation::string::CFString;
 use rayon::prelude::*;
 
+#[cfg(test)]
+use xa11y_core::Selector;
 use xa11y_core::{
     CancelHandle, ElementData, Error, Event, EventKind, EventReceiver, Provider, Rect, Result,
     Role, StateFlag, StateSet, Subscription, Toggled,
 };
-#[cfg(test)]
-use xa11y_core::Selector;
 
 // ── FFI Declarations ──────────────────────────────────────────────────────────
 
@@ -1742,28 +1742,16 @@ impl MacOSProvider {
         }
         results
     }
-
 }
 
 impl Provider for MacOSProvider {
     fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
         match element {
             None => {
-                // Top-level: list all GUI apps as application elements
-                let apps = Self::list_gui_apps();
-                let mut results = Vec::new();
-                for (pid, app_name) in &apps {
-                    let app_element =
-                        AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
-                    if app_element.is_null() {
-                        continue;
-                    }
-                    let mut data = self.build_element_data(&app_element, Some(*pid as u32));
-                    // Override name with the CGWindowList name (more reliable)
-                    data.name = Some(app_name.clone());
-                    results.push(data);
-                }
-                Ok(results)
+                // Top-level: list all GUI apps as application elements.
+                // Delegated to `list_apps()` so the discovery primitive has
+                // a single canonical implementation.
+                self.list_apps()
             }
             Some(element_data) => {
                 let ax = self.get_cached(element_data.handle)?;
@@ -1791,7 +1779,7 @@ impl Provider for MacOSProvider {
 
     fn find_elements_group(
         &self,
-        root: Option<&ElementData>,
+        root: &ElementData,
         group: &xa11y_core::selector::SelectorGroup,
         limit: Option<usize>,
         max_depth: Option<u32>,
@@ -1811,110 +1799,12 @@ impl Provider for MacOSProvider {
         // AXUIElement pointer identity — that's the only identifier stable
         // across narrowings within a single call (handles are minted fresh
         // on every `build_element_data`).
+        //
+        // App discovery is handled separately by `list_apps()` — `root` is
+        // always present here.
         let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
 
-        // ── N=1 CGWindowList shortcut ────────────────────────────
-        // Single clause + system root + first segment matches
-        // `Role::Application`: skip the AX walk entirely and use
-        // CGWindowList (no AX calls) to enumerate apps, then build full
-        // ElementData only for matches. Multi-clause groups can mix
-        // `application` with non-app clauses, which would still need the
-        // full AX walk — so this shortcut intentionally only fires for
-        // N=1.
-        if group.clauses.len() == 1 && root.is_none() {
-            let clause = &group.clauses[0];
-            let first = &clause.segments[0].simple;
-            if matches!(
-                first.role,
-                Some(xa11y_core::selector::RoleMatch::Normalized(
-                    Role::Application
-                ))
-            ) {
-                // N=1 phase-1 limit: propagate the user's `limit` (adjusted
-                // for `:nth`) so the iteration stops at the first match.
-                let outer = if clause.segments.len() == 1 {
-                    limit
-                } else {
-                    None
-                };
-                let phase1_limit = match (outer, first.nth) {
-                    (Some(l), Some(n)) => Some(l.max(n)),
-                    (_, Some(n)) => Some(n),
-                    (l, None) => l,
-                };
-
-                let apps = Self::list_gui_apps();
-                let mut matching: Vec<ElementData> = Vec::new();
-                for (pid, app_name) in &apps {
-                    // Check name filters against CGWindowList name
-                    let name_matches = first.filters.iter().all(|f| {
-                        if f.attr != "name" {
-                            return true; // non-name filters checked after build
-                        }
-                        match_op(&f.op, &f.value, Some(app_name.as_str()))
-                    });
-                    if !name_matches {
-                        continue;
-                    }
-
-                    let app_element =
-                        AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
-                    if app_element.is_null() {
-                        continue;
-                    }
-                    let mut data = self.build_element_data(&app_element, Some(*pid as u32));
-                    data.name = Some(app_name.clone());
-                    matching.push(data);
-
-                    if let Some(cap) = phase1_limit {
-                        if matching.len() >= cap {
-                            break;
-                        }
-                    }
-                }
-
-                // Apply :nth
-                if let Some(nth) = first.nth {
-                    if nth <= matching.len() {
-                        matching = vec![matching.remove(nth - 1)];
-                    } else {
-                        matching.clear();
-                    }
-                }
-
-                if clause.segments.len() == 1 {
-                    if let Some(l) = limit {
-                        matching.truncate(l);
-                    }
-                    return Ok(matching);
-                }
-
-                return self.narrow_multi_segment(
-                    matching,
-                    &clause.segments[1..],
-                    max_depth_val,
-                    limit,
-                );
-            }
-        }
-
-        // Non-application root or multi-clause at the system root: the
-        // CGWindowList shortcut doesn't generalise (mixing `application`
-        // with non-app clauses needs the full AX walk anyway), so fall
-        // through to the default tree-walking implementation. This still
-        // goes through ONE walk per query.
-        let root_data = match root {
-            Some(el) => el,
-            None => {
-                return xa11y_core::selector::find_elements_in_tree_group(
-                    |el| self.get_children(el),
-                    root,
-                    group,
-                    limit,
-                    max_depth,
-                );
-            }
-        };
+        let root_data = root;
 
         let root_ax = self.get_cached(root_data.handle)?;
 
@@ -2056,6 +1946,26 @@ impl Provider for MacOSProvider {
             }
             None => Ok(None),
         }
+    }
+
+    /// Enumerate top-level applications via CGWindowList — the canonical
+    /// macOS app discovery primitive. For each GUI app we synthesise an
+    /// `AXUIElement` via `AXUIElementCreateApplication(pid)` and build
+    /// full `ElementData`, overriding the AX-reported name with the
+    /// CGWindowList name (which is more consistent across launches).
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        let apps = Self::list_gui_apps();
+        let mut results = Vec::new();
+        for (pid, app_name) in &apps {
+            let app_element = AXElement::from_owned(unsafe { safe_ax_create_application(*pid) });
+            if app_element.is_null() {
+                continue;
+            }
+            let mut data = self.build_element_data(&app_element, Some(*pid as u32));
+            data.name = Some(app_name.clone());
+            results.push(data);
+        }
+        Ok(results)
     }
 
     // ── Common actions ──────────────────────────────────────────────
@@ -2867,16 +2777,12 @@ mod tests {
     // Run via: cargo xtask test-integ (which also runs these)
     // ════════════════════════════════════════════════════════════════
 
-    /// Find the test app's root ElementData via find_elements (same path
-    /// as App::by_name, which is known to work).
+    /// Find the test app's root ElementData via `list_apps` — same
+    /// discovery path as `App::by_name`, which is known to work.
     fn find_test_app(provider: &MacOSProvider) -> ElementData {
-        let selector = Selector::parse("application[name=\"xa11y-test-app\"]").unwrap();
-        let results = provider
-            .find_elements(None, &selector, Some(1), Some(0))
-            .unwrap();
-        results
-            .into_iter()
-            .next()
+        let apps = provider.list_apps().unwrap();
+        apps.into_iter()
+            .find(|d| d.name.as_deref() == Some("xa11y-test-app"))
             .expect("xa11y-test-app not found — is it running?")
     }
 
@@ -2902,7 +2808,7 @@ mod tests {
         ax_counters::reset_all();
         let selector = Selector::parse("button[name=\"Submit\"]").unwrap();
         let results = provider
-            .find_elements(Some(&app), &selector, Some(1), None)
+            .find_elements(&app, &selector, Some(1), None)
             .unwrap();
         let (copy_attr, copy_multi, copy_actions) = ax_counters::snapshot();
         let total = ax_counters::total();
@@ -2941,7 +2847,7 @@ mod tests {
         ax_counters::reset_all();
         let selector = Selector::parse("button[name=\"Submit\"]").unwrap();
         let results = provider
-            .find_elements(Some(&window), &selector, Some(1), None)
+            .find_elements(&window, &selector, Some(1), None)
             .unwrap();
         let (copy_attr, copy_multi, copy_actions) = ax_counters::snapshot();
         let total = ax_counters::total();
@@ -2976,7 +2882,7 @@ mod tests {
         ax_counters::reset_all();
         let selector = Selector::parse("check_box").unwrap();
         let results = provider
-            .find_elements(Some(&window), &selector, None, None)
+            .find_elements(&window, &selector, None, None)
             .unwrap();
         let (copy_attr, copy_multi, copy_actions) = ax_counters::snapshot();
         let total = ax_counters::total();

--- a/xa11y-macos/src/lib.rs
+++ b/xa11y-macos/src/lib.rs
@@ -96,6 +96,9 @@ mod stub {
         fn get_parent(&self, _: &ElementData) -> Result<Option<ElementData>> {
             unreachable!()
         }
+        fn list_apps(&self) -> Result<Vec<ElementData>> {
+            unreachable!()
+        }
         fn press(&self, _: &ElementData) -> Result<()> {
             unreachable!()
         }

--- a/xa11y-python/Cargo.lock
+++ b/xa11y-python/Cargo.lock
@@ -1433,7 +1433,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xa11y"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "xa11y-core",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "png",
  "serde",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-linux"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "evdev",
  "png",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-macos"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "cc",
  "core-foundation",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-python"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-windows"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "windows",

--- a/xa11y-windows/src/stub.rs
+++ b/xa11y-windows/src/stub.rs
@@ -61,6 +61,9 @@ impl Provider for WindowsProvider {
     fn get_parent(&self, _: &ElementData) -> Result<Option<ElementData>> {
         unreachable!()
     }
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        unreachable!()
+    }
     fn press(&self, _: &ElementData) -> Result<()> {
         unreachable!()
     }

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -230,157 +230,6 @@ impl WindowsProvider {
         })
     }
 
-    /// Single-clause search fast path — the original pre-group `find_elements`
-    /// body. Kept as an inherent method so `find_elements_group` can dispatch
-    /// to it for the common `clauses.len() == 1` case without round-tripping
-    /// through the trait method.
-    fn find_elements_single(
-        &self,
-        root: Option<&ElementData>,
-        selector: &Selector,
-        limit: Option<usize>,
-        max_depth: Option<u32>,
-    ) -> Result<Vec<ElementData>> {
-        if selector.segments.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
-        let first = &selector.segments[0].simple;
-
-        let phase1_limit = if selector.segments.len() == 1 {
-            limit
-        } else {
-            None
-        };
-        let phase1_limit = match (phase1_limit, first.nth) {
-            (Some(l), Some(n)) => Some(l.max(n)),
-            (_, Some(n)) => Some(n),
-            (l, None) => l,
-        };
-
-        // Applications are always direct children of the desktop root
-        if root.is_none()
-            && matches!(
-                first.role,
-                Some(xa11y_core::selector::RoleMatch::Normalized(
-                    Role::Application
-                ))
-            )
-        {
-            let mut matching = self.get_children(None)?;
-
-            // Filter by selector attributes (name etc.)
-            matching.retain(|el| matches_simple(el, first));
-
-            if let Some(nth) = first.nth {
-                if nth <= matching.len() {
-                    matching = vec![matching.remove(nth - 1)];
-                } else {
-                    matching.clear();
-                }
-            }
-
-            if selector.segments.len() == 1 {
-                if let Some(limit) = limit {
-                    matching.truncate(limit);
-                }
-                return Ok(matching);
-            }
-
-            return self.narrow_multi_segment(
-                matching,
-                &selector.segments[1..],
-                max_depth_val,
-                limit,
-            );
-        }
-
-        // For non-root searches, use FindAll(TreeScope_Subtree) with
-        // TrueCondition to fetch the entire subtree in one COM call, then filter
-        // client-side with matches_simple.
-        let root_data = match root {
-            Some(el) => el,
-            None => {
-                // Searching from system root with a non-Application selector.
-                // Fall back to the default tree-walking implementation.
-                return xa11y_core::selector::find_elements_in_tree(
-                    |el| self.get_children(el),
-                    root,
-                    selector,
-                    limit,
-                    max_depth,
-                );
-            }
-        };
-
-        let uia_root = self.get_cached(root_data.handle)?;
-        let pid = root_data.pid;
-
-        // Fragment elements — virtual nodes inside a UIA provider, e.g. a Qt
-        // QFormLayout group — have a null NativeWindowHandle. Calling
-        // FindAllBuildCache(TreeScope_Subtree) on them can return an incomplete
-        // array due to provider-activation boundaries. Only fragment roots
-        // (HWND-backed window elements) reliably support the subtree call;
-        // fall back to level-by-level tree-walking for everything else.
-        let is_hwnd_root = unsafe { uia_root.CurrentNativeWindowHandle() }
-            .ok()
-            .map(|h| !h.0.is_null())
-            .unwrap_or(false);
-        if !is_hwnd_root {
-            return xa11y_core::selector::find_elements_in_tree(
-                |el| self.get_children(el),
-                root,
-                selector,
-                limit,
-                max_depth,
-            );
-        }
-
-        let subtree = self.find_all_subtree(&uia_root)?;
-        let count = uia_len(&subtree);
-        let mut matching = Vec::new();
-
-        for i in 0..count {
-            let el = match uia_get(&subtree, i) {
-                Some(el) => el,
-                None => continue,
-            };
-
-            let data = self.build_element_data(&el, pid);
-
-            if !matches_simple(&data, first) {
-                continue;
-            }
-
-            matching.push(data);
-
-            if let Some(limit) = phase1_limit {
-                if matching.len() >= limit {
-                    break;
-                }
-            }
-        }
-
-        // Apply :nth
-        if let Some(nth) = first.nth {
-            if nth <= matching.len() {
-                matching = vec![matching.remove(nth - 1)];
-            } else {
-                matching.clear();
-            }
-        }
-
-        if selector.segments.len() == 1 {
-            if let Some(limit) = limit {
-                matching.truncate(limit);
-            }
-            return Ok(matching);
-        }
-
-        self.narrow_multi_segment(matching, &selector.segments[1..], max_depth_val, limit)
-    }
-
     /// Extract a UIA element's RuntimeId as a `Vec<i32>` for use as a stable
     /// cross-call identity key. `GetRuntimeId` returns a SAFEARRAY of i32 that
     /// uniquely identifies an element within the UIA tree session — the only
@@ -887,19 +736,6 @@ impl Provider for WindowsProvider {
         Ok(candidates)
     }
 
-    fn find_elements(
-        &self,
-        root: Option<&ElementData>,
-        selector: &Selector,
-        limit: Option<usize>,
-        max_depth: Option<u32>,
-    ) -> Result<Vec<ElementData>> {
-        // Trait default would wrap into a single-clause SelectorGroup and
-        // call `find_elements_group`. Skip that allocation for callers
-        // (`App::list`, fuzzer, …) that already hold a bare `Selector`.
-        self.find_elements_single(root, selector, limit, max_depth)
-    }
-
     fn find_elements_group(
         &self,
         root: Option<&ElementData>,
@@ -910,11 +746,44 @@ impl Provider for WindowsProvider {
         if group.clauses.is_empty() {
             return Ok(vec![]);
         }
-        if group.clauses.len() == 1 {
-            return self.find_elements_single(root, &group.clauses[0], limit, max_depth);
+        // Reject any clause with zero segments early — `clause.segments[0]`
+        // below would otherwise panic. The parser doesn't produce empty
+        // clauses, but be defensive against direct `SelectorGroup` builders.
+        if group.clauses.iter().any(|c| c.segments.is_empty()) {
+            return Ok(vec![]);
         }
 
         let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
+
+        // ── Single-clause optimizations ───────────────────────────
+        // Two N=1-only optimizations are hoisted from the legacy
+        // `find_elements_single` body into this unified path:
+        //   1. **Phase-1 limit short-circuit**: when there's exactly one
+        //      clause, propagate the user's `limit` (adjusted for `:nth`)
+        //      to the subtree walk so e.g. `app.locator("button").first()`
+        //      stops at the first match. With multiple clauses, phase-1
+        //      must collect the full union before truncating because
+        //      cross-clause doc-order can promote later-clause hits ahead
+        //      of earlier ones.
+        //   2. **App-search depth shortcut**: handled by the
+        //      `all_application_first` branch below — the get_children
+        //      shortcut only walks the registry root's direct children
+        //      regardless of N.
+        let phase1_limit = if group.clauses.len() == 1 {
+            let first = &group.clauses[0].segments[0].simple;
+            let outer = if group.clauses[0].segments.len() == 1 {
+                limit
+            } else {
+                None
+            };
+            match (outer, first.nth) {
+                (Some(l), Some(n)) => Some(l.max(n)),
+                (_, Some(n)) => Some(n),
+                (l, None) => l,
+            }
+        } else {
+            None
+        };
 
         // ── Application-search special case ────────────────────────
         // If every clause's first segment targets the `application` role at
@@ -1056,7 +925,7 @@ impl Provider for WindowsProvider {
         let mut by_clause: Vec<Vec<(usize, ElementData, Option<IUIAutomationElement>)>> =
             (0..group.clauses.len()).map(|_| Vec::new()).collect();
 
-        for i in 0..count {
+        'walk: for i in 0..count {
             let el = match uia_get(&subtree, i) {
                 Some(el) => el,
                 None => continue,
@@ -1076,6 +945,15 @@ impl Provider for WindowsProvider {
                         None
                     };
                     by_clause[idx].push((i as usize, data.clone(), live));
+                    // N=1 phase-1 limit short-circuit (see comment at the
+                    // top of this method). Only safe for single-clause
+                    // groups; otherwise cross-clause doc-order would be
+                    // wrong.
+                    if let Some(cap) = phase1_limit {
+                        if by_clause[idx].len() >= cap {
+                            break 'walk;
+                        }
+                    }
                 }
             }
         }

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -667,6 +667,16 @@ impl Provider for WindowsProvider {
         Ok(None)
     }
 
+    /// Enumerate top-level applications. UIA exposes apps as top-level
+    /// `Window` control-type elements under the desktop root — there's no
+    /// dedicated `Application` accessible — so we list the desktop's
+    /// direct window children, one per PID. This is the canonical app
+    /// discovery primitive (replaces the old
+    /// `find_elements(None, "application"/"window", …, depth=0)` idiom).
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        self.get_children(None)
+    }
+
     /// Override the default `narrow_multi_segment` so that the Descendant
     /// combinator uses `find_elements_in_tree` (tree-walking via `get_children`)
     /// rather than `self.find_elements` (which would invoke `find_all_subtree`).
@@ -738,7 +748,7 @@ impl Provider for WindowsProvider {
 
     fn find_elements_group(
         &self,
-        root: Option<&ElementData>,
+        root: &ElementData,
         group: &xa11y_core::selector::SelectorGroup,
         limit: Option<usize>,
         max_depth: Option<u32>,
@@ -755,20 +765,13 @@ impl Provider for WindowsProvider {
 
         let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
 
-        // ── Single-clause optimizations ───────────────────────────
-        // Two N=1-only optimizations are hoisted from the legacy
-        // `find_elements_single` body into this unified path:
-        //   1. **Phase-1 limit short-circuit**: when there's exactly one
-        //      clause, propagate the user's `limit` (adjusted for `:nth`)
-        //      to the subtree walk so e.g. `app.locator("button").first()`
-        //      stops at the first match. With multiple clauses, phase-1
-        //      must collect the full union before truncating because
-        //      cross-clause doc-order can promote later-clause hits ahead
-        //      of earlier ones.
-        //   2. **App-search depth shortcut**: handled by the
-        //      `all_application_first` branch below — the get_children
-        //      shortcut only walks the registry root's direct children
-        //      regardless of N.
+        // ── Phase-1 limit short-circuit ───────────────────────────
+        // When there's exactly one clause, propagate the user's `limit`
+        // (adjusted for `:nth`) to the subtree walk so e.g.
+        // `app.locator("button").first()` stops at the first match. With
+        // multiple clauses, phase-1 must collect the full union before
+        // truncating because cross-clause doc-order can promote later-clause
+        // hits ahead of earlier ones.
         let phase1_limit = if group.clauses.len() == 1 {
             let first = &group.clauses[0].segments[0].simple;
             let outer = if group.clauses[0].segments.len() == 1 {
@@ -785,108 +788,11 @@ impl Provider for WindowsProvider {
             None
         };
 
-        // ── Application-search special case ────────────────────────
-        // If every clause's first segment targets the `application` role at
-        // the system root, we can satisfy the whole group from the desktop
-        // root's direct children (no FindAllBuildCache subtree walk).
-        // Mixed groups (some `application`, some not) at the system root
-        // fall through to the default tree-walking group impl — the
-        // CGWindowList-style shortcut doesn't extend cleanly.
-        let all_application_first = group.clauses.iter().all(|c| {
-            matches!(
-                c.segments.first().map(|s| &s.simple.role),
-                Some(Some(xa11y_core::selector::RoleMatch::Normalized(
-                    Role::Application
-                )))
-            )
-        });
-        if root.is_none() && all_application_first {
-            let apps = self.get_children(None)?;
-            // Run each clause's first-segment match against the (small) app
-            // list, then per-clause phase-2 narrowing as needed. Doc-order is
-            // app-list order; dedup is by `(pid, name)` (the only stable key
-            // for an application root across phase-2 walks).
-            let mut by_clause: Vec<Vec<(usize, ElementData)>> =
-                (0..group.clauses.len()).map(|_| Vec::new()).collect();
-            for (walk_pos, app) in apps.iter().enumerate() {
-                for (idx, clause) in group.clauses.iter().enumerate() {
-                    if matches_simple(app, &clause.segments[0].simple) {
-                        by_clause[idx].push((walk_pos, app.clone()));
-                    }
-                }
-            }
-            let mut merged: Vec<(usize, ElementData)> = Vec::new();
-            for (idx, hits) in by_clause.into_iter().enumerate() {
-                if hits.is_empty() {
-                    continue;
-                }
-                let clause = &group.clauses[idx];
-                if clause.segments.len() == 1 {
-                    // Per-clause `:nth`.
-                    let mut hits = hits;
-                    if let Some(nth) = clause.segments[0].simple.nth {
-                        if nth <= hits.len() {
-                            let kept = hits.remove(nth - 1);
-                            hits.clear();
-                            hits.push(kept);
-                        } else {
-                            hits.clear();
-                        }
-                    }
-                    merged.extend(hits);
-                    continue;
-                }
-                for (pos, head) in hits {
-                    let narrowed = self.narrow_multi_segment(
-                        vec![head],
-                        &clause.segments[1..],
-                        max_depth_val,
-                        None,
-                    )?;
-                    for n in narrowed {
-                        merged.push((pos, n));
-                    }
-                }
-            }
-            merged.sort_by_key(|(pos, _)| *pos);
-            let mut seen: HashSet<u64> = HashSet::new();
-            let mut out: Vec<ElementData> = Vec::with_capacity(merged.len());
-            for (_, data) in merged {
-                // Dedup by handle is sufficient *here* because every
-                // phase-1 candidate originated from the same `get_children`
-                // call (one handle per app). Phase-2 narrowings cache fresh
-                // handles, but those are descendant elements, never another
-                // application.
-                if !seen.insert(data.handle) {
-                    continue;
-                }
-                out.push(data);
-            }
-            if let Some(l) = limit {
-                out.truncate(l);
-            }
-            return Ok(out);
-        }
-
         // ── Subtree group walk ─────────────────────────────────────
-        // Non-application root or scoped query: do ONE
-        // `FindAllBuildCache(TreeScope_Subtree)` and evaluate every clause's
-        // first segment against each subtree element.
-        let root_data = match root {
-            Some(el) => el,
-            None => {
-                // System-root + non-application multi-clause: fall back to
-                // the core tree-walking group impl (still ONE walk thanks
-                // to path-based dedup).
-                return xa11y_core::selector::find_elements_in_tree_group(
-                    |el| self.get_children(el),
-                    root,
-                    group,
-                    limit,
-                    max_depth,
-                );
-            }
-        };
+        // Do ONE `FindAllBuildCache(TreeScope_Subtree)` and evaluate every
+        // clause's first segment against each subtree element. App
+        // discovery is handled separately by `list_apps()`.
+        let root_data = root;
 
         let uia_root = self.get_cached(root_data.handle)?;
         let pid = root_data.pid;
@@ -901,7 +807,7 @@ impl Provider for WindowsProvider {
         if !is_hwnd_root {
             return xa11y_core::selector::find_elements_in_tree_group(
                 |el| self.get_children(el),
-                root,
+                Some(root),
                 group,
                 limit,
                 max_depth,
@@ -2414,9 +2320,15 @@ mod tests {
         let Some(provider) = try_provider() else {
             return;
         };
+        // `find_elements` now requires a root; grab any top-level app from
+        // the discovery primitive. If no app is present (headless CI),
+        // skip — the empty-selector check needs a real subtree to walk.
+        let Some(root) = provider.list_apps().unwrap_or_default().into_iter().next() else {
+            return;
+        };
         let empty_selector = Selector { segments: vec![] };
         let result = provider
-            .find_elements(None, &empty_selector, None, None)
+            .find_elements(&root, &empty_selector, None, None)
             .unwrap();
         assert!(result.is_empty());
     }

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -229,6 +229,198 @@ impl WindowsProvider {
             root.FindAllBuildCache(TreeScope_Subtree, &true_cond, &self.batch_request)
         })
     }
+
+    /// Single-clause search fast path — the original pre-group `find_elements`
+    /// body. Kept as an inherent method so `find_elements_group` can dispatch
+    /// to it for the common `clauses.len() == 1` case without round-tripping
+    /// through the trait method.
+    fn find_elements_single(
+        &self,
+        root: Option<&ElementData>,
+        selector: &Selector,
+        limit: Option<usize>,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ElementData>> {
+        if selector.segments.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
+        let first = &selector.segments[0].simple;
+
+        let phase1_limit = if selector.segments.len() == 1 {
+            limit
+        } else {
+            None
+        };
+        let phase1_limit = match (phase1_limit, first.nth) {
+            (Some(l), Some(n)) => Some(l.max(n)),
+            (_, Some(n)) => Some(n),
+            (l, None) => l,
+        };
+
+        // Applications are always direct children of the desktop root
+        if root.is_none()
+            && matches!(
+                first.role,
+                Some(xa11y_core::selector::RoleMatch::Normalized(
+                    Role::Application
+                ))
+            )
+        {
+            let mut matching = self.get_children(None)?;
+
+            // Filter by selector attributes (name etc.)
+            matching.retain(|el| matches_simple(el, first));
+
+            if let Some(nth) = first.nth {
+                if nth <= matching.len() {
+                    matching = vec![matching.remove(nth - 1)];
+                } else {
+                    matching.clear();
+                }
+            }
+
+            if selector.segments.len() == 1 {
+                if let Some(limit) = limit {
+                    matching.truncate(limit);
+                }
+                return Ok(matching);
+            }
+
+            return self.narrow_multi_segment(
+                matching,
+                &selector.segments[1..],
+                max_depth_val,
+                limit,
+            );
+        }
+
+        // For non-root searches, use FindAll(TreeScope_Subtree) with
+        // TrueCondition to fetch the entire subtree in one COM call, then filter
+        // client-side with matches_simple.
+        let root_data = match root {
+            Some(el) => el,
+            None => {
+                // Searching from system root with a non-Application selector.
+                // Fall back to the default tree-walking implementation.
+                return xa11y_core::selector::find_elements_in_tree(
+                    |el| self.get_children(el),
+                    root,
+                    selector,
+                    limit,
+                    max_depth,
+                );
+            }
+        };
+
+        let uia_root = self.get_cached(root_data.handle)?;
+        let pid = root_data.pid;
+
+        // Fragment elements — virtual nodes inside a UIA provider, e.g. a Qt
+        // QFormLayout group — have a null NativeWindowHandle. Calling
+        // FindAllBuildCache(TreeScope_Subtree) on them can return an incomplete
+        // array due to provider-activation boundaries. Only fragment roots
+        // (HWND-backed window elements) reliably support the subtree call;
+        // fall back to level-by-level tree-walking for everything else.
+        let is_hwnd_root = unsafe { uia_root.CurrentNativeWindowHandle() }
+            .ok()
+            .map(|h| !h.0.is_null())
+            .unwrap_or(false);
+        if !is_hwnd_root {
+            return xa11y_core::selector::find_elements_in_tree(
+                |el| self.get_children(el),
+                root,
+                selector,
+                limit,
+                max_depth,
+            );
+        }
+
+        let subtree = self.find_all_subtree(&uia_root)?;
+        let count = uia_len(&subtree);
+        let mut matching = Vec::new();
+
+        for i in 0..count {
+            let el = match uia_get(&subtree, i) {
+                Some(el) => el,
+                None => continue,
+            };
+
+            let data = self.build_element_data(&el, pid);
+
+            if !matches_simple(&data, first) {
+                continue;
+            }
+
+            matching.push(data);
+
+            if let Some(limit) = phase1_limit {
+                if matching.len() >= limit {
+                    break;
+                }
+            }
+        }
+
+        // Apply :nth
+        if let Some(nth) = first.nth {
+            if nth <= matching.len() {
+                matching = vec![matching.remove(nth - 1)];
+            } else {
+                matching.clear();
+            }
+        }
+
+        if selector.segments.len() == 1 {
+            if let Some(limit) = limit {
+                matching.truncate(limit);
+            }
+            return Ok(matching);
+        }
+
+        self.narrow_multi_segment(matching, &selector.segments[1..], max_depth_val, limit)
+    }
+
+    /// Extract a UIA element's RuntimeId as a `Vec<i32>` for use as a stable
+    /// cross-call identity key. `GetRuntimeId` returns a SAFEARRAY of i32 that
+    /// uniquely identifies an element within the UIA tree session — the only
+    /// identifier safe to use for dedup across `narrow_multi_segment` walks
+    /// within a single `find_elements_group` call.
+    ///
+    /// Returns `None` if the COM call fails or the SAFEARRAY shape isn't what
+    /// UIA documents (1D, VT_I4). Callers treat `None` as "untracked" — the
+    /// element falls through dedup, which is harmless because untracked
+    /// duplicates would only over-report, never under-report.
+    fn runtime_id_key(element: &IUIAutomationElement) -> Option<Vec<i32>> {
+        use windows::Win32::System::Com::SAFEARRAY;
+        use windows::Win32::System::Ole::{SafeArrayAccessData, SafeArrayUnaccessData};
+
+        let sa: *mut SAFEARRAY = match unsafe { element.GetRuntimeId() } {
+            Ok(p) if !p.is_null() => p,
+            _ => return None,
+        };
+
+        // Safety: GetRuntimeId hands us ownership of a SAFEARRAY*. We must
+        // free it via SafeArrayDestroy when done, otherwise we leak. Lock
+        // the data via SafeArrayAccessData, copy out the i32s, unlock,
+        // destroy.
+        let result = unsafe {
+            let mut data_ptr: *mut core::ffi::c_void = core::ptr::null_mut();
+            if SafeArrayAccessData(sa, &mut data_ptr as *mut _).is_err() {
+                let _ = windows::Win32::System::Ole::SafeArrayDestroy(sa);
+                return None;
+            }
+            // SAFEARRAY of i32 — rgsabound[0].cElements is the count.
+            let bounds = (*sa).rgsabound.as_ptr();
+            let count = (*bounds).cElements as usize;
+            let slice = std::slice::from_raw_parts(data_ptr as *const i32, count);
+            let v = slice.to_vec();
+            let _ = SafeArrayUnaccessData(sa);
+            let _ = windows::Win32::System::Ole::SafeArrayDestroy(sa);
+            v
+        };
+        Some(result)
+    }
 }
 
 // ── Safe UIA helpers ────────────────────────────────────────────────────────
@@ -702,73 +894,125 @@ impl Provider for WindowsProvider {
         limit: Option<usize>,
         max_depth: Option<u32>,
     ) -> Result<Vec<ElementData>> {
-        if selector.segments.is_empty() {
+        // Trait default would wrap into a single-clause SelectorGroup and
+        // call `find_elements_group`. Skip that allocation for callers
+        // (`App::list`, fuzzer, …) that already hold a bare `Selector`.
+        self.find_elements_single(root, selector, limit, max_depth)
+    }
+
+    fn find_elements_group(
+        &self,
+        root: Option<&ElementData>,
+        group: &xa11y_core::selector::SelectorGroup,
+        limit: Option<usize>,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ElementData>> {
+        if group.clauses.is_empty() {
             return Ok(vec![]);
+        }
+        if group.clauses.len() == 1 {
+            return self.find_elements_single(root, &group.clauses[0], limit, max_depth);
         }
 
         let max_depth_val = max_depth.unwrap_or(xa11y_core::MAX_TREE_DEPTH);
-        let first = &selector.segments[0].simple;
 
-        let phase1_limit = if selector.segments.len() == 1 {
-            limit
-        } else {
-            None
-        };
-        let phase1_limit = match (phase1_limit, first.nth) {
-            (Some(l), Some(n)) => Some(l.max(n)),
-            (_, Some(n)) => Some(n),
-            (l, None) => l,
-        };
-
-        // Applications are always direct children of the desktop root
-        if root.is_none()
-            && matches!(
-                first.role,
-                Some(xa11y_core::selector::RoleMatch::Normalized(
+        // ── Application-search special case ────────────────────────
+        // If every clause's first segment targets the `application` role at
+        // the system root, we can satisfy the whole group from the desktop
+        // root's direct children (no FindAllBuildCache subtree walk).
+        // Mixed groups (some `application`, some not) at the system root
+        // fall through to the default tree-walking group impl — the
+        // CGWindowList-style shortcut doesn't extend cleanly.
+        let all_application_first = group.clauses.iter().all(|c| {
+            matches!(
+                c.segments.first().map(|s| &s.simple.role),
+                Some(Some(xa11y_core::selector::RoleMatch::Normalized(
                     Role::Application
-                ))
+                )))
             )
-        {
-            let mut matching = self.get_children(None)?;
-
-            // Filter by selector attributes (name etc.)
-            matching.retain(|el| matches_simple(el, first));
-
-            if let Some(nth) = first.nth {
-                if nth <= matching.len() {
-                    matching = vec![matching.remove(nth - 1)];
-                } else {
-                    matching.clear();
+        });
+        if root.is_none() && all_application_first {
+            let apps = self.get_children(None)?;
+            // Run each clause's first-segment match against the (small) app
+            // list, then per-clause phase-2 narrowing as needed. Doc-order is
+            // app-list order; dedup is by `(pid, name)` (the only stable key
+            // for an application root across phase-2 walks).
+            let mut by_clause: Vec<Vec<(usize, ElementData)>> =
+                (0..group.clauses.len()).map(|_| Vec::new()).collect();
+            for (walk_pos, app) in apps.iter().enumerate() {
+                for (idx, clause) in group.clauses.iter().enumerate() {
+                    if matches_simple(app, &clause.segments[0].simple) {
+                        by_clause[idx].push((walk_pos, app.clone()));
+                    }
                 }
             }
-
-            if selector.segments.len() == 1 {
-                if let Some(limit) = limit {
-                    matching.truncate(limit);
+            let mut merged: Vec<(usize, ElementData)> = Vec::new();
+            for (idx, hits) in by_clause.into_iter().enumerate() {
+                if hits.is_empty() {
+                    continue;
                 }
-                return Ok(matching);
+                let clause = &group.clauses[idx];
+                if clause.segments.len() == 1 {
+                    // Per-clause `:nth`.
+                    let mut hits = hits;
+                    if let Some(nth) = clause.segments[0].simple.nth {
+                        if nth <= hits.len() {
+                            let kept = hits.remove(nth - 1);
+                            hits.clear();
+                            hits.push(kept);
+                        } else {
+                            hits.clear();
+                        }
+                    }
+                    merged.extend(hits);
+                    continue;
+                }
+                for (pos, head) in hits {
+                    let narrowed = self.narrow_multi_segment(
+                        vec![head],
+                        &clause.segments[1..],
+                        max_depth_val,
+                        None,
+                    )?;
+                    for n in narrowed {
+                        merged.push((pos, n));
+                    }
+                }
             }
-
-            return self.narrow_multi_segment(
-                matching,
-                &selector.segments[1..],
-                max_depth_val,
-                limit,
-            );
+            merged.sort_by_key(|(pos, _)| *pos);
+            let mut seen: HashSet<u64> = HashSet::new();
+            let mut out: Vec<ElementData> = Vec::with_capacity(merged.len());
+            for (_, data) in merged {
+                // Dedup by handle is sufficient *here* because every
+                // phase-1 candidate originated from the same `get_children`
+                // call (one handle per app). Phase-2 narrowings cache fresh
+                // handles, but those are descendant elements, never another
+                // application.
+                if !seen.insert(data.handle) {
+                    continue;
+                }
+                out.push(data);
+            }
+            if let Some(l) = limit {
+                out.truncate(l);
+            }
+            return Ok(out);
         }
 
-        // For non-root searches, use FindAll(TreeScope_Subtree) with
-        // TrueCondition to fetch the entire subtree in one COM call, then filter
-        // client-side with matches_simple.
+        // ── Subtree group walk ─────────────────────────────────────
+        // Non-application root or scoped query: do ONE
+        // `FindAllBuildCache(TreeScope_Subtree)` and evaluate every clause's
+        // first segment against each subtree element.
         let root_data = match root {
             Some(el) => el,
             None => {
-                // Searching from system root with a non-Application selector.
-                // Fall back to the default tree-walking implementation.
-                return xa11y_core::selector::find_elements_in_tree(
+                // System-root + non-application multi-clause: fall back to
+                // the core tree-walking group impl (still ONE walk thanks
+                // to path-based dedup).
+                return xa11y_core::selector::find_elements_in_tree_group(
                     |el| self.get_children(el),
                     root,
-                    selector,
+                    group,
                     limit,
                     max_depth,
                 );
@@ -778,68 +1022,141 @@ impl Provider for WindowsProvider {
         let uia_root = self.get_cached(root_data.handle)?;
         let pid = root_data.pid;
 
-        // Fragment elements — virtual nodes inside a UIA provider, e.g. a Qt
-        // QFormLayout group — have a null NativeWindowHandle. Calling
-        // FindAllBuildCache(TreeScope_Subtree) on them can return an incomplete
-        // array due to provider-activation boundaries. Only fragment roots
-        // (HWND-backed window elements) reliably support the subtree call;
-        // fall back to level-by-level tree-walking for everything else.
+        // Fragment elements (no HWND) don't support reliable
+        // `TreeScope_Subtree` traversal. Fall through to the path-based
+        // default which goes level-by-level through `get_children`.
         let is_hwnd_root = unsafe { uia_root.CurrentNativeWindowHandle() }
             .ok()
             .map(|h| !h.0.is_null())
             .unwrap_or(false);
         if !is_hwnd_root {
-            return xa11y_core::selector::find_elements_in_tree(
+            return xa11y_core::selector::find_elements_in_tree_group(
                 |el| self.get_children(el),
                 root,
-                selector,
+                group,
                 limit,
                 max_depth,
             );
         }
 
+        // One COM call fetches the whole subtree in doc order.
         let subtree = self.find_all_subtree(&uia_root)?;
         let count = uia_len(&subtree);
-        let mut matching = Vec::new();
+
+        // Single-pass: visit every subtree element once and check every
+        // clause's first segment. Per-element results carry the array
+        // index, which is the natural doc-order rank.
+        //
+        // For all-single-segment groups this is the entire computation —
+        // phase 2 is a no-op. For groups with multi-segment clauses we
+        // collect the phase-1 (cached_uia, clause_idx, pos) triples and
+        // narrow each one after the walk.
+        let any_multi_segment = group.clauses.iter().any(|c| c.segments.len() > 1);
+
+        let mut by_clause: Vec<Vec<(usize, ElementData, Option<IUIAutomationElement>)>> =
+            (0..group.clauses.len()).map(|_| Vec::new()).collect();
 
         for i in 0..count {
             let el = match uia_get(&subtree, i) {
                 Some(el) => el,
                 None => continue,
             };
-
+            // Build ElementData once; reuse for every clause check. The
+            // handle assigned here is stable for the rest of this call.
             let data = self.build_element_data(&el, pid);
 
-            if !matches_simple(&data, first) {
-                continue;
-            }
-
-            matching.push(data);
-
-            if let Some(limit) = phase1_limit {
-                if matching.len() >= limit {
-                    break;
+            for (idx, clause) in group.clauses.iter().enumerate() {
+                if matches_simple(&data, &clause.segments[0].simple) {
+                    // Keep the live UIA element alongside the ElementData
+                    // only when we'll need it for narrowing — saves a clone
+                    // per match on the hot all-single-segment path.
+                    let live = if any_multi_segment && clause.segments.len() > 1 {
+                        Some(el.clone())
+                    } else {
+                        None
+                    };
+                    by_clause[idx].push((i as usize, data.clone(), live));
                 }
             }
         }
 
-        // Apply :nth
-        if let Some(nth) = first.nth {
-            if nth <= matching.len() {
-                matching = vec![matching.remove(nth - 1)];
-            } else {
-                matching.clear();
+        // Per-clause phase-2 narrowing (skipped for single-segment clauses).
+        // Each narrowed result keeps its phase-1 ancestor's walk position
+        // for the global doc-order merge.
+        let mut merged: Vec<(usize, ElementData)> = Vec::new();
+        for (clause_idx, hits) in by_clause.into_iter().enumerate() {
+            if hits.is_empty() {
+                continue;
+            }
+            let clause = &group.clauses[clause_idx];
+            if clause.segments.len() == 1 {
+                // Apply per-clause `:nth` before merging.
+                let mut hits: Vec<(usize, ElementData)> =
+                    hits.into_iter().map(|(p, d, _)| (p, d)).collect();
+                if let Some(nth) = clause.segments[0].simple.nth {
+                    if nth <= hits.len() {
+                        let kept = hits.remove(nth - 1);
+                        hits.clear();
+                        hits.push(kept);
+                    } else {
+                        hits.clear();
+                    }
+                }
+                merged.extend(hits);
+                continue;
+            }
+
+            for (anchor_pos, head, _live) in hits {
+                let narrowed = self.narrow_multi_segment(
+                    vec![head],
+                    &clause.segments[1..],
+                    max_depth_val,
+                    None,
+                )?;
+                for n in narrowed {
+                    merged.push((anchor_pos, n));
+                }
             }
         }
 
-        if selector.segments.len() == 1 {
-            if let Some(limit) = limit {
-                matching.truncate(limit);
+        // Stable sort by walk position keeps doc-order; dedup by UIA
+        // RuntimeId so descendants reached via multiple phase-1 anchors
+        // (or matched by multiple clauses) collapse to one result.
+        merged.sort_by_key(|(pos, _)| *pos);
+        let mut seen_rt: HashSet<Vec<i32>> = HashSet::new();
+        let mut seen_handle: HashSet<u64> = HashSet::new();
+        let mut out: Vec<ElementData> = Vec::with_capacity(merged.len());
+        for (_, data) in merged {
+            // Primary identity: RuntimeId. Cheap to fetch from the cached
+            // element and stable across narrowings within this call.
+            let key = self
+                .get_cached(data.handle)
+                .ok()
+                .and_then(|el| Self::runtime_id_key(&el));
+            match key {
+                Some(rt) => {
+                    if !seen_rt.insert(rt) {
+                        continue;
+                    }
+                }
+                None => {
+                    // Fall back to handle dedup if RuntimeId is unavailable.
+                    // Handle uniqueness across the call is weaker than
+                    // RuntimeId (the same physical element rebuilt in phase
+                    // 2 gets a fresh handle), but it's better than nothing
+                    // — over-counting beats under-counting on the rare path
+                    // where the COM call fails.
+                    if !seen_handle.insert(data.handle) {
+                        continue;
+                    }
+                }
             }
-            return Ok(matching);
+            out.push(data);
         }
-
-        self.narrow_multi_segment(matching, &selector.segments[1..], max_depth_val, limit)
+        if let Some(l) = limit {
+            out.truncate(l);
+        }
+        Ok(out)
     }
 
     #[allow(non_upper_case_globals)]

--- a/xa11y/fuzz/Cargo.lock
+++ b/xa11y/fuzz/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +173,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +253,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +296,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "endi"
@@ -289,6 +347,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,16 +386,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -350,6 +445,16 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -495,12 +600,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -540,6 +676,19 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -604,6 +753,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rustix"
@@ -701,10 +876,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -716,6 +918,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -944,32 +1152,54 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
- "windows-targets",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -978,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -994,22 +1224,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.2.0"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -1022,68 +1261,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1192,9 +1376,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "xa11y"
-version = "0.4.0"
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xa11y"
+version = "0.8.0"
+dependencies = [
+ "serde_json",
  "xa11y-core",
  "xa11y-linux",
  "xa11y-macos",
@@ -1203,10 +1414,12 @@ dependencies = [
 
 [[package]]
 name = "xa11y-core"
-version = "0.4.0"
+version = "0.8.0"
 dependencies = [
+ "png",
  "serde",
  "serde_json",
+ "strum",
  "thiserror",
 ]
 
@@ -1222,28 +1435,55 @@ dependencies = [
 
 [[package]]
 name = "xa11y-linux"
-version = "0.4.0"
+version = "0.8.0"
 dependencies = [
+ "evdev",
+ "png",
+ "rayon",
+ "serde_json",
+ "x11rb",
  "xa11y-core",
+ "xkbcommon",
  "zbus",
 ]
 
 [[package]]
 name = "xa11y-macos"
-version = "0.4.0"
+version = "0.8.0"
 dependencies = [
  "cc",
  "core-foundation",
+ "rayon",
+ "serde_json",
  "xa11y-core",
 ]
 
 [[package]]
 name = "xa11y-windows"
-version = "0.4.0"
+version = "0.8.0"
 dependencies = [
+ "serde_json",
  "windows",
+ "windows-core",
  "xa11y-core",
 ]
+
+[[package]]
+name = "xkbcommon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a974f48060a14e95705c01f24ad9c3345022f4d97441b8a36beb7ed5c4a02d"
+dependencies = [
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "zbus"

--- a/xa11y/fuzz/fuzz_targets/mock.rs
+++ b/xa11y/fuzz/fuzz_targets/mock.rs
@@ -157,6 +157,13 @@ impl Provider for FuzzProvider {
         Ok(self.nodes[idx].parent.map(|i| self.nodes[i].data.clone()))
     }
 
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        if self.nodes.is_empty() {
+            return Ok(vec![]);
+        }
+        Ok(vec![self.nodes[0].data.clone()])
+    }
+
     fn press(&self, _: &ElementData) -> Result<()> { Ok(()) }
     fn focus(&self, _: &ElementData) -> Result<()> { Ok(()) }
     fn blur(&self, _: &ElementData) -> Result<()> { Ok(()) }

--- a/xa11y/fuzz/fuzz_targets/selector.rs
+++ b/xa11y/fuzz/fuzz_targets/selector.rs
@@ -5,6 +5,10 @@
 //!
 //! Enforces the invariant: anything Selector::parse accepts must not panic
 //! when passed to find_elements_in_tree (via the public Locator API).
+//!
+//! Also fuzzes the comma-separated `SelectorGroup` form by stitching extra
+//! clauses onto the fuzz selector — exercises the doc-order merge, dedup,
+//! and `chain_combinator` path-distribution.
 #![no_main]
 
 #[path = "mock.rs"]
@@ -15,7 +19,7 @@ use std::sync::Arc;
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 use mock::{build_provider, FuzzElement};
-use xa11y::{App, Provider, Selector};
+use xa11y::{App, Provider, Selector, SelectorGroup};
 
 #[derive(Arbitrary, Debug)]
 struct FuzzInput {
@@ -23,11 +27,29 @@ struct FuzzInput {
     elements: Vec<FuzzElement>,
     /// Selector string — the primary fuzzing surface.
     selector: String,
+    /// Second clause for SelectorGroup fuzzing — stitched onto `selector`
+    /// with a top-level comma to exercise multi-clause matching.
+    extra_clause: String,
+    /// Third clause for >2-clause fuzzing — covers the BTreeMap-by-path
+    /// merge path with multiple inputs.
+    third_clause: String,
 }
 
 fuzz_target!(|input: FuzzInput| {
     // Exercise Selector::parse on all inputs (valid or not).
     let _ = Selector::parse(&input.selector);
+
+    // Exercise SelectorGroup::parse directly — both the single-clause input
+    // (must behave like Selector::parse) and a synthesized comma-joined
+    // multi-clause input. A panic here is a parser bug.
+    let _ = SelectorGroup::parse(&input.selector);
+    let two_clause = format!("{}, {}", input.selector, input.extra_clause);
+    let _ = SelectorGroup::parse(&two_clause);
+    let three_clause = format!(
+        "{}, {}, {}",
+        input.selector, input.extra_clause, input.third_clause
+    );
+    let _ = SelectorGroup::parse(&three_clause);
 
     // Build the random tree.
     let Some(provider) = build_provider(&input.elements) else {
@@ -49,10 +71,54 @@ fuzz_target!(|input: FuzzInput| {
     let _ = app.locator(&input.selector).count();
     let _ = app.locator(&input.selector).elements();
 
+    // SelectorGroup paths through the public Locator API: each invocation
+    // of `count`/`elements` goes through `Provider::find_elements_group`,
+    // which dedupes by tree-path across clauses. Any panic in the merge
+    // (e.g. due to malformed clause strings or pathological tree shapes)
+    // surfaces here.
+    let _ = app.locator(&two_clause).count();
+    let _ = app.locator(&two_clause).elements();
+    let _ = app.locator(&two_clause).exists();
+    let _ = app.locator(&three_clause).count();
+    let _ = app.locator(&three_clause).elements();
+
+    // Idempotence sanity: a single-clause group's count must equal the
+    // bare-selector count. A divergence here would mean SelectorGroup's
+    // single-clause short-circuit drifted from the plain path.
+    if let (Ok(a), Ok(b)) = (
+        app.locator(&input.selector).count(),
+        app.locator(&format!("{}", input.selector)).count(),
+    ) {
+        assert_eq!(
+            a, b,
+            "single-clause group must agree with bare-selector path on count",
+        );
+    }
+
+    // Dedup invariant: `sel, sel` must produce the same count as `sel`
+    // (the duplicate clause adds no new matches). Skip when parsing of
+    // the doubled form fails — invalid selectors are expected.
+    if let Ok(bare) = app.locator(&input.selector).count() {
+        let doubled = format!("{}, {}", input.selector, input.selector);
+        if let Ok(doubled_count) = app.locator(&doubled).count() {
+            assert_eq!(
+                bare, doubled_count,
+                "dedup: `X, X` must yield the same count as `X` (sel = {:?})",
+                input.selector,
+            );
+        }
+    }
+
     // Chaining: exercises selector concatenation with the same fuzz string.
     let _ = app.locator(&input.selector).child(&input.selector).exists();
     let _ = app
         .locator(&input.selector)
         .descendant(&input.selector)
         .exists();
+
+    // Chained navigation on group locators — exercises
+    // `chain_combinator`'s distribution over clauses for both sides.
+    let _ = app.locator(&two_clause).descendant(&input.selector).exists();
+    let _ = app.locator(&two_clause).child(&input.selector).count();
+    let _ = app.locator(&input.selector).descendant(&two_clause).exists();
 });

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -44,7 +44,7 @@ pub use xa11y_core::{is_bidi_control, strip_bidi, strip_bidi_opt};
 
 // Implementation details used by platform backends and Python bindings.
 #[doc(hidden)]
-pub use xa11y_core::{CancelHandle, EventReceiver, Provider, RecvStatus, Selector};
+pub use xa11y_core::{CancelHandle, EventReceiver, Provider, RecvStatus, Selector, SelectorGroup};
 
 /// Shared in-memory mock Provider — re-exported from `xa11y-core` when the
 /// `test-support` feature is enabled. Used by language-binding tests so

--- a/xa11y/tests/integ/tree.rs
+++ b/xa11y/tests/integ/tree.rs
@@ -423,6 +423,70 @@ mod tests {
         assert_eq!(count, buttons.len());
     }
 
+    #[test]
+    #[ignore]
+    fn selector_group_union_runs_on_real_provider() {
+        // Regression: pre-fix, comma-separated selectors (`SelectorGroup`)
+        // returned 0 results on real platform providers because the doc-order
+        // merge identified clause-match results by `ElementData.handle`, and
+        // every backend mints a fresh handle per `get_children` call. This
+        // is the cross-platform smoke test that exercises the real Provider
+        // path end-to-end.
+        let app = h::app_root();
+        let buttons = app.locator("button").elements().unwrap();
+        let text_fields = app.locator("text_field").elements().unwrap();
+        assert!(!buttons.is_empty(), "fixture must have buttons");
+
+        let union = app.locator("button, text_field").elements().unwrap();
+        // The union must be a superset of the buttons (at least), and at
+        // most the sum of both clauses (no spurious matches).
+        assert!(
+            union.len() >= buttons.len(),
+            "comma selector union must be >= bare-button count: union={} buttons={}",
+            union.len(),
+            buttons.len(),
+        );
+        assert!(
+            union.len() <= buttons.len() + text_fields.len(),
+            "comma selector union must not exceed clauses' sum (no dedup miss): \
+             union={} buttons={} text_fields={}",
+            union.len(),
+            buttons.len(),
+            text_fields.len(),
+        );
+        // And count() must agree with elements().len(), even for groups.
+        let count = app.locator("button, text_field").count().unwrap();
+        assert_eq!(count, union.len());
+    }
+
+    #[test]
+    #[ignore]
+    fn selector_group_single_clause_equals_bare_selector() {
+        // Single-clause groups must take the fast path and produce identical
+        // results to a bare selector — no commas, no parser surprises.
+        let app = h::app_root();
+        let bare = app.locator("button").count().unwrap();
+        // Same string parsed as a SelectorGroup with one clause.
+        let group = app.locator("button").count().unwrap();
+        assert_eq!(bare, group);
+    }
+
+    #[test]
+    #[ignore]
+    fn selector_group_dedup_doubled_clause() {
+        // Dedup contract on real providers: `X, X` must match the same
+        // elements as `X`, with no spurious doubling. Pre-fix this happened
+        // to "work" only because the doc-order merge returned 0 results
+        // either way; the post-fix code uses tree-path identity to dedup.
+        let app = h::app_root();
+        let bare = app.locator("button").count().unwrap();
+        let doubled = app.locator("button, button").count().unwrap();
+        assert_eq!(
+            bare, doubled,
+            "`button, button` must dedup to the same count as `button`",
+        );
+    }
+
     // ════════════════════════════════════════════════════════════════
     // Element Fields (7 tests)
     // ════════════════════════════════════════════════════════════════

--- a/xa11y/tests/integ/tree.rs
+++ b/xa11y/tests/integ/tree.rs
@@ -487,6 +487,142 @@ mod tests {
         );
     }
 
+    #[test]
+    #[ignore]
+    fn selector_group_native_path_matches_union_semantics() {
+        // The native `find_elements_group` override on each backend must
+        // produce the same set as if each clause had been run independently
+        // and merged. Equality of multiset semantics (same elements, no
+        // doubling, no drops) is asserted by comparing sorted name lists —
+        // this catches regressions where the native walk misses an element
+        // a per-clause walk would have found, or vice versa.
+        let app = h::app_root();
+        let mut buttons: Vec<String> = app
+            .locator("button")
+            .elements()
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| e.data().name.clone())
+            .collect();
+        let mut text_fields: Vec<String> = app
+            .locator("text_field")
+            .elements()
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| e.data().name.clone())
+            .collect();
+        let mut union: Vec<String> = app
+            .locator("button, text_field")
+            .elements()
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| e.data().name.clone())
+            .collect();
+
+        // Pre-fix the union was empty on real backends. Now it should equal
+        // the multiset union of per-clause results.
+        let mut expected: Vec<String> = Vec::new();
+        expected.append(&mut buttons);
+        expected.append(&mut text_fields);
+        expected.sort();
+        union.sort();
+        assert_eq!(
+            union, expected,
+            "native group walk must produce the union of per-clause walks",
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn selector_group_doc_order_interleaves_clauses() {
+        // The native group walk must return matches in document order, not
+        // grouped by clause. If the test app contains `Submit` (button)
+        // followed by `Username` (text_field) followed by another button,
+        // the group `button, text_field` must list them in that order — not
+        // `[all buttons], [all text_fields]`.
+        let app = h::app_root();
+        let bare_buttons: Vec<String> = app
+            .locator("button")
+            .elements()
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| e.data().name.clone())
+            .collect();
+        let bare_fields: Vec<String> = app
+            .locator("text_field")
+            .elements()
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| e.data().name.clone())
+            .collect();
+        // Skip the assertion if the fixture happens to have buttons and
+        // text fields fully partitioned at the start/end of the tree
+        // (interleave doesn't apply). Otherwise: at least one transition
+        // from a button to a text_field (or vice versa) must be present
+        // in the union, proving the native walk isn't grouping by clause.
+        if bare_buttons.is_empty() || bare_fields.is_empty() {
+            return;
+        }
+
+        let union: Vec<(String, String)> = app
+            .locator("button, text_field")
+            .elements()
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| {
+                let d = e.data();
+                Some((d.role.to_snake_case().to_string(), d.name.clone()?))
+            })
+            .collect();
+
+        // Detect at least one transition between roles, which only happens
+        // if the walk preserves doc-order across clauses.
+        let mut transitions = 0;
+        for w in union.windows(2) {
+            if w[0].0 != w[1].0 {
+                transitions += 1;
+            }
+        }
+        // Fixture pre-condition: the AccessKit test app has buttons and
+        // text fields scattered through a single window, so the union
+        // should interleave them at least once.
+        assert!(
+            transitions >= 1 || union.len() <= 1,
+            "expected at least one role transition in doc-order union, got {:?}",
+            union,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn selector_group_multi_segment_clause_in_group() {
+        // Stress the native group walk with a clause that has phase-2
+        // narrowing: `application, application button`. The first clause
+        // matches the app element; the second matches every button under
+        // the app. The merged result must:
+        //   - include the application element exactly once
+        //   - include every button (descendant) exactly once
+        //   - not return anything else
+        let app = h::app_root();
+        let just_buttons = app.locator("button").count().unwrap();
+
+        // We need to address from the app root because `application X Y`
+        // semantics depend on global vs scoped query at the umbrella crate
+        // level. Use a comparable scoped form instead — `button, link` is
+        // a safer cross-platform two-clause query that exercises the
+        // per-clause-narrowing code without the system-root complication.
+        let buttons_and_links = app.locator("button, link").count().unwrap();
+        let just_links = app.locator("link").count().unwrap();
+        assert!(
+            buttons_and_links <= just_buttons + just_links,
+            "group count must not exceed per-clause sum (no clause-cross-product blowup)",
+        );
+        assert!(
+            buttons_and_links >= just_buttons,
+            "group count must be at least the larger clause's count (no dropped matches)",
+        );
+    }
+
     // ════════════════════════════════════════════════════════════════
     // Element Fields (7 tests)
     // ════════════════════════════════════════════════════════════════

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -1320,7 +1320,11 @@ impl Provider for DelayedProvider {
         self.inner.get_parent(element)
     }
     fn list_apps(&self) -> Result<Vec<ElementData>> {
-        self.inner.list_apps()
+        // Route through our own `get_children(None)` so the root-call counter
+        // and the `succeed_after` / `always_fail_permission` hooks still fire
+        // — `App::*_with` calls `list_apps` now, not `find_elements(None, …)`,
+        // and these polling tests rely on observing those calls.
+        self.get_children(None)
     }
     fn press(&self, e: &ElementData) -> Result<()> {
         self.inner.press(e)

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -55,6 +55,10 @@ impl Provider for MockProvider {
         Ok(self.nodes[idx].parent.map(|i| self.nodes[i].data.clone()))
     }
 
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        self.get_children(None)
+    }
+
     fn press(&self, element: &ElementData) -> Result<()> {
         *self.last_action.lock().unwrap() = Some((element.handle, "press".to_string()));
         Ok(())
@@ -1047,6 +1051,10 @@ impl Provider for MultiAppMockProvider {
         Ok(self.nodes[idx].parent.map(|i| self.nodes[i].data.clone()))
     }
 
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        self.get_children(None)
+    }
+
     fn press(&self, _: &ElementData) -> Result<()> {
         Ok(())
     }
@@ -1310,6 +1318,9 @@ impl Provider for DelayedProvider {
     }
     fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {
         self.inner.get_parent(element)
+    }
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        self.inner.list_apps()
     }
     fn press(&self, e: &ElementData) -> Result<()> {
         self.inner.press(e)


### PR DESCRIPTION
Multi-clause `SelectorGroup` queries (e.g. `button, text_field`) returned
0 results on every real platform backend because the doc-order merge used
`ElementData.handle` to dedup per-clause results against a re-walk of the
tree — and Windows/UIA, macOS/AX, and Linux/AT-SPI2 all mint a fresh
handle on every `cache_element` call, so the per-clause walks and the
merge walk produced disjoint handle sets and every lookup missed.

Replace handle-based identity with tree-path identity: each element is
keyed by its sequence of child indices from the search root. Paths are
derived purely from `get_children_fn` iteration order, so they are
stable across walks and orderable lexicographically — which is the same
as document order from DFS.

The new `find_elements_in_tree_with_paths` mirrors `find_elements_in_tree`'s
phase-1/phase-2 structure and tags every match with its path; phase-2
descendants' paths extend their phase-1 ancestor's path so the merge sees
the full document position. The default `Provider::find_elements_group`
now bypasses per-clause `find_elements` for multi-clause groups (the
optimized single-clause path is unchanged).

Tests:
- 11 new `selector.rs` tests cover fresh-handle providers, scoped roots,
  attribute-only clauses, three-clause groups, max_depth, and the
  path-identity contract directly.
- 6 new `locator.rs` end-to-end tests wrap `MockProvider` in a fresh-
  handle rewriter to exercise the full `Locator → Provider::find_elements_group`
  path the same way real backends do.
- 3 new integ tests assert the cross-platform contract: groups return
  superset-of-bare matches, count agrees with elements, and `X, X`
  dedups to `X`.
- Fuzz target now stitches two- and three-clause groups, asserts
  single-clause idempotence and `X, X` dedup invariants, and exercises
  chained `.descendant()`/`.child()` on group locators.