### PR TITLE
ci: claim macOS frontmost at launch instead of hardcoded killall list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,17 +361,13 @@ jobs:
         with:
           macos-tcc-client: ${{ env.TCC_CLIENT }}
 
-      # Front-app focus management is input_sim-specific, NOT generic a11y
-      # setup, so it stays out of setup-a11y: CGEventPost delivers to whichever
-      # app is frontmost, and the runner image occasionally boots with Setup
-      # Assistant holding focus, making every input_sim assertion read an empty
-      # event log. Dismiss the known offenders so the test app can take front.
-      - name: Dismiss front-most onboarding windows (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          for app in "Setup Assistant" "Notification Center" "Software Update"; do
-            sudo killall "$app" 2>/dev/null || true
-          done
+      # Front-most focus on macOS is claimed at app-launch time, not here: the
+      # harness actively activates the test app and polls until it is verified
+      # frontmost (tests.helpers.ensure_macos_frontmost), replacing the old
+      # hardcoded `killall` list of focus-stealing onboarding processes. That
+      # name-based approach rotted whenever GitHub rolled a new runner image
+      # with a different offender (issue #230); the active-claim approach is
+      # runner-image-agnostic and names whatever grabbed focus on failure.
 
       # ── Cache Cocoa test app binary ────────────────────────────────
       - name: Cache Cocoa test app binary

--- a/tests/harness/launch.py
+++ b/tests/harness/launch.py
@@ -34,6 +34,16 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 STARTUP_TIMEOUT = 30  # seconds
 
+# Apps with a real, activatable macOS window whose tests depend on holding the
+# frontmost slot — input_sim delivers CGEvents to the frontmost app, and focus
+# assertions read OS focus state. We actively claim the front before tests run
+# (see tests.helpers.ensure_macos_frontmost) instead of reactively killing a
+# hardcoded list of focus-stealing onboarding processes (issue #230). Excluded:
+# cocoa (--headless, accessory app — can't be frontmost) and accesskit
+# (synthesises its own focus events; its macOS coverage is the Rust integ
+# suite, and the Python harness skips all its suites on macOS anyway).
+_MACOS_FRONTMOST_APPS = {"tauri", "qt", "electron", "egui"}
+
 
 # ---------------------------------------------------------------------------
 # App definitions
@@ -259,6 +269,21 @@ def _launch_app(
                 time.sleep(0.5)
         if not content_ready:
             print(f"WARNING: content selector {content_ready_selector!r} not ready after timeout; proceeding anyway")
+
+    # macOS: claim the frontmost slot before handing the app to the suites, so
+    # input_sim/focus tests aren't silently misdirected to whatever onboarding
+    # process the runner image booted with (issue #230).
+    if sys.platform == "darwin" and app in _MACOS_FRONTMOST_APPS:
+        if str(PROJECT_ROOT) not in sys.path:
+            sys.path.insert(0, str(PROJECT_ROOT))
+        from tests.helpers import ensure_macos_frontmost
+
+        print(f"Ensuring test app (pid={proc.pid}) is frontmost (macOS)...")
+        ok, detail = ensure_macos_frontmost(proc.pid)
+        if not ok:
+            _kill_app(proc)
+            raise RuntimeError(detail)
+        print("Test app is frontmost.")
 
     return proc, discovered_name
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,6 +20,83 @@ import pytest
 import xa11y
 
 STARTUP_TIMEOUT = 30  # seconds
+FRONTMOST_TIMEOUT = 10  # seconds
+
+
+def _osascript(script: str, timeout: float = 5.0) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _macos_frontmost() -> tuple[int | None, str]:
+    """Return (unix pid, name) of the current macOS frontmost app process."""
+    try:
+        result = _osascript(
+            'tell application "System Events" to tell '
+            "(first application process whose frontmost is true) "
+            'to return (unix id as text) & "\t" & name'
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        return None, f"<osascript error: {exc!r}>"
+    if result.returncode != 0:
+        return None, f"<rc={result.returncode}: {result.stderr.strip()}>"
+    pid_str, _, name = result.stdout.strip().partition("\t")
+    try:
+        return int(pid_str), name or "<unknown>"
+    except ValueError:
+        return None, result.stdout.strip() or "<empty>"
+
+
+def ensure_macos_frontmost(
+    pid: int, *, timeout: float = FRONTMOST_TIMEOUT
+) -> tuple[bool, str]:
+    """Make process ``pid`` the frontmost macOS app and verify it stuck.
+
+    On macOS ``CGEventPost`` (input_sim) and OS-level focus both target
+    whichever app is frontmost. Runner images occasionally boot with an
+    onboarding or background process holding the front slot (Setup Assistant,
+    Notification Center, Software Update, …), which silently misdirects every
+    synthetic event so the test reads an empty event log.
+
+    Rather than maintain a hardcoded kill-list of offenders — which rots every
+    time GitHub rolls a new runner image — actively claim the front via System
+    Events and poll until our PID is verified frontmost. This is
+    runner-image-agnostic: it doesn't matter *what* grabbed focus, we take it
+    back, and on failure we name the offender so CI points straight at it.
+
+    No-op on non-macOS. Returns ``(ok, detail)``.
+    """
+    if sys.platform != "darwin":
+        return True, "not macOS"
+
+    activate = (
+        'tell application "System Events" to set frontmost of '
+        f"(first process whose unix id is {pid}) to true"
+    )
+    deadline = time.monotonic() + timeout
+    front_pid: int | None = None
+    front_name = "<unknown>"
+    while time.monotonic() < deadline:
+        try:
+            _osascript(activate)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            pass  # transient — retry until the deadline
+        front_pid, front_name = _macos_frontmost()
+        if front_pid == pid:
+            return True, f"frontmost (pid={pid})"
+        time.sleep(0.3)
+
+    return False, (
+        f"test app (pid={pid}) is not frontmost after {timeout:.0f}s; frontmost "
+        f"is {front_name!r} (pid={front_pid}). On macOS CGEventPost delivers "
+        f"synthetic events to the frontmost app, so input_sim and OS-focus tests "
+        f"cannot run reliably. A runner-image process grabbed the front slot — "
+        f"see https://github.com/xa11y/xa11y/issues/230."
+    )
 
 
 def launch_test_app(
@@ -28,6 +105,7 @@ def launch_test_app(
     env_overrides: dict[str, str] | None = None,
     startup_timeout: int = STARTUP_TIMEOUT,
     content_ready_selector: str | None = None,
+    require_frontmost: bool = False,
 ) -> Generator[xa11y.App, None, None]:
     """Launch a test app and yield its xa11y App handle.
 
@@ -39,6 +117,11 @@ def launch_test_app(
         content_ready_selector: If set, keep polling until this selector matches
             within the app's tree (useful for WebView apps where UI content
             loads asynchronously after the app window appears).
+        require_frontmost: On macOS, actively bring the app to the front and
+            verify it before yielding (see ensure_macos_frontmost). Set this for
+            apps with a real, activatable window whose tests depend on holding
+            the frontmost slot (input_sim via CGEventPost, OS-focus assertions).
+            No-op off macOS.
 
     Yields:
         The xa11y App for the running application.
@@ -127,6 +210,13 @@ def launch_test_app(
                 f"Content not ready: selector {content_ready_selector!r} "
                 f"not found after {startup_timeout}s."
             )
+
+    if require_frontmost and sys.platform == "darwin":
+        ok, detail = ensure_macos_frontmost(app.pid)
+        if not ok:
+            proc.terminate()
+            proc.wait(timeout=5)
+            pytest.fail(detail)
 
     yield app
 

--- a/tests/suites/cli/conftest.py
+++ b/tests/suites/cli/conftest.py
@@ -51,6 +51,7 @@ def _launch_qt():
         command=[sys.executable, script],
         app_names=["xa11y-qt-test-app", "xa11y", "python3", "python", "Python", "app.py"],
         env_overrides={"QT_ACCESSIBILITY": "1"},
+        require_frontmost=True,
     )
 
 
@@ -104,6 +105,7 @@ def _launch_tauri():
         command=[_TAURI_BINARY],
         app_names=["xa11y-tauri-test-app"],
         content_ready_selector='button[name="OK"]',
+        require_frontmost=True,
     )
 
 
@@ -139,6 +141,7 @@ def _launch_electron():
         command=[node_modules_electron, main_js, "--force-renderer-accessibility"],
         app_names=["xa11y-electron-test-app", "Electron", "xa11y"],
         content_ready_selector='button[name="OK"]',
+        require_frontmost=True,
     )
 
 
@@ -181,6 +184,7 @@ def _launch_egui():
         command=[_EGUI_BINARY],
         app_names=["xa11y-egui-test-app"],
         content_ready_selector='button[name="OK"]',
+        require_frontmost=True,
     )
 
 

--- a/tests/suites/python/conftest.py
+++ b/tests/suites/python/conftest.py
@@ -300,6 +300,7 @@ def _launch_qt() -> xa11y.App:
         command=[sys.executable, script, "--pid-file", pid_file],
         app_names=["xa11y-qt-test-app", "xa11y", "python3", "python", "Python", "app.py"],
         env_overrides={"QT_ACCESSIBILITY": "1"},
+        require_frontmost=True,
     )
 
 
@@ -358,6 +359,7 @@ def _launch_tauri() -> xa11y.App:
         command=[binary],
         app_names=["xa11y-tauri-test-app"],
         content_ready_selector='button[name="OK"]',
+        require_frontmost=True,
     )
 
 
@@ -384,6 +386,7 @@ def _launch_electron() -> xa11y.App:
         command=[str(node_modules_electron), main_js, "--force-renderer-accessibility"],
         app_names=["xa11y-electron-test-app", "Electron", "xa11y"],
         content_ready_selector='button[name="OK"]',
+        require_frontmost=True,
     )
 
 
@@ -432,6 +435,7 @@ def _launch_egui() -> xa11y.App:
         command=[binary],
         app_names=["xa11y-egui-test-app"],
         content_ready_selector='button[name="OK"]',
+        require_frontmost=True,
     )
 
 


### PR DESCRIPTION
macOS CGEventPost (input_sim) and OS-level focus target whichever app is
frontmost. Runner images occasionally boot with an onboarding/background
process (Setup Assistant, Notification Center, Software Update, …) holding
the front slot, silently misdirecting every synthetic event so input_sim
tests read an empty event log.

The previous fix was a hardcoded `killall` list of three offender names in
ci.yml. That name-based approach rotted every time GitHub rolled a new
runner image with a different offender (issue #230) and only ever surfaced
after a full test run had already burned.

Replace it with an active-claim approach that solves the whole class:
ensure_macos_frontmost() activates the test app via System Events and polls
until our PID is verified frontmost before handing the app to the suites.
This is runner-image-agnostic — it doesn't matter what grabbed focus, we
take it back — and on failure it names the offending app so CI points
straight at it.

- Add ensure_macos_frontmost() + helpers to tests/helpers.py.
- launch_test_app() grows a require_frontmost flag; wired on the
  real-window launchers (tauri, qt, electron, egui) in both conftests.
- The harness (the single launch point in CI) claims frontmost for the
  same app set, excluding cocoa (--headless accessory, can't be frontmost)
  and accesskit (synthesises its own focus; skipped on macOS anyway).
- Drop the hardcoded killall step from ci.yml.

https://claude.ai/code/session_01X8Xe93aZPQQeQu1Tjn4sFK