### PR TITLE
Add reusable setup-a11y action, dedup CI apt list, document CI

### DIFF
--- a/.github/actions/setup-a11y/action.yml
+++ b/.github/actions/setup-a11y/action.yml
@@ -1,0 +1,215 @@
+name: "Set up accessibility environment for xa11y"
+description: >-
+  Prepare a CI runner to drive accessibility tests with xa11y. On Linux it
+  installs the system libraries xa11y's targets need and (optionally) brings up
+  a headless display, a D-Bus session, and the AT-SPI bridge. On macOS it can
+  grant the Accessibility (TCC) permission the runner needs, or warns if it is
+  missing. On Windows it is a no-op (UI Automation works out of the box).
+
+# Usage (external consumer):
+#
+#   - uses: xa11y/xa11y/.github/actions/setup-a11y@main
+#     with:
+#       package-groups: base          # add 'gtk' / 'electron' if your app needs them
+#       extra-packages: my-app-deps    # any additional apt packages
+#   - run: pytest tests/               # DISPLAY / DBUS / AT-SPI are now live
+#
+# See docs: https://xa11y.dev/guides/ci/
+
+inputs:
+  package-groups:
+    description: >-
+      Space-separated apt package groups to install on Linux, defined in
+      apt-packages.txt. Available: base, gtk, electron. 'base' covers the
+      headless display + AT-SPI stack and is almost always what you want.
+    required: false
+    default: "base"
+  extra-packages:
+    description: "Additional apt packages to install on Linux (space-separated)."
+    required: false
+    default: ""
+  install-deps:
+    description: "Install system dependencies on Linux. Set to 'false' to skip apt entirely."
+    required: false
+    default: "true"
+  apt-cache-version:
+    description: "Cache-busting version passed to awalsh128/cache-apt-pkgs-action. Bump when the package set changes."
+    required: false
+    default: "1"
+  setup-display:
+    description: "Start Xvfb and export DISPLAY (Linux only)."
+    required: false
+    default: "true"
+  setup-atspi:
+    description: "Start a D-Bus session + AT-SPI bridge and export their env (Linux only)."
+    required: false
+    default: "true"
+  setup-window-manager:
+    description: >-
+      Start fluxbox (Linux only). Some toolkits (e.g. egui via AccessKit) only
+      publish their tree once a window manager has mapped/focused the window.
+    required: false
+    default: "false"
+  display:
+    description: "X display number to use for Xvfb (Linux only)."
+    required: false
+    default: ":99"
+  macos-tcc-client:
+    description: >-
+      Path to the binary that needs the Accessibility (TCC) permission on macOS
+      (e.g. the python interpreter running your tests). When set, the action
+      grants kTCCServiceAccessibility to it. When empty, the action prints a
+      warning instead — it cannot guess which process to grant.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # ── Linux: resolve the package list from apt-packages.txt ──────────
+    - name: Resolve apt package list
+      id: pkgs
+      if: ${{ runner.os == 'Linux' && inputs.install-deps == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        file="${GITHUB_ACTION_PATH}/apt-packages.txt"
+        out=""
+        for group in ${{ inputs.package-groups }}; do
+          group_pkgs=$(awk -v want="$group" '
+            /^#[[:space:]]*\[.*\]$/ {
+              cur=$0; sub(/^#[[:space:]]*\[/,"",cur); sub(/\][[:space:]]*$/,"",cur); next
+            }
+            /^[[:space:]]*#/ { next }
+            /^[[:space:]]*$/ { next }
+            { if (cur==want) print }
+          ' "$file")
+          if [ -z "$group_pkgs" ]; then
+            echo "::error::setup-a11y: unknown package group '$group' (see apt-packages.txt)"
+            exit 1
+          fi
+          out="$out $group_pkgs"
+        done
+        out="$out ${{ inputs.extra-packages }}"
+        # Collapse newlines/runs of whitespace into single spaces.
+        out=$(echo $out | tr '\n' ' ' | tr -s ' ')
+        echo "Resolved apt packages: $out"
+        echo "packages=$out" >> "$GITHUB_OUTPUT"
+
+    - name: Install system dependencies
+      # cache-apt-pkgs-action caches the .debs so warm runs finish in ~10s
+      # instead of the ~60s a cold apt-get update + install of ~30 packages
+      # takes. Bump apt-cache-version when the package set changes.
+      if: ${{ runner.os == 'Linux' && inputs.install-deps == 'true' }}
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        version: ${{ inputs.apt-cache-version }}
+        packages: ${{ steps.pkgs.outputs.packages }}
+
+    # ── Linux: bring up display + D-Bus + AT-SPI ───────────────────────
+    # Done in one step so Xvfb, the session bus, and the AT-SPI daemons
+    # share a parent shell; the env they produce is exported to GITHUB_ENV
+    # so later job steps inherit it. Background daemons persist across steps.
+    - name: Start accessibility environment
+      if: ${{ runner.os == 'Linux' && (inputs.setup-display == 'true' || inputs.setup-atspi == 'true') }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        find_atspi_bin() {
+          local exe="$1"
+          if [ -x "/usr/libexec/$exe" ]; then echo "/usr/libexec/$exe"
+          elif command -v "$exe" >/dev/null 2>&1; then command -v "$exe"
+          fi
+        }
+
+        if [ "${{ inputs.setup-display }}" = "true" ]; then
+          echo "Starting Xvfb on ${{ inputs.display }}..."
+          Xvfb "${{ inputs.display }}" -screen 0 1280x1024x24 -ac &
+          export DISPLAY="${{ inputs.display }}"
+          echo "DISPLAY=${{ inputs.display }}" >> "$GITHUB_ENV"
+          sleep 1
+        fi
+
+        if [ "${{ inputs.setup-window-manager }}" = "true" ]; then
+          echo "Starting fluxbox..."
+          fluxbox >/dev/null 2>&1 &
+          sleep 1
+        fi
+
+        if [ "${{ inputs.setup-atspi }}" = "true" ]; then
+          # Use dbus-launch (not dbus-run-session) so the session bus
+          # daemonizes and survives into subsequent job steps.
+          if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+            echo "Starting D-Bus session..."
+            eval "$(dbus-launch --sh-syntax)"
+            echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
+            echo "DBUS_SESSION_BUS_PID=$DBUS_SESSION_BUS_PID" >> "$GITHUB_ENV"
+          fi
+
+          export NO_AT_BRIDGE=0 AT_SPI_CLIENT=true ACCESSIBILITY_ENABLED=1
+          {
+            echo "NO_AT_BRIDGE=0"
+            echo "AT_SPI_CLIENT=true"
+            echo "ACCESSIBILITY_ENABLED=1"
+          } >> "$GITHUB_ENV"
+
+          bus_launcher=$(find_atspi_bin at-spi-bus-launcher)
+          if [ -n "${bus_launcher:-}" ]; then
+            "$bus_launcher" --launch-immediately &
+            sleep 1
+          else
+            echo "::warning::setup-a11y: at-spi-bus-launcher not found"
+          fi
+
+          registryd=$(find_atspi_bin at-spi2-registryd)
+          if [ -n "${registryd:-}" ]; then
+            "$registryd" &
+            sleep 1
+          else
+            echo "::warning::setup-a11y: at-spi2-registryd not found"
+          fi
+
+          # Flip the AT-SPI Status flags to enabled so clients see the tree.
+          # The daemons occasionally haven't registered the Status object yet
+          # at this instant; newer at-spi2-core also defaults these on. Ignore
+          # a transient failure here rather than fail setup.
+          for prop in IsEnabled ScreenReaderEnabled; do
+            dbus-send --session --print-reply --dest=org.a11y.Bus /org/a11y/bus \
+              org.freedesktop.DBus.Properties.Set \
+              string:org.a11y.Status string:"$prop" variant:boolean:true \
+              2>/dev/null || echo "setup-a11y: org.a11y.Status.$prop not set yet (continuing)"
+          done
+        fi
+
+        echo "Accessibility environment ready."
+
+    # ── macOS: grant or warn about the Accessibility (TCC) permission ──
+    - name: Configure macOS accessibility permission
+      if: ${{ runner.os == 'macOS' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        client="${{ inputs.macos-tcc-client }}"
+        if [ -z "$client" ]; then
+          echo "::warning::setup-a11y: macOS accessibility tests need the test process granted kTCCServiceAccessibility, but no 'macos-tcc-client' was provided. Trees will come back empty until the permission is granted. See https://xa11y.dev/guides/ci/#macos"
+          exit 0
+        fi
+        echo "Granting TCC kTCCServiceAccessibility to: $client"
+        # GitHub-hosted macOS runners allow sudo writes to the system TCC db
+        # (SIP only covers /System/*). Named columns keep the INSERT working
+        # across macOS versions regardless of extra columns.
+        sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
+          "INSERT OR REPLACE INTO access(service,client,client_type,auth_value,auth_reason,auth_version,csreq,policy_id,indirect_object_identifier_type,indirect_object_identifier,indirect_object_code_identity,flags,last_modified) \
+           VALUES('kTCCServiceAccessibility','${client}',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,$(date +%s));"
+        # Restart tccd so the grant is picked up without waiting for the next
+        # natural reload cycle. launchctl stop triggers an auto-restart.
+        sudo launchctl stop com.apple.tccd 2>/dev/null || true
+        sleep 2
+
+    # ── Windows: nothing to do ─────────────────────────────────────────
+    - name: Windows accessibility note
+      if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      run: |
+        echo "setup-a11y: no setup required on Windows — UI Automation is available by default."

--- a/.github/actions/setup-a11y/apt-packages.txt
+++ b/.github/actions/setup-a11y/apt-packages.txt
@@ -1,0 +1,37 @@
+# Canonical apt package groups for running xa11y accessibility tests on
+# Debian/Ubuntu CI runners. This is the SINGLE SOURCE OF TRUTH — it is read
+# by .github/actions/setup-a11y, which every Linux job in ci.yml goes through,
+# and by external consumers who reference that action. Edit here, everyone
+# picks it up.
+#
+# Format:
+#   # [group]      starts a named group
+#   pkg pkg ...    one or more packages belonging to the current group
+# Blank lines and any other `#` comment lines are ignored. Package order is
+# preserved so the awalsh128/cache-apt-pkgs-action cache key stays stable.
+#
+# When you change a group's contents, bump `apt-cache-version` on the
+# setup-a11y action call (or its default) so the cached .debs invalidate.
+
+# [base]
+# Headless display + session/accessibility bus that every GUI a11y test needs.
+xvfb dbus dbus-x11 fluxbox
+at-spi2-core
+# winit / xcb client libraries (AccessKit, Qt, egui windows).
+libxkbcommon-x11-0 libxkbcommon-x11-dev
+libxcursor1 libxrandr2 libxi6
+libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0
+libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3
+libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1
+libxcb-image0 libxcb-render-util0 libxcb-xkb1
+
+# [gtk]
+# GTK3/4 + WebKitGTK — needed by the GTK and Tauri test apps.
+libgtk-4-dev gir1.2-gtk-4.0 libgirepository-2.0-dev libcairo2-dev
+libwebkit2gtk-4.1-dev libssl-dev librsvg2-dev libgtk-3-dev
+
+# [electron]
+# Chromium/Electron runtime libraries on top of the base X/dbus/a11y set.
+libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2
+libdrm2 libgbm1 libxcomposite1 libxdamage1 libxfixes3
+libpango-1.0-0 libasound2t64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,24 +37,14 @@ jobs:
           python-version: "3.12"
 
       - name: Install system dependencies
-        # `awalsh128/cache-apt-pkgs-action` caches the .debs so re-runs on
-        # the same package-set finish in ~10s instead of the ~60s it takes
-        # to `apt-get update` + `install` 30 packages from scratch.
-        # Bump `version` to invalidate the cache when the package list changes.
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        # Package list lives in .github/actions/setup-a11y/apt-packages.txt.
+        # run_integ_tests.sh brings up its own Xvfb + D-Bus + AT-SPI, so this
+        # is install-only here.
+        uses: ./.github/actions/setup-a11y
         with:
-          version: 1
-          packages: >-
-            xvfb dbus dbus-x11 fluxbox
-            at-spi2-core
-            libxkbcommon-x11-0 libxkbcommon-x11-dev
-            libxcursor1 libxrandr2 libxi6
-            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0
-            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3
-            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1
-            libxcb-image0 libxcb-render-util0 libxcb-xkb1
-            libgtk-4-dev gir1.2-gtk-4.0 libgirepository-2.0-dev libcairo2-dev
-            libwebkit2gtk-4.1-dev libssl-dev librsvg2-dev libgtk-3-dev
+          package-groups: base gtk
+          setup-display: "false"
+          setup-atspi: "false"
 
       - name: Run unit tests
         run: cargo test --workspace
@@ -291,29 +281,16 @@ jobs:
           cache-dependency-path: xa11y-js/package-lock.json
 
       # ── System dependencies (Linux only) ──────────────────────────
+      # Package list lives in .github/actions/setup-a11y/apt-packages.txt.
+      # The harness step below wraps the run in Xvfb + dbus-run-session, so
+      # this is install-only (electron group adds the Chromium runtime libs).
       - name: Install system dependencies
-        # `awalsh128/cache-apt-pkgs-action` caches the .debs so re-runs on
-        # the same package-set finish in ~10s. Bump `version` to invalidate
-        # when the package list changes. Electron adds nss/atk/cups/drm/gbm
-        # on top of the base X/dbus/a11y set.
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/setup-a11y
         with:
-          version: 1
-          packages: >-
-            xvfb dbus dbus-x11 fluxbox
-            at-spi2-core
-            libxkbcommon-x11-0 libxkbcommon-x11-dev
-            libxcursor1 libxrandr2 libxi6
-            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0
-            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3
-            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1
-            libxcb-image0 libxcb-render-util0 libxcb-xkb1
-            libgtk-4-dev gir1.2-gtk-4.0 libgirepository-2.0-dev libcairo2-dev
-            libwebkit2gtk-4.1-dev libssl-dev librsvg2-dev libgtk-3-dev
-            libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2
-            libdrm2 libgbm1 libxcomposite1 libxdamage1 libxfixes3
-            libpango-1.0-0 libasound2t64
+          package-groups: base gtk electron
+          setup-display: "false"
+          setup-atspi: "false"
 
       # ── Build Rust workspace (all workspace test-app binaries) ─────
       - name: Build Rust workspace
@@ -524,19 +501,15 @@ jobs:
           cache: npm
           cache-dependency-path: xa11y-js/package-lock.json
 
+      # Package list lives in .github/actions/setup-a11y/apt-packages.txt.
+      # The "Run examples" step sets up Xvfb + dbus-run-session itself, so
+      # this is install-only.
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/setup-a11y
         with:
-          version: 1
-          packages: >-
-            xvfb dbus dbus-x11 fluxbox
-            at-spi2-core
-            libxkbcommon-x11-0 libxkbcommon-x11-dev
-            libxcursor1 libxrandr2 libxi6
-            libx11-xcb1 libxcb-render0 libxcb-shape0 libxcb-xfixes0
-            libegl1 libglib2.0-0 libfontconfig1 libdbus-1-3
-            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1
-            libxcb-image0 libxcb-render-util0 libxcb-xkb1
+          package-groups: base
+          setup-display: "false"
+          setup-atspi: "false"
 
       # ── Build everything the examples need ───────────────────────────
       - name: Build workspace (test app, CLI, Rust example)

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig({
             { label: "Overview", slug: "guides/overview" },
             { label: "CLI", slug: "guides/cli" },
             { label: "Desktop Testing", slug: "guides/desktop-testing" },
+            { label: "Testing in CI", slug: "guides/ci" },
             { label: "Input Simulation", slug: "guides/input" },
             { label: "Screenshots", slug: "guides/screenshots" },
             { label: "Platform Details", slug: "guides/platform-details" },

--- a/docs/site/src/content/docs/guides/ci.mdx
+++ b/docs/site/src/content/docs/guides/ci.mdx
@@ -1,0 +1,141 @@
+---
+title: Testing in CI
+description: Run xa11y accessibility tests on GitHub Actions across Linux, macOS, and Windows.
+---
+
+xa11y drives the *real* accessibility tree of a running application, so the
+hard part of CI isn't xa11y — it's standing up an environment where an
+accessibility API is actually available. A bare CI runner usually has no
+display, no accessibility bus, and (on macOS) no permission to read other
+apps' trees. This guide covers what each platform needs and gives you a
+reusable GitHub Action so you don't have to wire it up by hand.
+
+## Why it's tricky
+
+Each platform exposes accessibility differently, and each has a precondition
+that fails silently if you miss it:
+
+| Platform | API | What CI is missing by default |
+| --- | --- | --- |
+| **Linux** | AT-SPI2 (D-Bus) | No display, no D-Bus session, AT-SPI bridge not running/enabled |
+| **macOS** | AXUIElement | The test process isn't granted the Accessibility (TCC) permission |
+| **Windows** | UI Automation | Nothing — UIA works on hosted runners out of the box |
+
+The failure mode is the same on Linux and macOS: queries return an **empty
+tree** rather than an error, so it looks like your app has no UI. The
+sections below show how to satisfy each precondition.
+
+## The `setup-a11y` action
+
+The quickest path is the composite action that ships in this repo. It
+installs the Linux system libraries, brings up a headless display + D-Bus +
+AT-SPI, and (on macOS) grants the Accessibility permission — then exports the
+environment so every later step in the job inherits it.
+
+```yaml title=".github/workflows/test.yml"
+jobs:
+  a11y-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up accessibility environment
+        uses: xa11y/xa11y/.github/actions/setup-a11y@main
+        with:
+          package-groups: base   # add 'gtk' / 'electron' for those toolkits
+          # extra-packages: my-app-runtime-deps
+
+      - run: pip install xa11y pytest
+      - run: pytest tests/        # DISPLAY, DBUS, and AT-SPI are live here
+```
+
+### Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `package-groups` | `base` | Space-separated apt groups: `base`, `gtk`, `electron`. |
+| `extra-packages` | `""` | Extra apt packages your app needs. |
+| `install-deps` | `true` | Set `false` to skip apt entirely. |
+| `setup-display` | `true` | Start Xvfb and export `DISPLAY` (Linux). |
+| `setup-atspi` | `true` | Start D-Bus + AT-SPI and export their env (Linux). |
+| `setup-window-manager` | `false` | Start fluxbox — needed by toolkits (e.g. egui) that only publish their tree once a window is mapped/focused. |
+| `display` | `:99` | X display number for Xvfb. |
+| `macos-tcc-client` | `""` | Path to the binary to grant Accessibility (TCC) on macOS — e.g. your python interpreter. When empty, the action warns instead. |
+
+The Linux package set is defined once, in
+[`apt-packages.txt`](https://github.com/xa11y/xa11y/blob/main/.github/actions/setup-a11y/apt-packages.txt),
+grouped by purpose. Pick the groups your test app's toolkit needs:
+
+- **base** — headless display + AT-SPI stack. Always include this.
+- **gtk** — GTK3/4 + WebKitGTK (GTK apps, Tauri).
+- **electron** — Chromium/Electron runtime libraries.
+
+## macOS
+
+macOS won't let one process read another's accessibility tree unless it holds
+the **Accessibility** TCC permission. On a hosted runner you grant it to the
+process that runs your tests (often the python interpreter):
+
+```yaml
+- uses: actions/setup-python@v6
+  with:
+    python-version: "3.12"
+- name: Resolve python path
+  id: py
+  run: echo "path=$(python -c 'import sys; print(sys.executable)')" >> "$GITHUB_OUTPUT"
+
+- uses: xa11y/xa11y/.github/actions/setup-a11y@main
+  with:
+    macos-tcc-client: ${{ steps.py.outputs.path }}
+```
+
+If you skip this, queries return an empty tree and the action prints a
+warning. Granting TCC writes to the system TCC database (allowed on hosted
+runners because SIP only protects `/System`) and restarts `tccd` so the grant
+takes effect immediately.
+
+## Windows
+
+Nothing to set up — UI Automation is available on hosted `windows-latest`
+runners, which have an interactive desktop session. Just run your tests.
+
+## Doing it without the action
+
+If you can't use the composite action, here's the underlying setup for Linux.
+This is exactly what the action automates:
+
+```bash
+# 1. Headless display
+export DISPLAY=:99
+Xvfb :99 -screen 0 1280x1024x24 -ac &
+sleep 1
+
+# 2. Run everything inside a D-Bus session
+dbus-run-session -- bash -c '
+  # 3. Start + enable the AT-SPI bridge
+  /usr/libexec/at-spi-bus-launcher --launch-immediately &
+  sleep 1
+  /usr/libexec/at-spi2-registryd &
+  sleep 1
+  dbus-send --session --dest=org.a11y.Bus /org/a11y/bus \
+    org.freedesktop.DBus.Properties.Set \
+    string:org.a11y.Status string:IsEnabled variant:boolean:true
+
+  # 4. Run your tests
+  pytest tests/
+'
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Empty tree on **Linux** | AT-SPI bridge not running or `org.a11y.Status.IsEnabled` is false. Confirm `setup-atspi` ran. |
+| Empty tree on **macOS** | The test process wasn't granted Accessibility (TCC). Set `macos-tcc-client`. |
+| App not found by name on Linux | The app was launched via `cargo run`, which changes the AT-SPI process name. Run the built binary directly. |
+| Window never appears in the tree | The toolkit needs a window manager. Set `setup-window-manager: true`. |
+| `Xvfb` fails to start | The display number is taken. Set a different `display` (e.g. `:98`). |
+| Tests hang or flake on macOS | An onboarding window (Setup Assistant) holds front-app focus. Dismiss it before running input-driven tests. |


### PR DESCRIPTION
Make it easier to run xa11y accessibility tests in GitHub Actions:

- New composite action `.github/actions/setup-a11y` brings up the headless
  display + D-Bus + AT-SPI bridge on Linux, grants the Accessibility (TCC)
  permission on macOS (or warns when it can't), and is a no-op on Windows.
  Consumers can reference it directly to test their own apps.
- Single source of truth for the Linux apt package list in
  `apt-packages.txt`, grouped (base/gtk/electron). The linux, integ, and
  examples jobs now install through the action instead of three copy-pasted
  inline lists; their proven Xvfb + dbus-run-session runtime is unchanged
  (install-only mode).
- New "Testing in CI" docs guide covering why each platform is tricky, the
  action's inputs, macOS TCC, a no-action fallback, and troubleshooting.