### PR TITLE
ci: shared sccache + rust-cache, concurrency, prune dead jobs

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,13 +1,25 @@
 name: "Set up Rust toolchain + cargo cache"
 description: >-
-  Install a Rust toolchain (via dtolnay/rust-toolchain) and restore the cargo
-  registry/git/build cache (via actions/cache). Wraps the boilerplate that was
-  copy-pasted into every Rust job in ci.yml so the toolchain version, cache
-  paths, and cache-key scheme live in one place.
+  Install a Rust toolchain (via dtolnay/rust-toolchain), wire up a shared
+  sccache compilation cache (GitHub Actions backend, shared across every job
+  and run), and restore the cargo registry/build cache (via Swatinem/rust-cache).
+  Wraps the boilerplate that was copy-pasted into every Rust job in ci.yml so
+  the toolchain version and cache scheme live in one place.
 
 # Internal helper — not intended for external consumers (those use
-# setup-a11y). The cache `path` and `key` scheme mirror what the ci.yml jobs
-# used before this action existed, so the cache stays warm across the switch.
+# setup-a11y).
+#
+# Two complementary caches are layered here:
+#   * sccache (RUSTC_WRAPPER) caches individual rustc invocations in the GHA
+#     cache backend, *shared across every job and run*. This is what stops the
+#     14 integ cells + unit jobs + bindings from each recompiling xa11y core
+#     and its dependency tree from scratch.
+#   * Swatinem/rust-cache caches ~/.cargo (registry/git) and the target dir,
+#     scoped per job via the cache-key discriminator, so crate downloads and
+#     final link artifacts survive between runs.
+# CARGO_INCREMENTAL=0 is required for sccache to cache effectively (incremental
+# compilation units aren't cacheable); the shared rustc cache more than makes
+# up for the loss.
 
 inputs:
   toolchain:
@@ -24,21 +36,18 @@ inputs:
     default: ""
   cache-key:
     description: >-
-      Job-specific discriminator folded into the cache key (e.g. 'lint',
-      'integ', 'cross'). Keeps each job's cache separate, matching the
-      pre-existing per-job keys. Leave empty for the default workspace cache.
+      Job-specific discriminator folded into the rust-cache key (e.g. 'lint',
+      'integ', 'cross'). Keeps each job's target cache separate. Leave empty
+      for the default workspace cache.
     required: false
     default: ""
-  cache-paths:
+  workspaces:
     description: >-
-      Newline-separated paths to cache. Defaults to the cargo registry/git
-      plus the workspace `target` dir. Override for crates that build into a
-      different target dir (e.g. xa11y-js/target).
+      Newline-separated `path -> target-dir` entries passed to
+      Swatinem/rust-cache. Defaults to the workspace root. Override for crates
+      that build into a different location (e.g. 'xa11y/fuzz -> target').
     required: false
-    default: |
-      ~/.cargo/registry
-      ~/.cargo/git
-      target
+    default: ". -> target"
   cache:
     description: "Set to 'false' to install the toolchain without restoring a cache."
     required: false
@@ -54,13 +63,24 @@ runs:
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
 
-    - name: Cache cargo registry & build
+    - name: Set up sccache
+      uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Enable sccache (shared rustc cache) + disable incremental
+      shell: bash
+      run: |
+        {
+          echo "SCCACHE_GHA_ENABLED=true"
+          echo "RUSTC_WRAPPER=sccache"
+          echo "CARGO_INCREMENTAL=0"
+        } >> "$GITHUB_ENV"
+
+    - name: Cache cargo registry & build (Swatinem/rust-cache)
       if: ${{ inputs.cache == 'true' }}
-      uses: actions/cache@v5
+      uses: Swatinem/rust-cache@v2
       with:
