### PR TITLE
ci: enable Qt-on-macOS integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,10 +191,9 @@ jobs:
       # already has TCC. The ax_calls_* tests are #[ignore]d so they are
       # skipped by `cargo test --workspace`.
 
-      # Qt integration tests skipped: macOS AX tree for Qt apps has
-      # incomplete structure (nested AXApplication nodes). The depth
-      # limit prevents hangs but widgets aren't fully exposed.
-      # Re-enable after fixing macOS provider tree building for Qt.
+      # Qt-on-macOS compat/actions/events run in the `integ` matrix below
+      # (macos-latest × qt). The macOS AX tree exposes Qt widgets findably
+      # via the locator walk, so the suites pass without special handling.
 
   # ── Windows: unit tests + AccessKit Rust integ tests ───────────────
   windows:
@@ -257,6 +256,7 @@ jobs:
           - { os: ubuntu-latest,  app: electron }
           - { os: macos-latest,   app: cocoa }
           - { os: macos-latest,   app: tauri }
+          - { os: macos-latest,   app: qt }
           - { os: windows-latest, app: qt }
           # egui (eframe) — pure-Rust cross-platform GUI driven through
           # AccessKit. Outside the workspace so we build it explicitly per-OS.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Integration tests use shared helpers from `xa11y/tests/integ/mod.rs`:
 
 ### Key coverage gaps to address
 
-- **Qt-on-macOS integration tests in CI** — currently skipped in `.github/workflows/ci.yml` (macOS Qt job disabled); macOS integ for the AccessKit app is working and covered.
+- _(none currently)_ — Qt-on-macOS integration tests are now enabled in `.github/workflows/ci.yml` (`integ` matrix, `macos-latest × qt`), alongside the AccessKit, Cocoa, and Tauri macOS coverage.
 
 ## Design Tenets
 

--- a/docs/site/src/content/docs/guides/design.mdx
+++ b/docs/site/src/content/docs/guides/design.mdx
@@ -89,14 +89,13 @@ The matrix below summarises which apps are exercised on which platforms and what
 | Test app    | Frameworks tested            | Platforms in CI       | Suites that target it      | Features covered                         |
 |-------------|------------------------------|-----------------------|----------------------------|------------------------------------------|
 | AccessKit   | Rust + winit + AccessKit     | Linux, macOS, Windows | Rust core integ, JS integ  | compat, actions, events, screenshot      |
-| Qt          | PySide6 (Qt 6)               | Linux, Windows¹       | Python integ               | compat, actions, events                  |
-| GTK         | GTK 4 (PyGObject)            | Linux                 | Python integ               | compat, actions²                         |
+| Qt          | PySide6 (Qt 6)               | Linux, macOS, Windows | Python integ               | compat, actions, events                  |
+| GTK         | GTK 4 (PyGObject)            | Linux                 | Python integ               | compat, actions¹                         |
 | Cocoa       | AppKit (Swift)               | macOS                 | Python integ               | compat, actions, events                  |
 | Tauri       | Tauri (Rust + HTML)          | Linux, macOS, Windows | Python integ               | compat, actions, events, input_sim, screenshot |
 | Electron    | Chromium + Node              | Linux                 | JS integ                   | compat, actions, AccessibilityNotEnabled detection |
 
-¹ macOS Qt is intentionally skipped — Qt/PySide6 does not correctly nest child elements in the macOS AX tree. Tracked as a known gap; tests re-enable once the upstream issue is resolved.
-² GTK event subscription is exercised through the Rust integ suite via AT-SPI2 rather than duplicated in the per-app Python suite.
+¹ GTK event subscription is exercised through the Rust integ suite via AT-SPI2 rather than duplicated in the per-app Python suite.
 
 ### CI matrix
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ see Known Gaps.
 | App        | Platform(s)           | Python compat | Python actions | Python events | Python input_sim | Python screenshot | JS compat | JS actions | JS input_sim | JS screenshot | CLI |
 |------------|-----------------------|:-------------:|:--------------:|:-------------:|:----------------:|:-----------------:|:---------:|:----------:|:------------:|:-------------:|:---:|
 | accesskit  | linux, macos, windows | —¹            | —¹             | —¹            | —                | —                 | ✅        | ✅         | ✅²          | ✅²           | ❌  |
