### PR TITLE
Update product description from "API" to "library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
 
-A Playwright-style API for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
+A Playwright-style library for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
 
 **Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
       title: "xa11y",
       customCss: ["./src/styles/custom.css"],
       description:
-        "A Playwright-style API for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux.",
+        "A Playwright-style library for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux.",
       social: [
         {
           icon: "github",

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -16,15 +16,15 @@ const version = `v${verMatch[1]}`;
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>xa11y — Playwright-style UI automation for desktop apps</title>
-<meta name="description" content="A Playwright-style API for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
+<meta name="description" content="A Playwright-style library for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
 <meta property="og:title" content="xa11y — Playwright-style UI automation for desktop apps" />
-<meta property="og:description" content="A Playwright-style API for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
+<meta property="og:description" content="A Playwright-style library for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://xa11y.dev/" />
 <meta property="og:site_name" content="xa11y" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:title" content="xa11y — Playwright-style UI automation for desktop apps" />
-<meta name="twitter:description" content="A Playwright-style API for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
+<meta name="twitter:description" content="A Playwright-style library for desktop apps. Cross-platform UI automation, end-to-end testing, and accessibility tooling for native apps on macOS, Windows, and Linux." />
 <link rel="canonical" href="https://xa11y.dev/" />
 <link rel="api-catalog" href="/.well-known/api-catalog" />
 <link rel="service-doc" href="/guides/overview/" />
@@ -333,7 +333,7 @@ const version = `v${verMatch[1]}`;
     </h1>
 
     <p class="lede">
-      A Playwright-style API for driving native desktop apps on
+      A Playwright-style library for driving native desktop apps on
       macOS, Windows, and Linux. Built for end-to-end tests,
       computer-use agents, and assistive tools.
     </p>
@@ -428,7 +428,7 @@ const version = `v${verMatch[1]}`;
   <div>
     <div class="brand" style="margin-bottom:12px;"><span class="glyph">x</span> xa11y <span class="ver">{version}</span></div>
     <div style="color:var(--ink-muted); font-size:13px; line-height:1.55; max-width:34ch;">
-      A Playwright-style API for driving native desktop apps on macOS, Windows, and Linux. MIT-licensed, built in the open.
+      A Playwright-style library for driving native desktop apps on macOS, Windows, and Linux. MIT-licensed, built in the open.
     </div>
   </div>
   <div>

--- a/xa11y-python/README.md
+++ b/xa11y-python/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
 
-A Playwright-style API for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
+A Playwright-style library for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
 
 **Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 

--- a/xa11y/README.md
+++ b/xa11y/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
 
-A Playwright-style API for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
+A Playwright-style library for driving native desktop apps on macOS, Windows, and Linux. Built for end-to-end tests, computer-use agents, and assistive tools.
 
 **Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 


### PR DESCRIPTION
## Summary

Updates the product description across documentation and README files to refer to xa11y as a "Playwright-style library" instead of a "Playwright-style API". This change clarifies the nature of the project and improves consistency in how the product is presented.

## Changes

- Updated meta descriptions in the homepage (`docs/site/src/pages/index.astro`) for SEO and social media sharing (og:description, twitter:description)
- Updated the main lede/hero text on the homepage to use "library" terminology
- Updated footer description on the homepage
- Updated project descriptions in `README.md` files across the repository root, `xa11y/`, and `xa11y-python/` packages
- Updated Astro site configuration description in `docs/site/astro.config.mjs`

All changes maintain the same core messaging about cross-platform UI automation, end-to-end testing, and accessibility tooling while using more accurate terminology.

https://claude.ai/code/session_0169cd7a2C8gM2PNQkQvZGkE