### PR TITLE
Retry EVENT_E_ALL_SUBSCRIBERS_FAILED (0x80040201) on the UIA query path

### DIFF
--- a/docs/site/src/content/docs/guides/accessibility-quirks.mdx
+++ b/docs/site/src/content/docs/guides/accessibility-quirks.mdx
@@ -282,7 +282,9 @@ EVENT_E_ALL_SUBSCRIBERS_FAILED (0x80040201)
 
 Qt propagates this back through the action call **even though the UI action
 itself completed successfully**. The same code can surface from
-`FindAllBuildCache` during a find. Treat `0x80040201` as success.
+`FindAllBuildCache` during a find. xa11y treats `0x80040201` as success on
+action calls (`press`/`toggle`/`select`), and on query calls — where a value is
+still needed — retries the call a few times before giving up.
 
 ### Windows: `FindAllBuildCache` silently drops fragment elements
 

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -274,12 +274,40 @@ impl WindowsProvider {
 
 // ── Safe UIA helpers ────────────────────────────────────────────────────────
 
+/// Maximum number of attempts for a UIA call that keeps failing with
+/// `EVENT_E_ALL_SUBSCRIBERS_FAILED`, and the delay between attempts.
+const EVENT_SUBSCRIBER_FAILURE_ATTEMPTS: u32 = 3;
+const EVENT_SUBSCRIBER_FAILURE_RETRY_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(50);
+
 /// Wrap a UIA COM call, mapping the error to xa11y Error::Platform.
-fn uia_call<T>(f: impl FnOnce() -> windows::core::Result<T>) -> Result<T> {
-    f().map_err(|e| Error::Platform {
-        code: e.code().0 as i64,
-        message: e.to_string(),
-    })
+///
+/// `EVENT_E_ALL_SUBSCRIBERS_FAILED` (0x80040201) is transient (see the
+/// constant's doc above): some providers (notably Qt's UIA backend) surface
+/// it from query calls like `FindAllBuildCache` even though only the
+/// notification layer hiccupped. The action paths (`press`/`toggle`/`select`)
+/// can swallow it outright because the action already completed (#169); a
+/// query needs a value, so the call is retried a few times before the error
+/// is propagated. Any other error is returned immediately — this is a retry
+/// of one classified-transient HRESULT, not a fallback (tenet 1).
+/// See: https://github.com/xa11y/xa11y/issues/257
+fn uia_call<T>(f: impl Fn() -> windows::core::Result<T>) -> Result<T> {
+    let mut attempts_left = EVENT_SUBSCRIBER_FAILURE_ATTEMPTS;
+    loop {
+        attempts_left -= 1;
+        match f() {
+            Ok(v) => return Ok(v),
+            Err(e) if is_event_subscriber_failure(&e) && attempts_left > 0 => {
+                std::thread::sleep(EVENT_SUBSCRIBER_FAILURE_RETRY_DELAY);
+            }
+            Err(e) => {
+                return Err(Error::Platform {
+                    code: e.code().0 as i64,
+                    message: e.to_string(),
+                })
+            }
+        }
+    }
 }
 
 /// Read a BSTR VARIANT property from the element's pre-fetched snapshot.
@@ -2562,6 +2590,78 @@ mod tests {
                 !is_event_subscriber_failure(&err),
                 "HRESULT 0x{code:08X} must not be classified as an event-subscriber failure"
             );
+        }
+    }
+
+    // ── uia_call retry behaviour (issue #257) ───────────────────────────────
+
+    fn subscriber_failure() -> windows::core::Error {
+        EVENT_E_ALL_SUBSCRIBERS_FAILED.ok().unwrap_err()
+    }
+
+    #[test]
+    fn uia_call_success_calls_once() {
+        let calls = std::cell::Cell::new(0u32);
+        let result = uia_call(|| {
+            calls.set(calls.get() + 1);
+            Ok(42)
+        });
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn uia_call_retries_event_subscriber_failure_then_succeeds() {
+        // Two transient 0x80040201 failures, then success — the query path
+        // must ride out the same Qt-UIA hiccup the action path tolerates.
+        let calls = std::cell::Cell::new(0u32);
+        let result = uia_call(|| {
+            calls.set(calls.get() + 1);
+            if calls.get() < EVENT_SUBSCRIBER_FAILURE_ATTEMPTS {
+                Err(subscriber_failure())
+            } else {
+                Ok("tree")
+            }
+        });
+        assert_eq!(result.unwrap(), "tree");
+        assert_eq!(calls.get(), EVENT_SUBSCRIBER_FAILURE_ATTEMPTS);
+    }
+
+    #[test]
+    fn uia_call_propagates_persistent_event_subscriber_failure() {
+        // If every attempt fails with 0x80040201, the error must still
+        // surface (no infinite retry, no silent swallow on the read path —
+        // unlike an action, a query has no value to return).
+        let calls = std::cell::Cell::new(0u32);
+        let result: Result<()> = uia_call(|| {
+            calls.set(calls.get() + 1);
+            Err(subscriber_failure())
+        });
+        assert_eq!(calls.get(), EVENT_SUBSCRIBER_FAILURE_ATTEMPTS);
+        match result {
+            Err(Error::Platform { code, .. }) => {
+                assert_eq!(code, EVENT_E_ALL_SUBSCRIBERS_FAILED.0 as i64);
+            }
+            other => panic!("expected Error::Platform, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn uia_call_does_not_retry_other_errors() {
+        let calls = std::cell::Cell::new(0u32);
+        let e_fail = windows::core::HRESULT(0x80004005u32 as i32);
+        let result: Result<()> = uia_call(|| {
+            calls.set(calls.get() + 1);
+            Err(e_fail.ok().unwrap_err())
+        });
+        assert_eq!(
+            calls.get(),
+            1,
+            "non-transient errors must fail on the first attempt"
+        );
+        match result {
+            Err(Error::Platform { code, .. }) => assert_eq!(code, e_fail.0 as i64),
+            other => panic!("expected Error::Platform, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
#169 taught the action paths (press/toggle/select) to tolerate the
transient 0x80040201 that Qt's UIA backend leaks through COM calls, but
the query/discovery path (find_all_subtree behind exists()/
wait_visible()/dump(), root window enumeration, etc.) still mapped it
straight to a fatal Error::Platform via uia_call.

Unlike an action — where the operation already completed and the error
can be swallowed — a query needs a value, so uia_call now retries the
call up to 3 times with a 50ms delay before propagating the error. All
other HRESULTs still fail on the first attempt.

Fixes #257

https://claude.ai/code/session_01Biev2EEzRimd9KCSZC3474