-| qt         | linux, windows        | ✅            | ✅             | ✅            | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
+| qt         | linux, macos, windows | ✅            | ✅             | ✅            | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
 | gtk        | linux                 | ✅            | ✅             | ❌³           | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
 | cocoa      | macos                 | ✅            | ✅             | ✅            | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
 | tauri      | linux, macos, windows | ✅            | ✅             | ✅            | ✅               | ✅                | ❌        | ❌         | —            | —             | ❌  |
@@ -52,8 +52,6 @@ see Known Gaps.
 2. JS input_sim and screenshot run against the AccessKit app for the `integ` suite, and against Electron for the `integ-electron` suite.
 3. GTK has no event subscription tests. Only widget/compat and actions are covered.
 
-**macOS Qt (⚠️ disabled):** Qt/PySide6 does not correctly nest child elements in its macOS AX tree. macOS Qt tests are omitted until the upstream issue is resolved. Qt is tested on Linux and Windows only.
-
 ---
 
 ## Known Gaps
@@ -61,7 +59,6 @@ see Known Gaps.
 | ID              | Description                                                                                  | Severity | Workaround                                               |
 |-----------------|----------------------------------------------------------------------------------------------|:--------:|----------------------------------------------------------|
 | `cli_integ`     | No CLI integration tests exist for any app. The `xa11y` binary is not exercised end-to-end against a live app in CI. | **high** | Unit tests in `xa11y-python/tests/test_cli.py` cover CLI error paths only. |
-| `macos_qt`      | Qt/PySide6 AX tree does not correctly nest child elements on macOS; macOS Qt tests are disabled. | medium | Qt tested on Linux and Windows only.               |
 | `js_app_coverage` | JS integ tests cover only the AccessKit app and Electron. No JS tests for Qt, GTK, Cocoa, or Tauri. | medium | Python suites cover those apps.                   |
 | `gtk_events`    | No event subscription tests for GTK. Only compat and actions are covered.                    | low      | GTK event subscription is exercised in the Rust integ suite via AT-SPI2. |
 

--- a/tests/matrix.yaml
+++ b/tests/matrix.yaml
@@ -10,11 +10,7 @@ apps:
       JS integ tests also target this app for compat, actions, input_sim, and screenshot.
 
   qt:
-    platforms: [linux, windows]
-    unsupported:
-      macos:
-        reason: "Qt/PySide6 AX tree does not correctly nest child elements on macOS"
-        status: known_gap
+    platforms: [linux, macos, windows]
 
   gtk:
     platforms: [linux]
@@ -129,16 +125,6 @@ gaps:
     affects:
       apps: [accesskit]
       language: python
-
-  - id: macos_qt
-    description: >
-      Qt/PySide6 macOS AX tree does not correctly nest child elements; macOS Qt tests
-      are disabled.
-    severity: medium
-    workaround: "Qt tested on Linux and Windows only"
-    affects:
-      apps: [qt]
-      platforms: [macos]
 
   - id: js_input_sim_per_app
     description: >


### PR DESCRIPTION
The macOS Qt integ job was disabled on the claim that the Qt/PySide6 AX
tree "does not correctly nest child elements" on macOS. That claim traces
back to the initial repo import with no diagnostic evidence, and the
compat/actions/events suites discover widgets via the locator walk (up to
MAX_TREE_DEPTH=50), so extra wrapper nesting in the AX tree does not
prevent widgets from being found.

Add `macos-latest × qt` to the `integ` matrix and drop the stale
unsupported/gap entries. The qt suites are already toolkit-agnostic and
run on Linux and Windows; macOS is just a new OS for the same suites
(PySide6 requirements already install for any OS when app == qt, and TCC
is granted to the venv python). No provider or test changes were needed.