### PR TITLE
Enable Python compat suite against AccessKit on Linux

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -40,7 +40,7 @@ see Known Gaps.
 
 | App        | Platform(s)           | Python compat | Python actions | Python events | Python input_sim | Python screenshot | JS compat | JS actions | JS input_sim | JS screenshot | CLI |
 |------------|-----------------------|:-------------:|:--------------:|:-------------:|:----------------:|:-----------------:|:---------:|:----------:|:------------:|:-------------:|:---:|
-| accesskit  | linux, macos, windows | —¹            | —¹             | —¹            | —                | —                 | ✅        | ✅         | ✅²          | ✅²           | ❌  |
+| accesskit  | linux, macos, windows | ✅¹           | ✅¹            | ⚠️¹           | —                | —                 | ✅        | ✅         | ✅²          | ✅²           | ❌  |
 | qt         | linux, macos, windows | ✅            | ✅             | ✅            | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
 | gtk        | linux                 | ✅            | ✅             | ❌³           | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
 | cocoa      | macos                 | ✅            | ✅             | ✅            | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
@@ -48,7 +48,7 @@ see Known Gaps.
 | electron   | linux                 | ❌            | ❌             | ❌            | —                | —                 | ✅        | ✅         | ✅²          | ✅²           | ❌  |
 
 **Notes:**
-1. accesskit Python column is `—` because the primary coverage vehicle is the Rust integ suite in `xa11y/tests/integ/`. These are not duplicated in Python.
+1. The accesskit Python compat/actions suites run **on Linux only** (the harness gates this on `sys.platform`). Linux is where AccessKit's AT-SPI bridge — and its `"click"`-not-`"toggle"` action naming, which the toggle()-via-press fallback in `xa11y-linux/src/atspi.rs` depends on — is exercised. The events module also runs but its assertions are `xfail`-guarded (⚠️). On macOS/Windows the Rust integ suite in `xa11y/tests/integ/` stays the canonical AccessKit coverage, so Python is not duplicated there.
 2. JS input_sim and screenshot run against the AccessKit app for the `integ` suite, and against Electron for the `integ-electron` suite.
 3. GTK has no event subscription tests. Only widget/compat and actions are covered.
 

