### PR TITLE
docs: fix GFM tables not rendering and add rendered-table linter check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,6 +693,9 @@ jobs:
         working-directory: docs/site
         run: npm run build
 
+      - name: Check rendered doc tables
+        run: python docs/check_tables.py --rendered docs/site/dist
+
   # ── JavaScript bindings ───────────────────────────────────────────
   js:
     name: JS bindings (${{ matrix.os }})

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -100,6 +100,9 @@ jobs:
         working-directory: docs/site
         run: npm run build
 
+      - name: Check rendered doc tables
+        run: python docs/check_tables.py --rendered docs/site/dist
+
       - name: Build Python API docs (Sphinx)
         working-directory: docs/python
         run: sphinx-build -b html . _build/html

--- a/docs/check_tables.py
+++ b/docs/check_tables.py
@@ -1,23 +1,36 @@
 #!/usr/bin/env python3
-"""Check that GitHub-Flavored-Markdown tables in the docs are well-formed.
+"""Check that GitHub-Flavored-Markdown tables in the docs are well-formed
+*and* that they actually render to <table> elements in the built site.
 
-Scans all .mdx files under docs/site/src/content/docs/ for tables and
-validates each one against the rules Starlight's GFM renderer relies on:
+Two layers of checking, because table bugs come in two flavours:
 
-  - A blank line must precede the table, otherwise the header row is
-    folded into the preceding paragraph and the table never renders.
-  - The header row, the delimiter row, and every body row must all have
-    the same number of cells. A row with too few cells silently drops a
-    column (this is the bug that motivated the check); a row with too
-    many cells spills into an extra column.
+1. **Source well-formedness** (default). Scans all .mdx files under
+   docs/site/src/content/docs/ and validates each table against the
+   rules Starlight's GFM renderer relies on:
 
