### PR TITLE
feat(app): add predicate-based App discovery (find) across bindings

### DIFF
--- a/tests/harness/launch.py
+++ b/tests/harness/launch.py
@@ -188,77 +188,56 @@ def _launch_app(
 
     import xa11y  # imported late so the module is optional for callers that don't need it
 
-    discovered_name: str | None = None
     deadline = time.monotonic() + STARTUP_TIMEOUT
-    last_err = None
 
-    while time.monotonic() < deadline:
+    # Discovery is a single waited call: `App.find` polls the accessibility
+    # API internally, so the harness no longer hand-rolls a retry loop. Match
+    # on the PID we just launched *or* any of the platform's candidate names
+    # (the process name on Linux/macOS, the window title on Windows) — matching
+    # either absorbs the per-platform registration races in one place.
+    def _is_test_app(candidate: "xa11y.App") -> bool:
+        return candidate.pid == proc.pid or candidate.name in app_names
+
+    try:
+        app = xa11y.App.find(_is_test_app, timeout=STARTUP_TIMEOUT)
+    except (xa11y.SelectorNotMatchedError, xa11y.PlatformError) as exc:
+        # Distinguish "app crashed on launch" from "app never registered".
         if proc.poll() is not None:
             out = proc.stdout.read().decode() if proc.stdout else ""
             err = proc.stderr.read().decode() if proc.stderr else ""
             raise RuntimeError(
                 f"Test app (pid={proc.pid}) exited early (code {proc.returncode}).\n"
                 f"stdout: {out}\nstderr: {err}"
-            )
-
-        # Try exact match first (fast path on Linux/macOS).
-        for name in app_names:
-            try:
-                xa11y.App.by_name(name)
-                discovered_name = name
-                break
-            except (xa11y.SelectorNotMatchedError, xa11y.PlatformError):
-                pass
-
-        # Fall back to PID-based lookup to avoid false matches against the
-        # harness's own Python process when substring matching.
-        if discovered_name is None:
-            try:
-                xa11y.App.by_pid(proc.pid)
-                discovered_name = app_names[0]
-            except (xa11y.SelectorNotMatchedError, xa11y.PlatformError) as exc:
-                last_err = exc
-
-        if discovered_name is not None:
-            break
-
-        time.sleep(0.5)
-
-    if discovered_name is None:
+            ) from exc
         try:
-            all_apps = xa11y.App.list()
-            app_list = [(a.name, a.pid) for a in all_apps]
+            app_list = [(a.name, a.pid) for a in xa11y.App.list()]
         except Exception:
             app_list = "<failed to list>"
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        _kill_app(proc)
         out = proc.stdout.read().decode() if proc.stdout else ""
         err = proc.stderr.read().decode() if proc.stderr else ""
         raise RuntimeError(
             f"Test app (pid={proc.pid}) not found after {STARTUP_TIMEOUT}s.\n"
-            f"Last error: {last_err}\n"
+            f"Last error: {exc}\n"
             f"Available apps: {app_list}\n"
             f"stdout: {out}\nstderr: {err}"
-        )
+        ) from exc
 
+    discovered_name = app.name or app_names[0]
     print(f"Test app visible: {discovered_name!r} (pid={proc.pid})")
 
-    # Wait for content to be ready if a selector was specified.
+    # Wait for content to be ready if a selector was specified — again one
+    # library call (`wait_attached`) rather than a manual poll loop.
     if content_ready_selector is not None:
         print(f"Waiting for content: {content_ready_selector!r}")
-        content_ready = False
-        while time.monotonic() < deadline:
-            try:
-                xa11y.App.by_pid(proc.pid).locator(content_ready_selector).element()
-                content_ready = True
-                break
-            except (xa11y.SelectorNotMatchedError, xa11y.PlatformError):
-                time.sleep(0.5)
-        if not content_ready:
-            print(f"WARNING: content selector {content_ready_selector!r} not ready after timeout; proceeding anyway")
+        remaining = max(deadline - time.monotonic(), 1.0)
+        try:
+            app.locator(content_ready_selector).wait_attached(timeout=remaining)
+        except (xa11y.SelectorNotMatchedError, xa11y.TimeoutError, xa11y.PlatformError):
+            print(
+                f"WARNING: content selector {content_ready_selector!r} not ready "
+                f"after timeout; proceeding anyway"
+            )
 
     return proc, discovered_name
 

