### PR TITLE
fix(ci): build Cocoa test app in integ job instead of relying on cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,22 @@ jobs:
           path: test-apps/cocoa/xa11y-cocoa-test-app
           key: ${{ runner.os }}-cocoa-app-${{ hashFiles('test-apps/cocoa/main.swift', 'test-apps/cocoa/Makefile') }}
 
+      # ── Build Cocoa test app (Swift, macOS-only) ───────────────────
+      # The Cocoa app is NOT part of the Cargo workspace, so the "Build Rust
+      # workspace" step above doesn't produce it, and launch.py — unlike
+      # run_app_suite.sh — never builds it. Without this step the binary only
+      # ever exists when restored from the cache above, so the first time that
+      # entry is evicted the harness has nothing to launch and the job dies.
+      # Build only on a cache miss (mirrors the `[ ! -f ... ]` guard in
+      # scripts/run_app_suite.sh) so a cache hit short-circuits the swiftc run,
+      # and so the post-job cache save always has a binary to store.
+      - name: Build Cocoa test app
+        if: matrix.app == 'cocoa'
+        run: |
+          if [ ! -f test-apps/cocoa/xa11y-cocoa-test-app ]; then
+            make -C test-apps/cocoa build
+          fi
+
       # ── Run harness ───────────────────────────────────────────────
       # On Linux, DISPLAY / D-Bus / AT-SPI (+ the egui window manager) were
       # already brought up by the setup-a11y step above, and XA11Y_A11Y_READY


### PR DESCRIPTION
The cocoa integ matrix cell had a cache-restore step for the Swift test
app binary but no step that actually builds it. Unlike run_app_suite.sh,
the launch.py harness that CI invokes never builds the app, and the app
is not part of the Cargo workspace, so 'Build Rust workspace' never
produces it either. The binary therefore existed only when restored from
the cache, with nothing to regenerate it once that entry was evicted —
at which point the harness has nothing to launch and the job fails fast.

Add a 'Build Cocoa test app' step (macOS-only) that builds when the
binary is missing, mirroring the cache-then-build pattern already used
for the Tauri and egui test apps and the '[ ! -f ... ]' guard in
run_app_suite.sh. A cache hit still short-circuits the swiftc run, and
the post-job cache save now always has a binary to store.