-        path: ${{ inputs.cache-paths }}
-        # ${{ runner.os }}-cargo[-<key>]-<lockhash> — identical to the inline
-        # blocks this replaced, so existing caches are still hit.
-        key: ${{ runner.os }}-cargo${{ inputs.cache-key != '' && format('-{0}', inputs.cache-key) || '' }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo${{ inputs.cache-key != '' && format('-{0}', inputs.cache-key) || '' }}-
+        # Folded into rust-cache's auto key (job id + os + rustc + lockfiles),
+        # mirroring the old per-job ${{ runner.os }}-cargo-<key> scheme.
+        key: ${{ inputs.cache-key }}
+        workspaces: ${{ inputs.workspaces }}
+        cache-on-failure: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,57 +188,6 @@ jobs:
         shell: pwsh
         run: .\scripts\run_integ_tests_windows.ps1
 
-  # ── Build the Rust workspace once per OS ───────────────────────────
-  #
-  # The 14 integ cells all need the same two workspace binaries — the xa11y
-  # CLI (every cell's `cli` suite) and the AccessKit test app. Building the
-  # workspace independently in each cell recompiled core + the dependency tree
-  # up to 14× per run. Instead we build it once per OS here and hand the
-  # binaries to the integ cells as an artifact, so the workspace is compiled
-  # three times per run (once per platform), not fourteen. sccache (wired into
-  # setup-rust) additionally dedups the remaining per-cell compiles — the
-  # Python extension and the JS native binding — across cells and runs.
-  build-workspace:
-    name: Build workspace (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          cache-key: integ
-
-      # Linux needs the build/link libraries (libxkbcommon et al.) the
-      # workspace's AccessKit/winit test app pulls in. No display or AT-SPI is
-      # needed — this job only compiles, it doesn't run anything.
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        uses: ./.github/actions/setup-a11y
-        with:
-          package-groups: base
-          setup-display: "false"
-          setup-atspi: "false"
-
-      - name: Build Rust workspace
-        run: cargo build --workspace
-
-      # Ship only the two binaries the integ cells consume. upload-artifact
-      # drops the executable bit (it's restored on download below).
-      - name: Upload workspace binaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: workspace-bins-${{ matrix.os }}
-          path: |
-            target/debug/xa11y${{ runner.os == 'Windows' && '.exe' || '' }}
-            target/debug/xa11y-test-app${{ runner.os == 'Windows' && '.exe' || '' }}
-          if-no-files-found: error
-          retention-days: 1
-
   # ── Compatibility integ matrix: one app × one OS × all language suites ──
   #
   # Each matrix cell starts the test app once, then runs the Python, JS, and
@@ -247,12 +196,12 @@ jobs:
   # and CI share one code path. This replaced the old per-language per-app
   # per-OS jobs and their run_<app>_tests.sh scripts.
   #
-  # Cells consume the workspace binaries built once per OS by build-workspace
-  # rather than running `cargo build --workspace` themselves.
+  # Each cell builds the workspace itself; the shared sccache in setup-rust
+  # keeps that cheap (warm rustc cache reused across cells and runs) without
+  # serializing the matrix behind a build-once job.
   integ:
     name: Integ (${{ matrix.app }}) on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: build-workspace
     strategy:
       fail-fast: false
       matrix:
@@ -308,19 +257,9 @@ jobs:
           package-groups: base gtk electron
           setup-window-manager: ${{ matrix.app == 'egui' }}
 
-      # ── Workspace binaries (xa11y CLI + AccessKit test app) ────────
-      # Built once per OS by the build-workspace job; downloaded here instead
-      # of recompiling the workspace in every cell. upload-artifact strips the
-      # executable bit, so restore it on Unix.
-      - name: Download workspace binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: workspace-bins-${{ matrix.os }}
-          path: target/debug
-
-      - name: Restore executable bit (Unix)
-        if: runner.os != 'Windows'
-        run: chmod +x target/debug/xa11y target/debug/xa11y-test-app
+      # ── Build Rust workspace (all workspace test-app binaries) ─────
+      - name: Build Rust workspace
+        run: cargo build --workspace
 
       # ── Tauri app (not in workspace — has its own Cargo.lock) ──────
       - name: Cache Tauri test app build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main, master]
 
+# Cancel superseded runs on a branch/PR so rapid pushes don't pile up full
+# matrix runs. We never cancel pushes to main/master (release-relevant), only
+# in-progress PR runs that a newer commit has obsoleted.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
@@ -181,6 +188,57 @@ jobs:
         shell: pwsh
         run: .\scripts\run_integ_tests_windows.ps1
 
+  # ── Build the Rust workspace once per OS ───────────────────────────
+  #
+  # The 14 integ cells all need the same two workspace binaries — the xa11y
+  # CLI (every cell's `cli` suite) and the AccessKit test app. Building the
+  # workspace independently in each cell recompiled core + the dependency tree
+  # up to 14× per run. Instead we build it once per OS here and hand the
+  # binaries to the integ cells as an artifact, so the workspace is compiled
+  # three times per run (once per platform), not fourteen. sccache (wired into
+  # setup-rust) additionally dedups the remaining per-cell compiles — the
+  # Python extension and the JS native binding — across cells and runs.
+  build-workspace:
+    name: Build workspace (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key: integ
+
+      # Linux needs the build/link libraries (libxkbcommon et al.) the
+      # workspace's AccessKit/winit test app pulls in. No display or AT-SPI is
+      # needed — this job only compiles, it doesn't run anything.
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/setup-a11y
+        with:
+          package-groups: base
+          setup-display: "false"
+          setup-atspi: "false"
+
+      - name: Build Rust workspace
+        run: cargo build --workspace
+
+      # Ship only the two binaries the integ cells consume. upload-artifact
+      # drops the executable bit (it's restored on download below).
+      - name: Upload workspace binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace-bins-${{ matrix.os }}
+          path: |
+            target/debug/xa11y${{ runner.os == 'Windows' && '.exe' || '' }}
+            target/debug/xa11y-test-app${{ runner.os == 'Windows' && '.exe' || '' }}
+          if-no-files-found: error
+          retention-days: 1
+
   # ── Compatibility integ matrix: one app × one OS × all language suites ──
   #
   # Each matrix cell starts the test app once, then runs the Python, JS, and
@@ -188,16 +246,23 @@ jobs:
   # `cargo xtask test-<app>` uses locally (scripts/run_app_suite.sh), so local
   # and CI share one code path. This replaced the old per-language per-app
   # per-OS jobs and their run_<app>_tests.sh scripts.
+  #
+  # Cells consume the workspace binaries built once per OS by build-workspace
+  # rather than running `cargo build --workspace` themselves.
   integ:
     name: Integ (${{ matrix.app }}) on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: build-workspace
     strategy:
       fail-fast: false
       matrix:
         include:
           - { os: ubuntu-latest,  app: accesskit }
-          - { os: macos-latest,   app: accesskit }
-          - { os: windows-latest, app: accesskit }
+          # AccessKit on macOS/Windows is covered by the Windows Rust integ
+          # job and the local macOS harness; those integ cells ran no language
+          # suites (cli+js are skipped for accesskit, and python is skipped off
+          # Linux — see suite_skips_by_app in tests/harness/launch.py), so they
+          # only burned a build with nothing to test. Dropped.
           - { os: ubuntu-latest,  app: qt }
           - { os: ubuntu-latest,  app: gtk }
           - { os: ubuntu-latest,  app: tauri }
@@ -243,9 +308,19 @@ jobs:
           package-groups: base gtk electron
           setup-window-manager: ${{ matrix.app == 'egui' }}
 
-      # ── Build Rust workspace (all workspace test-app binaries) ─────
-      - name: Build Rust workspace
-        run: cargo build --workspace
+      # ── Workspace binaries (xa11y CLI + AccessKit test app) ────────
+      # Built once per OS by the build-workspace job; downloaded here instead
+      # of recompiling the workspace in every cell. upload-artifact strips the
+      # executable bit, so restore it on Unix.
+      - name: Download workspace binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace-bins-${{ matrix.os }}
+          path: target/debug
+
+      - name: Restore executable bit (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x target/debug/xa11y target/debug/xa11y-test-app
 
       # ── Tauri app (not in workspace — has its own Cargo.lock) ──────
       - name: Cache Tauri test app build
@@ -626,19 +701,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry & build
-        uses: actions/cache@v5
+      # Shares the sccache compilation cache with the js/integ jobs that build
+      # the same xa11y-js native binding; rust-cache stores xa11y-js/target.
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            xa11y-js/target
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('xa11y-js/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-docs-
+          cache-key: docs
+          workspaces: xa11y-js -> target
 
       # napi build links xa11y-js → xa11y → xa11y-linux on the Linux
       # docs runner; xa11y-linux now needs libxkbcommon at link time.
@@ -697,19 +766,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry & build
-        uses: actions/cache@v5
+      # Shares the sccache compilation cache with the docs/integ jobs that
+      # build the same native binding; rust-cache stores xa11y-js/target.
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            xa11y-js/target
-          key: ${{ runner.os }}-cargo-js-${{ hashFiles('xa11y-js/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-js-
+          cache-key: js
+          workspaces: xa11y-js -> target
 
       # xa11y-js → xa11y → xa11y-linux requires libxkbcommon to link on
       # Linux. macOS / Windows skip this — those runners don't pull
@@ -772,10 +835,18 @@ jobs:
         with:
           toolchain: nightly
           cache-key: fuzz
-          cache-paths: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            xa11y/fuzz/target
+          # cargo-fuzz builds into xa11y/fuzz/target; rust-cache covers
+          # ~/.cargo (registry/git) automatically.
+          workspaces: xa11y/fuzz -> target
+
+      # Cache the cargo-fuzz binary so we don't recompile it from source every
+      # run (mirrors the cargo-deny cache in license-check).
+      - name: Cache cargo-fuzz binary
+        id: cache-cargo-fuzz
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: cargo-fuzz-${{ runner.os }}-${{ runner.arch }}
 
       # The fuzz binaries link xa11y → xa11y-linux, which needs libxkbcommon
       # at link time ([link] group). Without it the targets fail to link
@@ -788,6 +859,7 @@ jobs:
           setup-atspi: "false"
 
       - name: Install cargo-fuzz
+        if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz
 
       - name: Run fuzz targets


### PR DESCRIPTION
## Why

From the most recent main run (`26691131564`: **8m10s wall, 70m CPU**), every long pole was an `integ` matrix cell, and the time inside each cell was **compilation, not test execution**. The workspace + bindings were recompiled over and over: workspace built ~18× per run, and inside each integ cell core compiled up to 3× (workspace build, Python extension via maturin, JS native via napi).

## What shipped

- **Shared `sccache` (GHA backend)** wired into the `setup-rust` action, so every Rust job — the integ cells, unit jobs, and the Python/JS binding builds — reuses compiled `rustc` outputs across jobs *and* runs instead of rebuilding core + deps from scratch. `CARGO_INCREMENTAL=0` so sccache can cache. This is the main lever and keeps the matrix fully parallel.
- **`Swatinem/rust-cache`** replaces the hand-rolled `actions/cache` in `setup-rust` (smarter keys, target pruning). The `docs` and `js` jobs route through `setup-rust` too, so they share the same sccache + cache layer.
- **`concurrency: cancel-in-progress`** for PR runs only (never main/master).
- **Dropped the accesskit macOS/Windows integ cells** — they ran *zero* language suites (`cli`+`js` skipped for accesskit, `python` skipped off Linux per `suite_skips_by_app` in `tests/harness/launch.py`), so they only burned a build. AccessKit there is covered by the Windows Rust-integ job and the local macOS harness.
- **Cache the `cargo-fuzz` binary** so the fuzz job stops recompiling it each run (mirrors the existing `cargo-deny` cache).

## What we tried and dropped

A **build-once `build-workspace` job** (compile the workspace per OS, hand binaries to integ cells via artifact) was implemented and measured, then **reverted**: with sccache warm, integ cells rebuild the workspace mostly from cache anyway, so the `needs:` gate serialized the critical path (build-workspace windows ~2m13s → qt-windows) for more than it saved. Clean negative result.

## Measured impact (warm runs)

| | Wall clock | CPU min |
|---|---|---|
| Baseline (pre-PR) | 8m10s | 70m13s |
| sccache + build-once | 7m18s | 62m27s |
| **sccache, no build-once (this PR)** | **6m04s** | **60m27s** |

**Net vs baseline: −2m06s wall (−26%), −9m46s CPU (−14%), 2 fewer jobs.** Build-dominated cells all fell (e.g. qt-windows 7m12s→5m27s, qt-ubuntu 5m11s→4m45s, fuzz 1m32s→53s). sccache adds minor overhead to a few trivially-small jobs (cross-compile, JS-win), but none are on the critical path.

https://claude.ai/code/session_01Qr39jqWDNBt8xGGYMUsvwA