--- a/tests/suites/cli/conftest.py
+++ b/tests/suites/cli/conftest.py
@@ -19,19 +19,18 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 def _connect_to_running_app(xa11y, pid: int):
     """Connect to a test app the harness already launched.
 
-    Tries ``App.by_pid`` first (most precise) with a generous timeout to
-    absorb AT-SPI registration delays on Linux, then falls back to
-    ``App.by_name`` using the harness-discovered ``XA11Y_TEST_APP_NAME`` —
-    on some toolkits the app exposes a name to AT-SPI before its pid lookup
-    becomes resolvable.
+    Matches the PID we were handed *or* the harness-discovered
+    ``XA11Y_TEST_APP_NAME`` in a single waited lookup. ``App.find`` polls the
+    accessibility API internally with a generous timeout to absorb AT-SPI
+    registration delays on Linux; matching either signal covers the case
+    where a toolkit exposes a name before its pid lookup becomes resolvable
+    (or vice versa), without a pid-then-name fallback chain.
     """
-    try:
-        return xa11y.App.by_pid(pid, timeout=10.0)
-    except (xa11y.SelectorNotMatchedError, xa11y.PlatformError):
-        name = os.environ.get("XA11Y_TEST_APP_NAME")
-        if not name:
-            raise
-        return xa11y.App.by_name(name, timeout=10.0)
+    name = os.environ.get("XA11Y_TEST_APP_NAME")
+    return xa11y.App.find(
+        lambda a: a.pid == pid or (name is not None and a.name == name),
+        timeout=10.0,
+    )
 
 
 # ── Per-app launch configurations ────────────────────────────────────────────

--- a/tests/suites/python/conftest.py
+++ b/tests/suites/python/conftest.py
@@ -607,13 +607,16 @@ def app(app_name: str) -> xa11y.App:
     pid_env = os.environ.get("XA11Y_TEST_APP_PID")
     if pid_env:
         pid = int(pid_env)
-        try:
-            app_handle = xa11y.App.by_pid(pid, timeout=10.0)
-        except (xa11y.SelectorNotMatchedError, xa11y.PlatformError):
-            name = os.environ.get("XA11Y_TEST_APP_NAME")
-            if not name:
-                raise
-            app_handle = xa11y.App.by_name(name, timeout=10.0)
+        name = os.environ.get("XA11Y_TEST_APP_NAME")
+        # One waited lookup that matches the PID we were handed *or* the
+        # harness-discovered name — `App.find` polls internally, so there's
+        # no need for a pid-then-name fallback chain. On some toolkits the app
+        # exposes a name to AT-SPI before its pid lookup resolves (or vice
+        # versa); matching either signal absorbs both races.
+        app_handle = xa11y.App.find(
+            lambda a: a.pid == pid or (name is not None and a.name == name),
+            timeout=10.0,
+        )
         yield app_handle
         return
 

