### PR TITLE
ci(bindings): allowlist App::find_with/try_find_with and App.find parity

### DIFF
--- a/bindings/parity_allowlist.toml
+++ b/bindings/parity_allowlist.toml
@@ -13,6 +13,8 @@ rust_only = [
     { method = "App::by_pid_with", reason = "Binding uses the global singleton provider; `_with` variants are Rust-only plumbing for explicit provider injection." },
     { method = "App::by_pid_with_timeout", reason = "Binding uses the global singleton provider; `_with` variants are Rust-only plumbing for explicit provider injection." },
     { method = "App::list_with", reason = "Binding uses the global singleton provider; `_with` variants are Rust-only plumbing for explicit provider injection." },
+    { method = "App::find_with", reason = "Binding uses the global singleton provider; `_with` variants are Rust-only plumbing for explicit provider injection. Exposed to Python as `App.find`." },
+    { method = "App::try_find_with", reason = "Fallible-predicate variant of `find_with`; binding `App.find` routes through it and re-raises predicate errors. `_with` variants are Rust-only plumbing for explicit provider injection." },
 
     # ── Internal constructors / plumbing accessors ────────────────────────
     { method = "App::provider", reason = "Internal plumbing for provider implementors, not user API." },
@@ -44,6 +46,7 @@ python_only = [
     { method = "App::by_name", reason = "Binding-level convenience over App::by_name_with using the singleton provider; mirrors `xa11y::AppExt::by_name`." },
     { method = "App::by_pid", reason = "Binding-level convenience over App::by_pid_with using the singleton provider; mirrors `xa11y::AppExt::by_pid`." },
     { method = "App::list", reason = "Binding-level convenience over App::list_with using the singleton provider; mirrors `xa11y::AppExt::list`." },
+    { method = "App::find", reason = "Binding-level convenience over App::try_find_with/find_with using the singleton provider; mirrors `xa11y::AppExt::find`. Predicate-based waited discovery over App.list()." },
 
     # Flattened StateSet: Python exposes each boolean state directly on
     # Element (element.enabled, element.visible, ...) instead of a nested
@@ -77,6 +80,8 @@ rust_only = [
     { method = "App::by_pid_with", reason = "Binding uses the global singleton provider; `_with` variants are Rust-only plumbing for explicit provider injection." },
     { method = "App::by_pid_with_timeout", reason = "Binding uses the global singleton provider; `_with` variants are Rust-only plumbing for explicit provider injection." },
     { method = "App::list_with", reason = "Binding uses the global singleton provider; `_with` variants are Rust-only plumbing for explicit provider injection." },
+    { method = "App::find_with", reason = "Binding uses the global singleton provider; `_with` variants are Rust-only plumbing for explicit provider injection. Exposed to JS as `App.find`, implemented as a JS-side poll loop in index.js." },
+    { method = "App::try_find_with", reason = "Fallible-predicate variant of `find_with`; the JS `App.find` poll loop propagates predicate errors directly. `_with` variants are Rust-only plumbing for explicit provider injection." },
 
     # ── Internal constructors / plumbing accessors ────────────────────────
     { method = "App::provider", reason = "Internal plumbing for provider implementors, not user API." },
@@ -107,6 +112,7 @@ js_only = [
     { method = "App::by_name", reason = "Binding-level convenience over App::by_name_with using the singleton provider; mirrors `xa11y::AppExt::by_name`." },
     { method = "App::by_pid", reason = "Binding-level convenience over App::by_pid_with using the singleton provider; mirrors `xa11y::AppExt::by_pid`." },
     { method = "App::list", reason = "Binding-level convenience over App::list_with using the singleton provider; mirrors `xa11y::AppExt::list`." },
+    { method = "App::find", reason = "Binding-level convenience over App::try_find_with/find_with using the singleton provider; mirrors `xa11y::AppExt::find`. Implemented as a JS-side poll loop over App.list() in index.js, declared in index.d.ts." },
 
     # App.waitForEvent is a JS-only convenience that wraps subscribe() + a
     # one-shot waitForEvent() on the returned Subscription.


### PR DESCRIPTION
Commit #235 added predicate-based discovery to xa11y-core
(App::find_with / App::try_find_with) and exposed it in the Python and
JS bindings as the idiomatic App.find (mirroring xa11y::AppExt::find),
but did not update the bindings parity allowlist. The check-bindings-parity
CI step then failed on three drifts:

- App::find_with / App::try_find_with: core methods with no Python/JS
  counterpart (they are _with provider-injection plumbing, same as the
  existing by_name_with / list_with entries).
- App::find: a Python/JS method with no Rust-core counterpart (it is a
  binding-level convenience over the _with variants using the singleton
  provider).

Add matching allowlist entries to [python.rust_only], [python.python_only],
[js.rust_only], and [js.js_only], following the established convention for
the by_name/by_pid/list trio.