--- a/tests/harness/launch.py
+++ b/tests/harness/launch.py
@@ -378,12 +378,24 @@ def _run_suites(
 
     worst_rc = 0
 
-    # Per-app suite skips. accesskit's widget schema differs from the shared
-    # python/cli/js fixtures (e.g. "Submit"/"Cancel" instead of "OK"), and its
-    # primary coverage is the Rust integ suite — skip all three harness
-    # suites.
+    # Per-app suite skips. The AccessKit app's widget schema differs from the
+    # shared OK-button fixtures, so the CLI and JS suites (which have their own
+    # AccessKit coverage) stay skipped for it.
+    #
+    # The Python suite IS wired up for AccessKit (full APP_CONFIGS entry:
+    # Submit/Cancel schema, single checkbox, no dialog), but only on Linux.
+    # Linux is the one platform where AccessKit's AT-SPI bridge
+    # (accesskit_unix) is exercised, and where its hardcoded
+    # "click"-not-"toggle" action naming makes the toggle()-via-press fallback
+    # in xa11y-linux/src/atspi.rs load-bearing — exactly the gap that went
+    # uncaught before (see tests/matrix.yaml accesskit_python_compat_on_linux).
+    # On macOS/Windows the Rust integ suite remains the canonical AccessKit
+    # coverage, so the Python suite is skipped there.
+    accesskit_skips = {"cli", "js"}
+    if sys.platform != "linux":
+        accesskit_skips.add("python")
     suite_skips_by_app = {
-        "accesskit": {"python", "cli", "js"},
+        "accesskit": accesskit_skips,
     }
 
     for suite in suites:

--- a/tests/matrix.yaml
+++ b/tests/matrix.yaml
@@ -80,7 +80,11 @@ rust_core:
 # coverage[app][language] = list of features covered, or [] for none.
 coverage:
   accesskit:
-    python: []          # intentional: Rust integ suite is the primary vehicle (see gaps.accesskit_python_suite)
+    # Python compat/actions run against the AccessKit app on Linux only (the
+    # harness gates this on sys.platform). The events module also runs but its
+    # assertions are xfail-guarded. On macOS/Windows the Rust integ suite stays
+    # the canonical AccessKit coverage. See note below.
+    python: [compat, actions, events]
     js: [compat, actions, input_sim, screenshot]
     cli: [compat, actions]  # CLI is Rust — natural to test against the Rust test app
 
@@ -115,13 +119,17 @@ coverage:
     cli: [compat, actions]
 
 gaps:
-  - id: accesskit_python_suite
+  - id: accesskit_python_suite_non_linux
     description: >
-      No Python compat suite for the AccessKit app. The Rust integ suite in
-      xa11y/tests/integ/ is the primary coverage vehicle; duplicating it in Python
-      would add noise without signal. CLI is covered (CLI is Rust — natural fit).
+      The Python compat/actions suite now runs against the AccessKit app on
+      Linux (tests/harness/launch.py wires it up there; see APP_CONFIGS
+      "accesskit" in tests/suites/python/conftest.py). It is intentionally NOT
+      run on macOS or Windows: AccessKit's AX/UIA bridges are already covered
+      canonically by the Rust integ suite in xa11y/tests/integ/, and the
+      Linux AT-SPI bridge (accesskit_unix) is the one with behaviour the
+      Python suite uniquely guards (the "click"-not-"toggle" action naming).
     severity: low
-    workaround: "Rust integ suite (cargo xtask test-integ) covers compat, actions, events, screenshot"
+    workaround: "Rust integ suite (cargo xtask test-integ) covers compat, actions, events, screenshot on macOS/Windows"
     affects:
       apps: [accesskit]
       language: python
@@ -148,28 +156,13 @@ gaps:
       language: python
       features: [events]
 
-  - id: accesskit_python_compat_on_linux
-    description: >
-      tests/harness/launch.py skips the python/js/cli compat suites entirely
-      for the AccessKit test app (suite_skips_by_app["accesskit"]) on the
-      grounds that the Rust integ suite is canonical for accesskit. The
-      practical consequence is that no Python/CLI test runs against
-      AccessKit on Linux — which is the only place accesskit_unix's
-      hardcoded "click"-not-"toggle" AT-SPI action naming is the underlying
-      truth. PR #211 surfaced this when the toggle()-via-press fallback in
-      xa11y-linux/src/atspi.rs was missing for every AccessKit-on-Linux
-      provider (egui, accesskit_winit, eframe, bevy, …) and no compat
-      test had caught it. The fallback is now in place plus an
-      `action_toggle_dispatches_to_click_when_toggle_unavailable` Rust
-      integ test, but the broader compat-suite gap remains.
-    severity: medium
-    workaround: >
-      Rust integ suite covers compat/actions/events/screenshot against
-      AccessKit on all three OSes; the new Rust integ test exercises the
-      specific fallback. Wiring the Python/CLI suites against AccessKit
-      would mean an APP_CONFIGS entry that maps the schema (Submit/Cancel
-      vs OK/Cancel etc.) — out of scope for #211.
-    affects:
-      apps: [accesskit]
-      language: python
+# Resolved gaps (kept here briefly for provenance):
+#   accesskit_python_compat_on_linux — the Python compat/actions suite now
+#   runs against the AccessKit app on Linux via tests/harness/launch.py, with
+#   an APP_CONFIGS "accesskit" entry mapping the Submit/Cancel schema. This
+#   exercises accesskit_unix's "click"-not-"toggle" action naming and the
+#   toggle()-via-press fallback in xa11y-linux/src/atspi.rs end-to-end through
+#   the bindings (test_checkbox_toggle_changes_state / _via_element /
+#   test_checkbox_press_via_element). The remaining (intentional) non-coverage
+#   on macOS/Windows is tracked as accesskit_python_suite_non_linux above.
 

--- a/tests/suites/python/conftest.py
+++ b/tests/suites/python/conftest.py
@@ -178,6 +178,63 @@ APP_CONFIGS: dict[str, dict] = {
         "add_item_button_name": None,
         "remove_item_button_name": None,
     },
+    "accesskit": {
+        # The AccessKit test app (test-apps/accesskit/src/main.rs) is the
+        # canonical AccessKit-on-AT-SPI target on Linux. Its widget schema
+        # differs from the shared toolkit fixtures: buttons are Submit/Cancel
+        # (no OK), there is a single checkbox, and there is no native dialog.
+        "dialog_button_name": None,
+        "dialog_name": None,
+        # Buttons — the app uses "Submit"/"Cancel" rather than "OK"/"Cancel".
+        # The shared button tests treat ``ok_button_name`` as "the primary
+        # activation button", so Submit fills that role here.
+        "ok_button_name": "Submit",
+        "cancel_button_name": "Cancel",
+        # Submit advertises no description in the AccessKit tree.
+        "ok_button_description": None,
+        # In the AccessKit app, pressing Submit does NOT enable Cancel — the
+        # checkbox toggle is what flips ``cancel_enabled`` (see handle_action
+        # in test-apps/accesskit/src/main.rs). Tell the shared button test not
+        # to assert the OK→Cancel-enable coupling that other toolkits provide.
+        "ok_press_enables_cancel": False,
+        # Checkboxes — a single checkbox labelled "I agree to terms",
+        # initially unchecked. There is no pre-checked checkbox.
+        "has_checkbox": True,
+        "checkbox_unchecked_name": "I agree to terms",
+        "checkbox_checked_name": None,
+        # Radio buttons — Role::RadioButton, "Option A"/"Option B".
+        "has_radio": True,
+        "radio_role": "radio_button",
+        "radio_a_name": "Option A",
+        "radio_b_name": "Option B",
+        # Slider — "Volume", numeric range 0..100.
+        "slider_selector": 'slider[name="Volume"]',
+        "slider_initial_value": 50.0,
+        "slider_min": 0.0,
+        "slider_max": 100.0,
+        # Spin button — "Quantity", numeric range 0..100.
+        "spinbutton_selector": 'spin_button[name="Quantity"]',
+        # Progress bar — labelled "75%" (ProgressIndicator value 0.75).
+        "progress_bar_selector": 'progress_bar[name="75%"]',
+        # Text field — "Name". The app sets the value to "John Doe", but
+        # accesskit_unix does not surface a Role::TextInput's value through the
+        # AT-SPI Text/EditableText interface, so xa11y reads it back as None
+        # and set_value() raises TextValueNotSupported. This is the same
+        # adapter limitation the Rust integ test `action_set_value_text`
+        # tolerates. Leave the initial value unchecked and mark the field
+        # non-settable so the action tests skip rather than fail.
+        "textfield_selector": 'text_field[name="Name"]',
+        "textfield_initial_value": None,
+        "textfield_settable": False,
+        # The AccessKit app has no multiline text area.
+        "textarea_selector": None,
+        # Window name comes from the winit window title but AT-SPI reports the
+        # binary name; leave unchecked.
+        "window_name_contains": None,
+        "submit_button_name": "Submit",
+        "add_item_button_name": "Add Item",
+        "remove_item_button_name": "Remove Item",
+    },
     "egui": {
         # egui has no native dialog primitive; tests that depend on opening a
         # platform dialog skip when this is None.
@@ -330,6 +387,27 @@ def _launch_electron() -> xa11y.App:
     )
 
 
+def _launch_accesskit() -> xa11y.App:
+    # Built as part of the Cargo workspace (`cargo build -p xa11y-test-app`);
+    # the binary lands in the workspace target dir.
+    binary = str(PROJECT_ROOT / "target" / "debug" / "xa11y-test-app")
+    if not Path(binary).exists():
+        result = subprocess.run(
+            ["cargo", "build", "-p", "xa11y-test-app"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"Failed to build AccessKit test app:\n{result.stdout}\n{result.stderr}"
+            )
+    yield from launch_test_app(
+        command=[binary, "--headless"],
+        app_names=["xa11y-test-app", "xa11y Test App"],
+    )
+
+
 def _launch_egui() -> xa11y.App:
     binary = str(
         PROJECT_ROOT / "test-apps" / "egui" / "target" / "debug" / "xa11y-egui-test-app"
@@ -363,6 +441,7 @@ _LAUNCHERS = {
     "cocoa": _launch_cocoa,
     "tauri": _launch_tauri,
     "electron": _launch_electron,
+    "accesskit": _launch_accesskit,
     "egui": _launch_egui,
 }
 

--- a/tests/suites/python/test_actions.py
+++ b/tests/suites/python/test_actions.py
@@ -41,8 +41,16 @@ def test_button_press_ok_enables_cancel(app, app_config):
     _time.sleep(ACTION_SETTLE)
 
     cancel_after = app.locator(f'button[name="{cancel_name}"]').element()
-    # After pressing OK, Cancel must be enabled (all apps implement this toggle).
-    assert cancel_after.enabled is True
+    # Most toolkits wire the primary button to enable the initially-disabled
+    # Cancel. The AccessKit test app instead enables Cancel from the checkbox
+    # toggle (see handle_action in test-apps/accesskit/src/main.rs), so its
+    # config opts out of the coupling — there we only assert press() did not
+    # raise and Cancel is still a usable button.
+    if app_config.get("ok_press_enables_cancel", True):
+        assert cancel_after.enabled is True
+    else:
+        assert cancel_after.role == "button"
+        assert isinstance(cancel_after.enabled, bool)
 
 
 def test_perform_action_press_equivalent(app, app_config):
@@ -249,6 +257,15 @@ def test_textfield_set_value(app, app_name, app_config):
     if not sel:
         pytest.skip("app has no text_field widget")
 
+    if not app_config.get("textfield_settable", True):
+        pytest.skip(
+            "text_field value is not settable via the a11y API for this app. "
+            "AccessKit's AT-SPI bridge (accesskit_unix) does not expose a "
+            "Role::TextInput through the EditableText interface, so set_value() "
+            "raises TextValueNotSupported (mirrors the Rust integ test "
+            "action_set_value_text)."
+        )
+
     if app_name in ("tauri", "electron"):
         pytest.skip(
             f"WebKit2GTK / Chromium ({app_name}) expose HTML <input> through "
@@ -410,6 +427,11 @@ def test_textfield_set_value_via_element(app, app_name, app_config):
     sel = app_config.get("textfield_selector")
     if not sel:
         pytest.skip("app has no text_field widget")
+    if not app_config.get("textfield_settable", True):
+        pytest.skip(
+            "text_field value is not settable via the a11y API for this app "
+            "(see test_textfield_set_value)."
+        )
     if app_name in ("tauri", "electron"):
         pytest.skip(
             f"WebKit2GTK / Chromium ({app_name}) expose HTML <input> through "


### PR DESCRIPTION
Closes the accesskit_python_compat_on_linux test gap. The harness
previously skipped the python/js/cli suites for the AccessKit app, so no
Python test ran against AccessKit on Linux — the one place where
accesskit_unix's hardcoded "click"-not-"toggle" AT-SPI action naming is
the underlying truth, and where the toggle()-via-press fallback in
xa11y-linux/src/atspi.rs is load-bearing. That fallback regressed once
with no compat test to catch it.

Changes:
- Add an "accesskit" APP_CONFIGS entry mapping the app's schema
  (Submit/Cancel instead of OK/Cancel, single checkbox, no dialog) plus a
  standalone launcher, so the shared compat/actions suites adapt to it.
- Gate the Python suite to Linux in tests/harness/launch.py. macOS/Windows
  AccessKit coverage remains the canonical Rust integ suite.
- Make two app-behavior couplings config-driven so the AccessKit app fits
  the shared assertions without weakening them for other toolkits:
  - ok_press_enables_cancel: the AccessKit app enables Cancel from the
    checkbox toggle, not from pressing Submit.
  - textfield_settable: accesskit_unix does not expose Role::TextInput via
    the AT-SPI EditableText interface (set_value raises
    TextValueNotSupported), mirroring the Rust integ test
    action_set_value_text.
- Update tests/matrix.yaml and tests/README.md coverage + gaps.

Verified on Linux (Xvfb + dbus-run-session, AT-SPI2): 47 passed,
23 skipped, 3 xfailed, 8 xpassed. The toggle()-via-press fallback is now
exercised end-to-end by test_checkbox_toggle_changes_state,
test_checkbox_toggle_via_element, and test_checkbox_press_via_element.

https://claude.ai/code/session_01GxbxDNB8NK87UGr1EW5tRn