--- a/xa11y-core/src/app.rs
+++ b/xa11y-core/src/app.rs
@@ -49,6 +49,60 @@ pub struct App {
 }
 
 impl App {
+    /// Find an application matching `predicate`, using an explicit provider.
+    ///
+    /// Prefer `App::find` from the `xa11y` crate which uses the global
+    /// singleton provider. `predicate` runs against each running app's
+    /// [`ElementData`] on every poll; the first match in enumeration order
+    /// wins. Timeout / polling semantics match
+    /// [`by_name_with`](Self::by_name_with): `Duration::ZERO` performs a
+    /// single attempt, only [`Error::SelectorNotMatched`] triggers a retry,
+    /// and a failing `list_apps()` short-circuits.
+    pub fn find_with<F>(
+        provider: Arc<dyn Provider>,
+        timeout: Duration,
+        predicate: F,
+    ) -> Result<Self>
+    where
+        F: Fn(&ElementData) -> bool,
+    {
+        Self::find_matching(provider, timeout, predicate, || {
+            "application matching predicate".to_string()
+        })
+    }
+
+    /// Shared predicate-based discovery loop. `describe` supplies the
+    /// [`Error::SelectorNotMatched`] selector string so name/pid lookups keep
+    /// their specific, actionable error messages while sharing one match loop.
+    fn find_matching<F, D>(
+        provider: Arc<dyn Provider>,
+        timeout: Duration,
+        predicate: F,
+        describe: D,
+    ) -> Result<Self>
+    where
+        F: Fn(&ElementData) -> bool,
+        D: Fn() -> String,
+    {
+        poll_lookup(timeout, || {
+            // Discovery is platform-specific (CGWindowList on macOS, AT-SPI
+            // registry on Linux, UIA desktop root on Windows). `list_apps()`
+            // is the canonical enumeration primitive and we filter in Rust,
+            // so app names containing `"`, `]`, or other characters
+            // significant in the selector grammar don't need escaping.
+            //
+            // Errors from `list_apps()` propagate so callers can distinguish
+            // "app not found" from "accessibility is broken".
+            let apps = provider.list_apps()?;
+            apps.into_iter()
+                .find(|d| predicate(d))
+                .map(|data| Self::from_data(Arc::clone(&provider), data))
+                .ok_or_else(|| Error::SelectorNotMatched {
+                    selector: describe(),
+                })
+        })
+    }
+
     /// Find an application by exact name, using an explicit provider.
     ///
     /// Prefer `App::by_name` from the `xa11y` crate which uses the global
@@ -64,27 +118,12 @@ impl App {
         name: &str,
         timeout: Duration,
     ) -> Result<Self> {
-        poll_lookup(timeout, || {
-            // Discovery is platform-specific (CGWindowList on macOS, AT-SPI
-            // registry on Linux, UIA desktop root on Windows) and returns
-            // top-level apps as `role=Application` everywhere except Windows,
-            // which reports `role=Window`. The role detail no longer matters
-            // here — `list_apps()` is the canonical enumeration primitive
-            // and we filter by name in Rust, so app names containing `"`,
-            // `]`, or other characters significant in the selector grammar
-            // don't need escaping.
-            //
-            // Errors from `list_apps()` propagate so callers can distinguish
-            // "app not found" from "accessibility is broken".
-            let apps = provider.list_apps()?;
-            let data = apps
-                .into_iter()
-                .find(|d| d.name.as_deref() == Some(name))
-                .ok_or_else(|| Error::SelectorNotMatched {
-                    selector: format!(r#"application[name="{}"]"#, name),
-                })?;
-            Ok(Self::from_data(Arc::clone(&provider), data))
-        })
+        Self::find_matching(
+            provider,
+            timeout,
+            |d| d.name.as_deref() == Some(name),
+            || format!(r#"application[name="{}"]"#, name),
+        )
     }
 
     /// Find an application by process ID, using an explicit provider.
@@ -93,16 +132,12 @@ impl App {
     /// singleton provider. See [`by_name_with`](Self::by_name_with) for the
     /// timeout / polling semantics.
     pub fn by_pid_with(provider: Arc<dyn Provider>, pid: u32, timeout: Duration) -> Result<Self> {
-        poll_lookup(timeout, || {
-            let apps = provider.list_apps()?;
-            let data = apps
-                .into_iter()
-                .find(|d| d.pid == Some(pid))
-                .ok_or_else(|| Error::SelectorNotMatched {
-                    selector: format!("application with pid={}", pid),
-                })?;
-            Ok(Self::from_data(Arc::clone(&provider), data))
-        })
+        Self::find_matching(
+            provider,
+            timeout,
+            |d| d.pid == Some(pid),
+            || format!("application with pid={}", pid),
+        )
     }
 
     /// List all running applications, using an explicit provider.
@@ -269,5 +304,23 @@ mod tests {
         let el = app.as_element();
         assert_eq!(el.data().role, Role::Application);
         assert_eq!(el.data().name.as_deref(), Some("TestApp"));
+    }
+
+    #[test]
+    fn find_with_matches_by_predicate() {
+        let provider: Arc<dyn Provider> = build_provider();
+        let app = App::find_with(provider, Duration::ZERO, |d| {
+            d.name.as_deref() == Some("TestApp")
+        })
+        .expect("predicate must match TestApp in mock tree");
+        assert_eq!(app.name, "TestApp");
+    }
+
+    #[test]
+    fn find_with_no_match_returns_selector_not_matched() {
+        let provider: Arc<dyn Provider> = build_provider();
+        let err = App::find_with(provider, Duration::ZERO, |_| false)
+            .expect_err("a never-true predicate must not match any app");
+        assert!(matches!(err, Error::SelectorNotMatched { .. }));
     }
 }

--- a/xa11y-core/src/app.rs
+++ b/xa11y-core/src/app.rs
@@ -58,6 +58,9 @@ impl App {
     /// [`by_name_with`](Self::by_name_with): `Duration::ZERO` performs a
     /// single attempt, only [`Error::SelectorNotMatched`] triggers a retry,
     /// and a failing `list_apps()` short-circuits.
+    ///
+    /// For a predicate that can itself fail, see
+    /// [`try_find_with`](Self::try_find_with).
     pub fn find_with<F>(
         provider: Arc<dyn Provider>,
         timeout: Duration,
@@ -65,6 +68,25 @@ impl App {
     ) -> Result<Self>
     where
         F: Fn(&ElementData) -> bool,
+    {
+        Self::try_find_with(provider, timeout, move |d| Ok(predicate(d)))
+    }
+
+    /// Like [`find_with`](Self::find_with), but with a fallible predicate.
+    ///
+    /// The predicate's result drives the same retry contract the lookup uses
+    /// for the apps it enumerates: `Ok(false)` means "not this one, keep
+    /// polling", while `Err(_)` aborts the search immediately and propagates
+    /// — it is *not* treated as "no match". Language bindings use this so a
+    /// predicate exception fails fast instead of being silently swallowed and
+    /// surfacing later as a spurious timeout.
+    pub fn try_find_with<F>(
+        provider: Arc<dyn Provider>,
+        timeout: Duration,
+        predicate: F,
+    ) -> Result<Self>
+    where
+        F: Fn(&ElementData) -> Result<bool>,
     {
         Self::find_matching(provider, timeout, predicate, || {
             "application matching predicate".to_string()
@@ -81,7 +103,7 @@ impl App {
         describe: D,
     ) -> Result<Self>
     where
-        F: Fn(&ElementData) -> bool,
+        F: Fn(&ElementData) -> Result<bool>,
         D: Fn() -> String,
     {
         poll_lookup(timeout, || {
@@ -92,14 +114,18 @@ impl App {
             // significant in the selector grammar don't need escaping.
             //
             // Errors from `list_apps()` propagate so callers can distinguish
-            // "app not found" from "accessibility is broken".
+            // "app not found" from "accessibility is broken". A predicate
+            // error propagates for the same reason — `poll_lookup` only
+            // retries `SelectorNotMatched`, so anything else fails fast.
             let apps = provider.list_apps()?;
-            apps.into_iter()
-                .find(|d| predicate(d))
-                .map(|data| Self::from_data(Arc::clone(&provider), data))
-                .ok_or_else(|| Error::SelectorNotMatched {
-                    selector: describe(),
-                })
+            for data in apps {
+                if predicate(&data)? {
+                    return Ok(Self::from_data(Arc::clone(&provider), data));
+                }
+            }
+            Err(Error::SelectorNotMatched {
+                selector: describe(),
+            })
         })
     }
 
@@ -121,7 +147,7 @@ impl App {
         Self::find_matching(
             provider,
             timeout,
-            |d| d.name.as_deref() == Some(name),
+            |d| Ok(d.name.as_deref() == Some(name)),
             || format!(r#"application[name="{}"]"#, name),
         )
     }
@@ -135,7 +161,7 @@ impl App {
         Self::find_matching(
             provider,
             timeout,
-            |d| d.pid == Some(pid),
+            |d| Ok(d.pid == Some(pid)),
             || format!("application with pid={}", pid),
         )
     }
@@ -321,6 +347,37 @@ mod tests {
         let provider: Arc<dyn Provider> = build_provider();
         let err = App::find_with(provider, Duration::ZERO, |_| false)
             .expect_err("a never-true predicate must not match any app");
+        assert!(matches!(err, Error::SelectorNotMatched { .. }));
+    }
+
+    #[test]
+    fn try_find_with_propagates_predicate_error_and_fails_fast() {
+        let provider: Arc<dyn Provider> = build_provider();
+        // A generous timeout: if the predicate error were treated as "no
+        // match" the call would block for 30s. Returning immediately proves
+        // the error short-circuits the poll loop.
+        let start = Instant::now();
+        let err = App::try_find_with(provider, Duration::from_secs(30), |_| {
+            Err(Error::Platform {
+                code: 7,
+                message: "boom".to_string(),
+            })
+        })
+        .expect_err("a predicate error must propagate, not retry");
+        assert!(matches!(err, Error::Platform { code: 7, .. }));
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "predicate error must fail fast, not wait out the timeout"
+        );
+    }
+
+    #[test]
+    fn try_find_with_ok_false_keeps_polling_then_times_out() {
+        let provider: Arc<dyn Provider> = build_provider();
+        // `Ok(false)` is "not yet" — with a zero timeout that's one attempt
+        // and then a normal not-found result (no error propagation).
+        let err = App::try_find_with(provider, Duration::ZERO, |_| Ok(false))
+            .expect_err("an always-Ok(false) predicate must not match");
         assert!(matches!(err, Error::SelectorNotMatched { .. }));
     }
 }

--- a/xa11y-js/__test__/unit/app-factories.test.js
+++ b/xa11y-js/__test__/unit/app-factories.test.js
@@ -177,6 +177,17 @@ test('App.find() rejects with AbortError when the signal is already aborted', as
   );
 });
 
+test('App.find() propagates a predicate exception immediately (fail fast)', async () => {
+  // A falsy return means "keep polling"; a *thrown* predicate must abort the
+  // search and surface, not be swallowed as "no match".
+  NativeAppStub.__listReturn = [Object.assign(new NativeAppStub(), { name: 'X', pid: 1 })];
+  const boom = new Error('predicate blew up');
+  await assert.rejects(
+    () => App.find(() => { throw boom; }, { timeout: 30000 }),
+    (err) => err === boom,
+  );
+});
+
 test('subscribed apps from factories produce an EventEmitter Subscription', async () => {
   // End-to-end assertion of the consumer-observable bug: the value
   // returned by `.subscribe()` is an `EventEmitter`-based `Subscription`,

--- a/xa11y-js/__test__/unit/app-factories.test.js
+++ b/xa11y-js/__test__/unit/app-factories.test.js
@@ -78,7 +78,7 @@ require.cache[nativePath] = {
 };
 
 // Now pull the wrapper — it captures `NativeAppStub` as its parent.
-const { App, Subscription } = require('../../index.js');
+const { App, Subscription, SelectorNotMatchedError } = require('../../index.js');
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
@@ -140,6 +140,41 @@ test('App.list() rewires every returned instance (not just the first)', async ()
       `every element must be rewired (index ${i})`,
     );
   }
+});
+
+test('App.find() resolves with the first app matching the predicate', async () => {
+  const a = Object.assign(new NativeAppStub(), { name: 'Other', pid: 1 });
+  const b = Object.assign(new NativeAppStub(), { name: 'Target', pid: 42 });
+  NativeAppStub.__listReturn = [a, b];
+  const app = await App.find((x) => x.pid === 42);
+  assert.equal(app.pid, 42);
+  assert.strictEqual(
+    Object.getPrototypeOf(app),
+    App.prototype,
+    'find() result must carry the wrapper prototype',
+  );
+});
+
+test('App.find() supports an async predicate', async () => {
+  NativeAppStub.__listReturn = [Object.assign(new NativeAppStub(), { name: 'Target', pid: 7 })];
+  const app = await App.find(async (x) => x.name === 'Target');
+  assert.equal(app.name, 'Target');
+});
+
+test('App.find() rejects with SelectorNotMatchedError on timeout', async () => {
+  NativeAppStub.__listReturn = [Object.assign(new NativeAppStub(), { name: 'Nope', pid: 1 })];
+  await assert.rejects(
+    () => App.find(() => false, { timeout: 20 }),
+    (err) => err instanceof SelectorNotMatchedError,
+  );
+});
+
+test('App.find() rejects with AbortError when the signal is already aborted', async () => {
+  NativeAppStub.__listReturn = [];
+  await assert.rejects(
+    () => App.find(() => true, { signal: AbortSignal.abort() }),
+    (err) => err.name === 'AbortError',
+  );
 });
 
 test('subscribed apps from factories produce an EventEmitter Subscription', async () => {

--- a/xa11y-js/index.d.ts
+++ b/xa11y-js/index.d.ts
@@ -70,6 +70,16 @@ export interface WaitUntilOptions {
   signal?: AbortSignal;
 }
 
+export interface FindOptions {
+  /**
+   * Timeout in milliseconds. Default: 5000. Rejects with
+   * `SelectorNotMatchedError` if no application matches in time.
+   */
+  timeout?: number;
+  /** Abort signal for cancellation. Rejects with `AbortError`. */
+  signal?: AbortSignal;
+}
+
 // Add `waitUntil` to the napi-generated `Locator` class via interface merging.
 // The method is attached to `native.Locator.prototype` in index.js.
 declare module './native.js' {
@@ -151,6 +161,26 @@ export declare class App {
   static byPid(pid: number, options?: AppLookupOptions): Promise<App>;
   /** List all running applications with an accessibility tree. */
   static list(): Promise<App[]>;
+  /**
+   * Find an application matching `predicate`, polling until one appears or
+   * the timeout elapses.
+   *
+   * The predicate receives each running `App` on every poll (it may be
+   * async); the first for which it returns truthy resolves the promise.
+   * Rejects with `SelectorNotMatchedError` if nothing matches in time.
+   *
+   * @example
+   * ```ts
+   * const app = await App.find(
+   *   (a) => a.pid === pid || ['my-app', 'My App'].includes(a.name),
+   *   { timeout: 30000 },
+   * );
+   * ```
+   */
+  static find(
+    predicate: (app: App) => boolean | Promise<boolean>,
+    options?: FindOptions,
+  ): Promise<App>;
 
   get name(): string;
   get pid(): number | null;

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -374,6 +374,69 @@ class App extends native.App {
   }
 
   /**
+   * Find an application matching `predicate`, polling until one appears or
+   * the timeout elapses.
+   *
+   * `predicate` receives each running `App` on every poll (it may be async);
+   * the first for which it returns truthy is returned. This is a JS-side
+   * poll loop over `App.list()`, mirroring `Locator.waitUntil` — the
+   * predicate runs as plain JS on the main thread, so it can use any logic.
+   * Rejects with `SelectorNotMatchedError` if nothing matches before
+   * `timeout`.
+   *
+   * @param {(app: App) => boolean | Promise<boolean>} predicate
+   * @param {object} [options]
+   * @param {number} [options.timeout=5000] - Timeout in milliseconds
+   * @param {AbortSignal} [options.signal] - Abort signal for cancellation
+   * @returns {Promise<App>}
+   * @example
+   * ```js
+   * const app = await App.find(
+   *   (a) => a.pid === pid || ['my-app', 'My App'].includes(a.name),
+   *   { timeout: 30000 },
+   * );
+   * ```
+   */
+  static async find(predicate, options = {}) {
+    const { timeout = 5000, signal } = options;
+    const deadline = Date.now() + timeout;
+
+    if (signal && signal.aborted) {
+      throw new DOMException('The operation was aborted', 'AbortError');
+    }
+
+    while (true) {
+      const apps = await App.list();
+      for (const app of apps) {
+        if (await predicate(app)) return app;
+      }
+
+      if (signal && signal.aborted) {
+        throw new DOMException('The operation was aborted', 'AbortError');
+      }
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new SelectorNotMatchedError(
+          `No application matched predicate after ${timeout}ms`,
+        );
+      }
+
+      await new Promise((resolve, reject) => {
+        const delay = Math.min(50, remaining);
+        const timer = setTimeout(() => {
+          if (signal) signal.removeEventListener('abort', onAbort);
+          resolve();
+        }, delay);
+        const onAbort = () => {
+          clearTimeout(timer);
+          reject(new DOMException('The operation was aborted', 'AbortError'));
+        };
+        if (signal) signal.addEventListener('abort', onAbort, { once: true });
+      });
+    }
+  }
+
+  /**
    * Subscribe to accessibility events from this application.
    *
    * @param {object} [opts]

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -382,7 +382,8 @@ class App extends native.App {
    * poll loop over `App.list()`, mirroring `Locator.waitUntil` — the
    * predicate runs as plain JS on the main thread, so it can use any logic.
    * Rejects with `SelectorNotMatchedError` if nothing matches before
-   * `timeout`.
+   * `timeout`. A falsy return keeps polling; if the predicate *throws*, the
+   * search aborts and that error propagates (it is not treated as no-match).
    *
    * @param {(app: App) => boolean | Promise<boolean>} predicate
    * @param {object} [options]

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -1103,6 +1103,10 @@ impl App {
     /// until a match appears or `timeout` (in seconds) elapses — see
     /// `by_name` for timeout semantics.
     ///
+    /// A falsy return means "not this one, keep polling". If the predicate
+    /// *raises*, the search aborts immediately and that exception propagates
+    /// — it is not swallowed as "no match".
+    ///
     /// ```python
     /// app = xa11y.App.find(
     ///     lambda a: a.pid == pid or a.name in ("my-app", "My App"),
@@ -1115,21 +1119,36 @@ impl App {
         let timeout = timeout_from(timeout)?;
         let provider = get_provider()?;
         // The predicate is Python, so the poll loop must hold the GIL to call
-        // it (mirrors `Locator.wait_until`). `find_with` runs the same poll
-        // loop as `by_name` / `by_pid`.
-        let app = xa11y::App::find_with(provider.clone(), timeout, |data| {
-            Python::with_gil(|py| -> bool {
-                match Py::new(py, App::from_data(data, provider.clone())) {
-                    Ok(app) => predicate
-                        .call1(py, (app,))
-                        .and_then(|r| r.extract::<bool>(py))
-                        .unwrap_or(false),
-                    Err(_) => false,
+        // it (mirrors `Locator.wait_until`). We route through `try_find_with`
+        // so a raised exception fails fast: stash the real `PyErr` here and
+        // return an error from the closure (which `poll_lookup` short-circuits
+        // on), then re-raise the original Python exception below rather than
+        // coercing it to a misleading "no match".
+        let pred_err: std::cell::RefCell<Option<PyErr>> = std::cell::RefCell::new(None);
+        let result = xa11y::App::try_find_with(provider.clone(), timeout, |data| {
+            Python::with_gil(|py| -> xa11y::Result<bool> {
+                let outcome: PyResult<bool> = (|| {
+                    let app = Py::new(py, App::from_data(data, provider.clone()))?;
+                    predicate.call1(py, (app,))?.bind(py).is_truthy()
+                })();
+                match outcome {
+                    Ok(matched) => Ok(matched),
+                    Err(e) => {
+                        *pred_err.borrow_mut() = Some(e);
+                        Err(xa11y::Error::Platform {
+                            code: -1,
+                            message: "find() predicate raised".to_string(),
+                        })
+                    }
                 }
             })
-        })
-        .map_err(to_py_err)?;
-        Ok(Self::from_core(app))
+        });
+        match result {
+            Ok(app) => Ok(Self::from_core(app)),
+            // A stashed predicate error takes precedence — re-raise the exact
+            // Python exception the predicate threw.
+            Err(e) => Err(pred_err.into_inner().unwrap_or_else(|| to_py_err(e))),
+        }
     }
 
     /// Create a Locator scoped to this application's accessibility tree.

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -1096,6 +1096,42 @@ impl App {
         Ok(apps.into_iter().map(Self::from_core).collect())
     }
 
+    /// Find an application matching `predicate`.
+    ///
+    /// `predicate` is called with an `App` for each running application on
+    /// every poll; the first for which it returns truthy is returned. Polls
+    /// until a match appears or `timeout` (in seconds) elapses — see
+    /// `by_name` for timeout semantics.
+    ///
+    /// ```python
+    /// app = xa11y.App.find(
+    ///     lambda a: a.pid == pid or a.name in ("my-app", "My App"),
+    ///     timeout=30.0,
+    /// )
+    /// ```
+    #[staticmethod]
+    #[pyo3(signature = (predicate, *, timeout=5.0))]
+    fn find(predicate: PyObject, timeout: f64) -> PyResult<Self> {
+        let timeout = timeout_from(timeout)?;
+        let provider = get_provider()?;
+        // The predicate is Python, so the poll loop must hold the GIL to call
+        // it (mirrors `Locator.wait_until`). `find_with` runs the same poll
+        // loop as `by_name` / `by_pid`.
+        let app = xa11y::App::find_with(provider.clone(), timeout, |data| {
+            Python::with_gil(|py| -> bool {
+                match Py::new(py, App::from_data(data, provider.clone())) {
+                    Ok(app) => predicate
+                        .call1(py, (app,))
+                        .and_then(|r| r.extract::<bool>(py))
+                        .unwrap_or(false),
+                    Err(_) => false,
+                }
+            })
+        })
+        .map_err(to_py_err)?;
+        Ok(Self::from_core(app))
+    }
+
     /// Create a Locator scoped to this application's accessibility tree.
     fn locator(&self, selector: &str) -> Locator {
         Locator {
@@ -1192,6 +1228,17 @@ impl App {
             pid: app.pid,
             provider: app.provider().clone(),
             inner_data: app.data.clone(),
+        }
+    }
+
+    /// Build a Python `App` view from raw element data — used to hand the
+    /// `find` predicate an `App` (with `.name` / `.pid`) per candidate.
+    fn from_data(data: &xa11y::ElementData, provider: Arc<dyn xa11y::Provider>) -> Self {
+        Self {
+            name: data.name.clone().unwrap_or_default(),
+            pid: data.pid,
+            provider,
+            inner_data: data.clone(),
         }
     }
 }

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -227,7 +227,7 @@ fn create_provider_boxed() -> Result<Box<dyn Provider>> {
 mod app_ext {
     use std::time::Duration;
 
-    use super::{provider, App, Result};
+    use super::{provider, App, ElementData, Result};
 
     /// Extension trait that adds singleton-based constructors to [`App`].
     ///
@@ -253,6 +253,14 @@ mod app_ext {
         fn by_pid(pid: u32, timeout: Duration) -> Result<Self>;
         /// List all running applications using the global singleton provider.
         fn list() -> Result<Vec<Self>>;
+        /// Find an application matching `predicate` using the global
+        /// singleton provider, polling until one appears or `timeout`
+        /// elapses. `predicate` runs against each running app's
+        /// [`ElementData`] on every poll. See [`App::find_with`] for
+        /// match / timeout semantics.
+        fn find<F>(timeout: Duration, predicate: F) -> Result<Self>
+        where
+            F: Fn(&ElementData) -> bool;
     }
 
     impl AppExt for App {
@@ -266,6 +274,13 @@ mod app_ext {
 
         fn list() -> Result<Vec<Self>> {
             App::list_with(provider()?)
+        }
+
+        fn find<F>(timeout: Duration, predicate: F) -> Result<Self>
+        where
+            F: Fn(&ElementData) -> bool,
+        {
+            App::find_with(provider()?, timeout, predicate)
         }
     }
 }

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -261,6 +261,12 @@ mod app_ext {
         fn find<F>(timeout: Duration, predicate: F) -> Result<Self>
         where
             F: Fn(&ElementData) -> bool;
+        /// Like [`find`](Self::find), but with a fallible predicate:
+        /// `Ok(false)` keeps polling while `Err(_)` aborts and propagates.
+        /// See [`App::try_find_with`].
+        fn try_find<F>(timeout: Duration, predicate: F) -> Result<Self>
+        where
+            F: Fn(&ElementData) -> Result<bool>;
     }
 
     impl AppExt for App {
@@ -281,6 +287,13 @@ mod app_ext {
             F: Fn(&ElementData) -> bool,
         {
             App::find_with(provider()?, timeout, predicate)
+        }
+
+        fn try_find<F>(timeout: Duration, predicate: F) -> Result<Self>
+        where
+            F: Fn(&ElementData) -> Result<bool>,
+        {
+            App::try_find_with(provider()?, timeout, predicate)
         }
     }
 }

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -31,22 +31,14 @@ use xa11y::*;
 /// Get the test app as an `App`, retrying briefly for registration.
 pub fn app_root() -> App {
     // On Linux/macOS, AT-SPI and AX report the process name ("xa11y-test-app").
-    // On Windows, UIA reports the window title ("xa11y Test App").
-    // Two candidate names to interleave, so we keep the manual loop (a
-    // single `by_name` with a long timeout per name would block on the
-    // wrong name for its full timeout before trying the right one).
+    // On Windows, UIA reports the window title ("xa11y Test App"). Match either
+    // candidate name in a single waited call — `App::find` polls internally, so
+    // we no longer interleave names by hand.
     let names = ["xa11y-test-app", "xa11y Test App"];
-    for attempt in 0..3 {
-        for name in &names {
-            if let Ok(app) = App::by_name(name, std::time::Duration::ZERO) {
-                return app;
-            }
-        }
-        if attempt < 2 {
-            std::thread::sleep(std::time::Duration::from_millis(200));
-        }
-    }
-    panic!("Could not find test app after retries (tried {:?})", names);
+    App::find(std::time::Duration::from_secs(2), |d| {
+        d.name.as_deref().is_some_and(|n| names.contains(&n))
+    })
+    .unwrap_or_else(|e| panic!("Could not find test app (tried {:?}): {e}", names))
 }
 
 /// Find exactly one element by selector within the app. Panics on failure.


### PR DESCRIPTION
Adds `App::find_with` to xa11y-core — a predicate-based discovery loop
that reuses the existing `poll_lookup` retry machinery. `by_name_with`
and `by_pid_with` are re-expressed over a shared `find_matching` helper,
preserving their specific SelectorNotMatched error messages.

Surfaces it everywhere:
- xa11y umbrella: `AppExt::find(timeout, predicate)`
- Python: `App.find(predicate, *, timeout=5.0)` — predicate receives an
  `App` per candidate, evaluated under the GIL like `Locator.wait_until`
- JS: `App.find(predicate, { timeout, signal })` implemented in the
  hand-written index.js wrapper as a JS-side poll loop over `App.list()`,
  mirroring the existing `Locator.waitUntil` pattern. The predicate runs
  as plain JS on the main thread (no ThreadsafeFunction round-trip).

This lets callers express "find the app matching pid P or any of names
[...]" in a single waited call, removing the need for hand-rolled poll
loops in test harness / discovery code.

Tests: core unit tests for match/no-match; JS stub-harness tests for
match, async predicate, timeout, and abort.