-A "table" is detected as a header row starting with `|` immediately
-followed by a delimiter row (pipes, dashes, optional colons). Pipes
-inside inline code spans or escaped as `\\|` are not treated as cell
-separators. Fenced code blocks (```) are skipped so example tables in
-documentation aren't validated as real ones.
+     - A blank line must precede the table, otherwise the header row is
+       folded into the preceding paragraph and the table never renders.
+     - The header row, the delimiter row, and every body row must all
+       have the same number of cells. A row with too few cells silently
+       drops a column (this is the bug that motivated the check); a row
+       with too many cells spills into an extra column.
 
-Exit code 0 if all tables are well-formed, 1 if any problems are found.
+   A "table" is detected as a header row starting with `|` immediately
+   followed by a delimiter row (pipes, dashes, optional colons). Pipes
+   inside inline code spans or escaped as `\\|` are not treated as cell
+   separators. Fenced code blocks (```) are skipped so example tables in
+   documentation aren't validated as real ones.
+
+2. **Rendered output** (`--rendered <dist>`). Even a perfectly-formed
+   source table renders as a raw paragraph if the GFM remark plugin is
+   not wired into the MDX pipeline — exactly the regression in issue
+   #247, where an Astro upgrade stopped `@astrojs/mdx` from enabling
+   `remark-gfm`. Static source checks can't see that, so this mode maps
+   every .mdx source to its built HTML page and asserts the number of
+   `<table>` elements matches the number of source tables. It catches
+   config/toolchain regressions that drop *all* tables at once.
+
+Exit code 0 if everything checks out, 1 if any problems are found.
 """
 
 import re
@@ -25,6 +38,10 @@ import sys
 from pathlib import Path
 
 DOCS_DIR = Path(__file__).parent / "site" / "src" / "content" / "docs"
+
+# Matches the opening tag of a rendered HTML table, e.g. `<table>` or
+# `<table class="...">`. Used by the rendered-output check.
+RENDERED_TABLE = re.compile(r"<table[\s/>]")
 
 # A delimiter row: only pipes, dashes, colons and whitespace, with at
 # least one dash and at least one pipe.
@@ -64,6 +81,85 @@ def split_cells(line: str) -> list[str]:
         i += 1
     cells.append("".join(buf))
     return cells
+
+
+def iter_tables(lines: list[str]):
+    """Yield the 0-based header line index of every table in `lines`.
+
+    A table is a header row starting with `|` immediately followed by a
+    delimiter row. Fenced code blocks are skipped so example tables in
+    documentation aren't counted. Shared by the source and rendered
+    checks so both agree on what "a table" is.
+    """
+    n = len(lines)
+    in_fence = False
+    i = 0
+    while i < n:
+        line = lines[i]
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            i += 1
+            continue
+        is_header = (
+            not in_fence
+            and line.lstrip().startswith("|")
+            and i + 1 < n
+            and DELIMITER_ROW.match(lines[i + 1])
+        )
+        if not is_header:
+            i += 1
+            continue
+        yield i
+        # Skip past the delimiter row and the contiguous body rows.
+        j = i + 2
+        while (
+            j < n
+            and lines[j].lstrip().startswith("|")
+            and not lines[j].lstrip().startswith("```")
+        ):
+            j += 1
+        i = j
+
+
+def count_tables(filepath: Path) -> int:
+    """Number of real (non-fenced) tables in an .mdx source file."""
+    return sum(1 for _ in iter_tables(filepath.read_text().splitlines()))
+
+
+def rendered_html_path(filepath: Path, dist: Path) -> Path:
+    """Map an .mdx source path to its built HTML page under `dist`.
+
+    Astro/Starlight emits `<slug>/index.html` for each doc, where the
+    slug is the source path relative to the content root without its
+    extension. `index.mdx` collapses onto its parent directory.
+    """
+    slug = filepath.relative_to(DOCS_DIR).with_suffix("")
+    if slug.name == "index":
+        slug = slug.parent
+    return dist / slug / "index.html"
+
+
+def check_rendered(filepath: Path, dist: Path) -> list[str]:
+    """Return reasons the built page doesn't match the source's tables."""
+    n_source = count_tables(filepath)
+    if n_source == 0:
+        return []
+
+    html_path = rendered_html_path(filepath, dist)
+    if not html_path.exists():
+        return [
+            f"has {n_source} table(s) but built page is missing: "
+            f"{html_path.relative_to(dist)}"
+        ]
+
+    n_rendered = len(RENDERED_TABLE.findall(html_path.read_text()))
+    if n_rendered != n_source:
+        return [
+            f"has {n_source} source table(s) but built page renders "
+            f"{n_rendered} <table> element(s) — GFM tables may not be "
+            f"reaching the HTML (see issue #247)"
+        ]
+    return []
 
 
 def check_file(filepath: Path) -> list[tuple[int, str]]:
@@ -113,26 +209,46 @@ def check_file(filepath: Path) -> list[tuple[int, str]]:
     return errors
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+
+    dist: Path | None = None
+    if "--rendered" in argv:
+        idx = argv.index("--rendered")
+        try:
+            dist = Path(argv[idx + 1])
+        except IndexError:
+            print("ERROR: --rendered requires a path to the built dist/ dir")
+            return 1
+        if not dist.is_dir():
+            print(f"ERROR: dist directory not found: {dist}", file=sys.stderr)
+            return 1
+
     mdx_files = sorted(DOCS_DIR.rglob("*.mdx"))
     if not mdx_files:
         print(f"ERROR: no .mdx files found in {DOCS_DIR}", file=sys.stderr)
         return 1
 
-    all_errors: list[tuple[Path, int, str]] = []
+    all_errors: list[tuple[Path, str]] = []
     for filepath in mdx_files:
         for lineno, reason in check_file(filepath):
-            all_errors.append((filepath, lineno, reason))
+            all_errors.append((filepath, f"{lineno}: {reason}"))
+
+    if dist is not None:
+        for filepath in mdx_files:
+            for reason in check_rendered(filepath, dist):
+                all_errors.append((filepath, reason))
 
     if all_errors:
-        print(f"Found {len(all_errors)} malformed table issue(s):\n")
-        for filepath, lineno, reason in all_errors:
+        print(f"Found {len(all_errors)} table issue(s):\n")
+        for filepath, reason in all_errors:
             rel = filepath.relative_to(DOCS_DIR)
-            print(f"  {rel}:{lineno}: {reason}")
+            print(f"  {rel}:{reason}")
         print()
         return 1
 
-    print(f"All tables OK ({len(mdx_files)} files checked)")
+    where = "source + rendered" if dist is not None else "source"
+    print(f"All tables OK ({len(mdx_files)} files checked, {where})")
     return 0
 
 

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -3,6 +3,14 @@ import starlight from "@astrojs/starlight";
 
 export default defineConfig({
   site: "https://xa11y.dev",
+  // Astro 6.4 made `markdown.gfm` an opt-in flag whose default is supplied
+  // internally by the markdown processor, but `@astrojs/mdx` still gates
+  // `remark-gfm` on this value being truthy. Without it, GFM tables in our
+  // `.mdx` docs render as raw paragraphs (see issue #247). Set it explicitly
+  // so tables, strikethrough, and task lists render in the MDX pipeline.
+  markdown: {
+    gfm: true,
+  },
   integrations: [
     starlight({
       title: "xa11y",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -519,7 +519,20 @@ fn do_docs() -> bool {
     if !install_ok {
         return false;
     }
-    run_in("npm", &["run", "build"], &site_dir)
+    let build_ok = run_in("npm", &["run", "build"], &site_dir);
+    if !build_ok {
+        return false;
+    }
+
+    // Source well-formedness can't catch a toolchain regression that
+    // drops every table from the rendered HTML (issue #247), so verify
+    // the built pages actually contain the <table> elements.
+    heading("Check rendered doc tables");
+    run_in(
+        "python",
+        &["docs/check_tables.py", "--rendered", "docs/site/dist"],
+        &root,
+    )
 }
 
 fn do_coverage() -> bool {


### PR DESCRIPTION
Fixes #247.

## What was wrong

Every table on xa11y.dev rendered as a raw `| ... |` paragraph. The built HTML had zero `<table>` elements; only GFM features broke (CommonMark `<code>`/`<em>` still worked), pointing at `remark-gfm`.

Root cause: a version-skew regression from the recent astro 6.4.2→6.4.4 bump (#244). Astro 6.4 made `markdown.gfm` an optional, undefined-by-default deprecated flag (the real default is now supplied inside the markdown processor). But the installed `@astrojs/mdx` 5.0.6 still gates `remark-gfm` on `config.markdown.gfm` being truthy — with it now `undefined`, MDX silently stopped enabling GFM for all `.mdx` docs.

## The fix

Set `markdown: { gfm: true }` explicitly in `astro.config.mjs`. After rebuild, all guide pages emit real `<table>` elements.

## Linter update (red→green)

`check_tables.py` only validated table *source* well-formedness, which can't catch a toolchain regression that drops every table from the *rendered* HTML. Added a `--rendered <dist>` mode that maps each `.mdx` to its built page and asserts the `<table>` count matches the source table count.

- Red: rebuilding with the fix removed → reports all 9 affected pages, exit 1.
- Green: with the fix → `All tables OK (11 files checked, source + rendered)`, exit 0.

Wired into `cargo xtask docs` (post-build) and the `ci.yml` / `docs.yml` doc-build jobs. Source-only default mode is unchanged; ruff passes; xtask compiles.

https://claude.ai/code/session_01KAbFmR6b6qj6qsWi9yWN73

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAbFmR6b6qj6qsWi9yWN73)_