### PR TITLE
docs(seo): rework landing + accurate sitemap lastmod

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Full history so generate_sitemap.py can use `git log` to set
+          # accurate <lastmod> values from each source file's commit time.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
 
-Cross-platform accessibility library for reading and interacting with accessibility trees. One API for macOS, Windows, and Linux.
+A Playwright-style API for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
 
-**Use cases:** UI testing, AI agent tooling, assistive technology, desktop automation.
+**Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 
 **[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
 

--- a/docs/generate_sitemap.py
+++ b/docs/generate_sitemap.py
@@ -15,13 +15,16 @@ hardcoded.
 
 from __future__ import annotations
 
-import datetime
+import subprocess
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
 SITE_BASE = "https://xa11y.dev"
-DIST = Path(__file__).resolve().parent / "site" / "dist"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIST = REPO_ROOT / "docs" / "site" / "dist"
+CONTENT_ROOT = REPO_ROOT / "docs" / "site" / "src" / "content" / "docs"
+LANDING_SOURCE = REPO_ROOT / "docs" / "site" / "src" / "pages" / "index.astro"
 
 # Directory prefixes (relative to dist) whose HTML files should not be
 # advertised to search engines.
@@ -62,6 +65,44 @@ def should_include(path: Path) -> bool:
     return True
 
 
+def source_for(dist_path: Path) -> Path | None:
+    """Map a built HTML file back to its hand-written source, if any.
+
+    Returns the source path for the custom landing and Starlight MDX/MD pages.
+    Returns None for generated API reference pages (cargo doc, Sphinx) where
+    no clean per-page source mapping exists — those pages omit lastmod rather
+    than emit a misleading value.
+    """
+    rel = dist_path.relative_to(DIST).as_posix()
+    if rel == "index.html":
+        return LANDING_SOURCE if LANDING_SOURCE.exists() else None
+    if rel.startswith("api/"):
+        return None
+    if rel.endswith("/index.html"):
+        slug = rel[: -len("/index.html")]
+        for ext in (".mdx", ".md"):
+            candidate = CONTENT_ROOT / f"{slug}{ext}"
+            if candidate.exists():
+                return candidate
+    return None
+
+
+def git_mtime(source: Path) -> str | None:
+    """Return ISO date (YYYY-MM-DD) of the last commit touching `source`."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%cs", "--", str(source)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    out = result.stdout.strip()
+    return out or None
+
+
 def main() -> int:
     if not DIST.exists():
         print(
@@ -70,24 +111,32 @@ def main() -> int:
         )
         return 1
 
-    today = datetime.date.today().isoformat()
-    urls = sorted(
-        {url_for(p) for p in DIST.rglob("*.html") if should_include(p)}
-    )
+    seen: dict[str, Path] = {}
+    for p in DIST.rglob("*.html"):
+        if not should_include(p):
+            continue
+        u = url_for(p)
+        seen.setdefault(u, p)
+    pages = sorted(seen.items())
 
     ns = "http://www.sitemaps.org/schemas/sitemap/0.9"
     ET.register_namespace("", ns)
     root = ET.Element(f"{{{ns}}}urlset")
-    for u in urls:
+    dated = 0
+    for u, p in pages:
         el = ET.SubElement(root, f"{{{ns}}}url")
         ET.SubElement(el, f"{{{ns}}}loc").text = u
-        ET.SubElement(el, f"{{{ns}}}lastmod").text = today
+        src = source_for(p)
+        mtime = git_mtime(src) if src else None
+        if mtime:
+            ET.SubElement(el, f"{{{ns}}}lastmod").text = mtime
+            dated += 1
 
     tree = ET.ElementTree(root)
     ET.indent(tree, space="  ")
     out = DIST / "sitemap.xml"
     tree.write(out, encoding="utf-8", xml_declaration=True)
-    print(f"wrote {len(urls)} URLs to {out}")
+    print(f"wrote {len(pages)} URLs to {out} ({dated} with lastmod)")
     return 0
 
 

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
       title: "xa11y",
       customCss: ["./src/styles/custom.css"],
       description:
-        "Cross-platform accessibility library for reading and interacting with accessibility trees.",
+        "A Playwright-style API for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux.",
       social: [
         {
           icon: "github",

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -15,8 +15,16 @@ const version = `v${verMatch[1]}`;
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>xa11y — Cross-platform accessibility trees</title>
-<meta name="description" content="A unified API for accessibility trees across macOS, Windows, and Linux. Test desktop apps, power AI agents, or build assistive tools." />
+<title>xa11y — Playwright-style UI automation for desktop apps</title>
+<meta name="description" content="A Playwright-style API for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
+<meta property="og:title" content="xa11y — Playwright-style UI automation for desktop apps" />
+<meta property="og:description" content="A Playwright-style API for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://xa11y.dev/" />
+<meta property="og:site_name" content="xa11y" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="xa11y — Playwright-style UI automation for desktop apps" />
+<meta name="twitter:description" content="A Playwright-style API for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
 <link rel="canonical" href="https://xa11y.dev/" />
 <link rel="api-catalog" href="/.well-known/api-catalog" />
 <link rel="service-doc" href="/guides/overview/" />
@@ -320,13 +328,14 @@ const version = `v${verMatch[1]}`;
 <section class="hero" style="border-top:0;">
   <div>
     <h1 class="head">
-      cross-platform<br/>
-      accessibility <em>trees</em>.
+      drive desktop apps<br/>
+      via the <em>accessibility tree</em>.
     </h1>
 
     <p class="lede">
-      A unified API for accessibility trees across macOS, Windows, and Linux.
-      Test desktop apps, power AI agents, or build assistive tools.
+      A Playwright-style API for driving native desktop apps on
+      macOS, Windows, and Linux. Built for end-to-end tests,
+      computer-use agents, and assistive tools.
     </p>
 
     <div class="cta">
@@ -383,6 +392,7 @@ const version = `v${verMatch[1]}`;
 
 <!-- FEATURES -->
 <section class="no-rule">
+  <h2 class="sec-eyebrow">capabilities</h2>
   <div class="features">
     <div class="feature">
       <h3>simple interface</h3>
@@ -405,7 +415,7 @@ const version = `v${verMatch[1]}`;
 
 <!-- USE CASES -->
 <section>
-  <div class="sec-eyebrow">use cases</div>
+  <h2 class="sec-eyebrow">use cases</h2>
   <div class="qs">
     <ol id="uc-list" role="tablist"></ol>
     <div class="qs-pane"><pre id="uc-pane"></pre></div>
@@ -418,7 +428,7 @@ const version = `v${verMatch[1]}`;
   <div>
     <div class="brand" style="margin-bottom:12px;"><span class="glyph">x</span> xa11y <span class="ver">{version}</span></div>
     <div style="color:var(--ink-muted); font-size:13px; line-height:1.55; max-width:34ch;">
-      A unified API for accessibility trees on macOS, Windows and Linux. MIT-licensed, built in the open.
+      A Playwright-style API for driving native desktop apps on macOS, Windows, and Linux. MIT-licensed, built in the open.
     </div>
   </div>
   <div>
@@ -669,8 +679,8 @@ const version = `v${verMatch[1]}`;
       ].join('\n'),
     },
     {
-      h: 'AI agents',
-      d: 'Hand a model the structured tree and a screenshot of the same frame, then let it call press() and type_text() — no OCR required.',
+      h: 'computer-use agents',
+      d: 'Build computer-use agents or MCP tools. Hand a model the accessibility tree, then let it call press() and type_text(). No OCR or calculating click coordinates.',
       rust: [
 'use xa11y::*;',
 '',

--- a/xa11y-python/README.md
+++ b/xa11y-python/README.md
@@ -6,9 +6,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
 
-Cross-platform accessibility library for reading and interacting with accessibility trees. One API for macOS, Windows, and Linux.
+A Playwright-style API for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
 
-**Use cases:** UI testing, AI agent tooling, assistive technology, desktop automation.
+**Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 
 **[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
 

--- a/xa11y/README.md
+++ b/xa11y/README.md
@@ -6,9 +6,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
 
-Cross-platform accessibility library for reading and interacting with accessibility trees. One API for macOS, Windows, and Linux.
+A Playwright-style API for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
 
-**Use cases:** UI testing, AI agent tooling, assistive technology, desktop automation.
+**Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 
 **[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
 


### PR DESCRIPTION
## Summary

- **Landing copy + SEO meta**: H1 now leads with *"drive desktop apps via the **accessibility tree**"*. Lede reframes xa11y as *"a Playwright-style API for driving native desktop apps."* Same positioning mirrored across README, footer, site description, and a new full set of OG / Twitter card meta tags. The middle use-case tab is renamed to **computer-use agents** and works in an MCP-tools mention.
- **Heading hierarchy**: the features section had four orphan `<h3>` cards with no parent — now has an `<h2 class="sec-eyebrow">capabilities</h2>` above it. The use-cases eyebrow is promoted from `<div>` to `<h2>`.
- **Sitemap `<lastmod>` is now honest**: hand-written pages (landing + Starlight guides) get the commit time of their source file via `git log -1 --format=%cs`; generated API reference pages omit lastmod entirely (Google explicitly downweights values it can't trust). Requires `fetch-depth: 0` on the docs-workflow checkout so history is available on CI.

Phrase choices come from a research pass into how 2026 LLM-agent and developer queries cluster — *"computer use"* (Anthropic's tool name), *"Playwright for desktop apps"* (high-intent query lane with no current OSS owner), and the dominant phrasing across awesome-lists / MCP listings / 2026 tutorials.

Follow-up tracked in #205: drop the self-hosted Rust API reference and link to docs.rs instead. Bigger blast radius than this PR — kept separate.

## Test plan

- [ ] Deploy Docs workflow passes (it now uses `fetch-depth: 0` and the updated sitemap script)
- [ ] After deploy, `https://xa11y.dev/sitemap.xml` has `<lastmod>` only on hand-written pages (landing, `/guides/*`) and omits it on `/api/python/reference/*` and `/api/rust/reference/*`
- [ ] After deploy, OG / Twitter cards render correctly when the landing URL is shared (verify with a card debugger)
- [ ] Landing renders with new H1, "capabilities" h2 above features, computer-use-agents tab, and updated footer