### PR TITLE
Robust app attach: PID-direct by_pid, attach diagnostics, macOS subscribe retry (#258)

### DIFF
--- a/xa11y-core/src/app.rs
+++ b/xa11y-core/src/app.rs
@@ -177,15 +177,30 @@ impl App {
     /// Find an application by process ID, using an explicit provider.
     ///
     /// Prefer `App::by_pid` from the `xa11y` crate which uses the global
-    /// singleton provider. See [`by_name_with`](Self::by_name_with) for the
-    /// timeout / polling semantics.
+    /// singleton provider.
+    ///
+    /// This is the supported way to **wait for a freshly launched process to
+    /// surface** in the accessibility tree: the lookup polls
+    /// [`Provider::app_by_pid`] until the application becomes reachable or
+    /// `timeout` elapses, covering the window between process spawn and the
+    /// platform bridge registering the app (slow CI runners, toolkits that
+    /// initialise accessibility lazily). There is no need to hand-roll a
+    /// poll over [`list_with`](Self::list_with).
+    ///
+    /// Timeout / polling semantics match [`by_name_with`](Self::by_name_with):
+    /// `Duration::ZERO` performs exactly one attempt, only
+    /// [`Error::SelectorNotMatched`] ("not reachable yet") triggers a retry,
+    /// and permission / platform errors short-circuit immediately.
+    ///
+    /// Where the platform supports it (macOS AX, Windows UIA), the provider
+    /// attaches to the process directly instead of filtering app enumeration,
+    /// so an app whose window is still unnamed mid-startup is found as soon
+    /// as the accessibility API can reach it.
     pub fn by_pid_with(provider: Arc<dyn Provider>, pid: u32, timeout: Duration) -> Result<Self> {
-        Self::find_matching(
-            provider,
-            timeout,
-            |d| Ok(d.pid == Some(pid)),
-            || format!("application with pid={}", pid),
-        )
+        poll_lookup(timeout, || {
+            let data = provider.app_by_pid(pid)?;
+            Ok(Self::from_data(Arc::clone(&provider), data))
+        })
     }
 
     /// List all running applications, using an explicit provider.

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -1,5 +1,5 @@
 use crate::element::ElementData;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::event_provider::Subscription;
 use crate::selector::{matches_simple, Combinator, Selector, SelectorGroup, SelectorSegment};
 
@@ -47,6 +47,39 @@ pub trait Provider: Send + Sync {
     /// profiles, and silently routing app discovery through `get_children`
     /// would hide the difference from implementors.
     fn list_apps(&self) -> Result<Vec<ElementData>>;
+
+    /// Find the application owning process `pid` — one attempt, no polling.
+    ///
+    /// This is the single-shot discovery primitive behind `App::by_pid`; the
+    /// core's lookup loop owns the retry/timeout policy. Returns
+    /// [`Error::SelectorNotMatched`] when no accessible application for `pid`
+    /// exists *yet* — the signal the poll loop retries on — and any other
+    /// error when the lookup itself failed (permissions, platform API
+    /// failure), which short-circuits the poll.
+    ///
+    /// The default implementation filters [`list_apps`](Self::list_apps) by
+    /// `pid`, and its not-matched error carries enumeration diagnostics (how
+    /// many apps were visible and how many had no resolvable pid) so a
+    /// timeout on an opaque CI runner says *why* the app was invisible.
+    /// Backends override this where the platform supports reaching a process
+    /// directly (`AXUIElementCreateApplication` on macOS, a UIA `ProcessId`
+    /// property search on Windows): direct attach is immune to enumeration
+    /// blind spots such as top-level windows that are still unnamed while the
+    /// app starts up.
+    fn app_by_pid(&self, pid: u32) -> Result<ElementData> {
+        let apps = self.list_apps()?;
+        let total = apps.len();
+        let unresolved = apps.iter().filter(|a| a.pid.is_none()).count();
+        if let Some(data) = apps.into_iter().find(|a| a.pid == Some(pid)) {
+            return Ok(data);
+        }
+        Err(Error::SelectorNotMatched {
+            selector: format!(
+                "application with pid={pid} (enumerated {total} running apps, \
+                 {unresolved} without a resolvable pid)"
+            ),
+        })
+    }
 
     /// Search for elements matching a selector.
     ///
@@ -256,6 +289,13 @@ impl<T: Provider + ?Sized> Provider for &T {
     }
     fn list_apps(&self) -> Result<Vec<ElementData>> {
         (**self).list_apps()
+    }
+    // Delegated explicitly (despite having a default impl) so a concrete
+    // provider's PID-direct override isn't bypassed when it's used through a
+    // shared reference — the default body on `&T` would re-route through
+    // `list_apps` and silently lose the override.
+    fn app_by_pid(&self, pid: u32) -> Result<ElementData> {
+        (**self).app_by_pid(pid)
     }
     fn find_elements(
         &self,

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -987,10 +987,15 @@ impl LinuxProvider {
         }
 
         // Fall back to Application.Id for adapters that set it to pid.
+        // Require that a process with that id actually exists — a registry
+        // index from a misbehaving bridge usually names a long-dead or absurd
+        // pid. This is only a cheap sanity filter: a low index can still
+        // collide with a real process (1 = init), which is why the D-Bus
+        // connection pid above is authoritative whenever available.
         if let Ok(proxy) = self.make_proxy(&aref.bus_name, &aref.path, "org.a11y.atspi.Application")
         {
             if let Ok(pid) = proxy.get_property::<i32>("Id") {
-                if pid > 0 {
+                if pid > 0 && std::path::Path::new(&format!("/proc/{pid}")).exists() {
                     return Some(pid as u32);
                 }
             }
@@ -1515,6 +1520,50 @@ impl Provider for LinuxProvider {
             .collect();
 
         Ok(results)
+    }
+
+    /// Find an application by pid directly against the AT-SPI registry.
+    ///
+    /// Differs from filtering `list_apps()` in two ways that matter for a
+    /// freshly launched process:
+    ///
+    /// * No empty-name filter — toolkits can register on the bus before the
+    ///   app name is set, and a pid match is precise enough on its own.
+    /// * The not-matched error reports how many registry entries were
+    ///   examined and how many had no resolvable pid (the misreported-pid
+    ///   bridge quirk `get_app_pid` documents), so a timeout on CI says why
+    ///   the app was invisible instead of just "not found".
+    fn app_by_pid(&self, pid: u32) -> Result<ElementData> {
+        let registry = AccessibleRef {
+            bus_name: "org.a11y.atspi.Registry".to_string(),
+            path: "/org/a11y/atspi/accessible/root".to_string(),
+        };
+        let children = self.get_atspi_children(&registry)?;
+
+        let mut total = 0usize;
+        let mut unresolved = 0usize;
+        for child in children.iter().filter(|c| c.path != "/org/a11y/atspi/null") {
+            total += 1;
+            match self.get_app_pid(child) {
+                Some(p) if p == pid => {
+                    let mut data = self.build_element_data(child, Some(p));
+                    // Mirror list_apps: prefer the registry-reported name.
+                    let name = self.get_name(child).unwrap_or_default();
+                    if !name.is_empty() {
+                        data.name = Some(name);
+                    }
+                    return Ok(data);
+                }
+                Some(_) => {}
+                None => unresolved += 1,
+            }
+        }
+        Err(Error::SelectorNotMatched {
+            selector: format!(
+                "application with pid={pid} ({total} AT-SPI registry entries examined, \
+                 {unresolved} without a resolvable pid)"
+            ),
+        })
     }
 
     fn press(&self, element: &ElementData) -> Result<()> {

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use core_foundation::base::TCFType;
 use core_foundation::number::CFNumber;
@@ -27,7 +27,11 @@ type CFArrayRef = *const c_void;
 type CFIndex = isize;
 
 const AX_ERROR_SUCCESS: i32 = 0;
+const AX_ERROR_INVALID_UI_ELEMENT: i32 = -25202;
+const AX_ERROR_CANNOT_COMPLETE: i32 = -25204;
 const AX_ERROR_ACTION_UNSUPPORTED: i32 = -25206;
+const AX_ERROR_NOT_IMPLEMENTED: i32 = -25208;
+const AX_ERROR_NO_VALUE: i32 = -25212;
 const AX_VALUE_CGPOINT: i32 = 1;
 const AX_VALUE_CGSIZE: i32 = 2;
 const CF_NUMBER_FLOAT64: i32 = 13;
@@ -2014,6 +2018,75 @@ impl Provider for MacOSProvider {
         Ok(results)
     }
 
+    /// Attach to an application directly by pid via
+    /// `AXUIElementCreateApplication` — no window enumeration involved.
+    ///
+    /// `list_apps()` discovers apps through CGWindowList, which only sees
+    /// processes that already own a window with a non-empty owner name (and
+    /// needs Screen Recording permission to read names). During app startup
+    /// none of that holds yet, so a freshly launched process can be
+    /// AX-reachable while still invisible to enumeration. Direct attach
+    /// avoids that blind spot entirely.
+    ///
+    /// `AXUIElementCreateApplication` succeeds for *any* pid without checking
+    /// the process, so reachability is probed by reading `AXRole`. AXError
+    /// codes that mean "not reachable (yet)" — the process is still
+    /// launching, has exited, or doesn't implement the AX API — map to
+    /// `SelectorNotMatched` so the core poll loop keeps retrying until its
+    /// deadline; anything else is a genuine platform failure and
+    /// short-circuits.
+    fn app_by_pid(&self, pid: u32) -> Result<ElementData> {
+        let app_element = AXElement::from_owned(unsafe { safe_ax_create_application(pid as i32) });
+        if app_element.is_null() {
+            return Err(Error::SelectorNotMatched {
+                selector: format!(
+                    "application with pid={pid} (AXUIElementCreateApplication returned NULL)"
+                ),
+            });
+        }
+        let attr = CFString::new("AXRole");
+        let mut value: CFTypeRef = std::ptr::null();
+        let err = ffi_copy_attribute_value(
+            app_element.as_ptr(),
+            attr.as_concrete_TypeRef() as CFTypeRef,
+            &mut value,
+        );
+        match err {
+            AX_ERROR_SUCCESS => {
+                if !value.is_null() {
+                    unsafe { safe_cf_release(value) };
+                }
+                let mut data = self.build_element_data(&app_element, Some(pid));
+                // Keep `name` consistent with `list_apps()`, which overrides
+                // the AX-reported name with the CGWindowList owner name. A
+                // pre-window process has no CGWindowList entry yet; the
+                // AX-reported name from build_element_data then stands.
+                if let Some((_, name)) = Self::list_gui_apps()
+                    .into_iter()
+                    .find(|(p, _)| *p == pid as i32)
+                {
+                    data.name = Some(name);
+                }
+                Ok(data)
+            }
+            AX_ERROR_CANNOT_COMPLETE
+            | AX_ERROR_INVALID_UI_ELEMENT
+            | AX_ERROR_NOT_IMPLEMENTED
+            | AX_ERROR_NO_VALUE => Err(Error::SelectorNotMatched {
+                selector: format!(
+                    "application with pid={pid} (AX attach probe returned AXError {err}: \
+                     process not yet AX-reachable, exited, or has no accessibility bridge)"
+                ),
+            }),
+            _ => Err(Error::Platform {
+                code: err as i64,
+                message: format!(
+                    "AXUIElementCopyAttributeValue(AXRole) failed while attaching to pid {pid}"
+                ),
+            }),
+        }
+    }
+
     // ── Common actions ──────────────────────────────────────────────
 
     fn press(&self, element: &ElementData) -> Result<()> {
@@ -2370,6 +2443,53 @@ unsafe extern "C" fn ax_observer_callback(
     }
 }
 
+/// How long `subscribe()` keeps retrying transient `AXObserverAddNotification`
+/// failures while the target app finishes launching, and the pause between
+/// attempts. Cold CI runners can enumerate an app that still answers
+/// `kAXErrorCannotComplete` for a moment; 2s comfortably covers that window
+/// without masking a genuinely broken target for long.
+const SUBSCRIBE_REGISTER_RETRY_BUDGET: Duration = Duration::from_secs(2);
+const SUBSCRIBE_REGISTER_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
+/// One pass of `AXObserverAddNotification` over `notifications`. On the first
+/// failure, rolls back the registrations made so far — so the observer holds
+/// no registrations referencing `ctx_ptr` when the caller frees it — and
+/// returns the failing AXError together with the notification name. Removal
+/// results during rollback are deliberately ignored: this is already an error
+/// path and the registration failure is the error the caller acts on.
+fn register_notifications(
+    observer: CFTypeRef,
+    app_element: AXUIElementRef,
+    ctx_ptr: *mut c_void,
+    notifications: &[&'static str],
+) -> std::result::Result<(), (i32, &'static str)> {
+    for (idx, notif) in notifications.iter().enumerate() {
+        let name = CFString::new(notif);
+        let err = unsafe {
+            safe_ax_observer_add_notification(
+                observer,
+                app_element,
+                name.as_concrete_TypeRef() as CFTypeRef,
+                ctx_ptr,
+            )
+        };
+        if err != AX_ERROR_SUCCESS {
+            for added in &notifications[..idx] {
+                let added_name = CFString::new(added);
+                let _ = unsafe {
+                    safe_ax_observer_remove_notification(
+                        observer,
+                        app_element,
+                        added_name.as_concrete_TypeRef() as CFTypeRef,
+                    )
+                };
+            }
+            return Err((err, notif));
+        }
+    }
+    Ok(())
+}
+
 impl MacOSProvider {
     fn subscribe_impl(&self, pid: i32, app_name: String) -> Result<Subscription> {
         let (tx, rx) = std::sync::mpsc::channel();
@@ -2422,49 +2542,46 @@ impl MacOSProvider {
         ];
 
         // Register every notification, failing the whole subscribe on the
-        // first error (tenet 1): a partially-registered observer would
-        // silently never deliver the missing event kinds. Mirrors the
+        // first persistent error (tenet 1): a partially-registered observer
+        // would silently never deliver the missing event kinds. Mirrors the
         // Windows backend's AddAutomationEventHandler rollback.
-        for (idx, notif) in notifications.iter().enumerate() {
-            let name = CFString::new(notif);
-            let err = unsafe {
-                safe_ax_observer_add_notification(
-                    observer,
-                    app_element,
-                    name.as_concrete_TypeRef() as CFTypeRef,
-                    ctx_ptr,
-                )
-            };
-            if err != AX_ERROR_SUCCESS {
-                // Roll back the notifications registered so far so the
-                // observer holds no registrations referencing `ctx_ptr`
-                // when we free it below. Removal results are deliberately
-                // ignored: this is already an error path and the original
-                // registration failure is the error we surface.
-                for added in &notifications[..idx] {
-                    let added_name = CFString::new(added);
-                    let _ = unsafe {
-                        safe_ax_observer_remove_notification(
-                            observer,
-                            app_element,
-                            added_name.as_concrete_TypeRef() as CFTypeRef,
-                        )
-                    };
+        //
+        // A freshly launched app can be enumerable yet still answer
+        // kAXErrorCannotComplete / kAXErrorInvalidUIElement while its AX
+        // bridge finishes initialising (cold CI runners especially). Those
+        // codes are transient "not ready yet" signals, so registration is
+        // retried as a whole — each failed attempt rolls back its partial
+        // registrations inside `register_notifications` — until
+        // SUBSCRIBE_REGISTER_RETRY_BUDGET elapses. This is an explicit,
+        // bounded retry of the same mechanism, not a fallback: on exhaustion
+        // the original AXError is surfaced unchanged.
+        let retry_start = Instant::now();
+        loop {
+            match register_notifications(observer, app_element, ctx_ptr, &notifications) {
+                Ok(()) => break,
+                Err((err, _))
+                    if matches!(err, AX_ERROR_CANNOT_COMPLETE | AX_ERROR_INVALID_UI_ELEMENT)
+                        && retry_start.elapsed() < SUBSCRIBE_REGISTER_RETRY_BUDGET =>
+                {
+                    std::thread::sleep(SUBSCRIBE_REGISTER_RETRY_INTERVAL);
                 }
-                // Release everything this function owns so far: `app_element`
-                // (released after the loop on the success path), `observer`,
-                // and the leaked `ObserverContext` box. We return before the
-                // success-path release / CancelHandle ownership transfer, so
-                // nothing is double-released.
-                unsafe {
-                    safe_cf_release(app_element);
-                    safe_cf_release(observer);
-                    drop(Box::from_raw(ctx_ptr as *mut ObserverContext));
+                Err((err, notif)) => {
+                    // Release everything this function owns so far:
+                    // `app_element` (released after the loop on the success
+                    // path), `observer`, and the leaked `ObserverContext`
+                    // box. We return before the success-path release /
+                    // CancelHandle ownership transfer, so nothing is
+                    // double-released.
+                    unsafe {
+                        safe_cf_release(app_element);
+                        safe_cf_release(observer);
+                        drop(Box::from_raw(ctx_ptr as *mut ObserverContext));
+                    }
+                    return Err(Error::Platform {
+                        code: err as i64,
+                        message: format!("AXObserverAddNotification({notif}) failed"),
+                    });
                 }
-                return Err(Error::Platform {
-                    code: err as i64,
-                    message: format!("AXObserverAddNotification({notif}) failed"),
-                });
             }
         }
 

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -136,10 +136,27 @@ class App:
         """
     @staticmethod
     def by_pid(pid: int, *, timeout: float = 5.0) -> App:
-        """Find an application by process ID. See ``by_name`` for ``timeout``."""
+        """Find an application by process ID.
+
+        This is the supported way to *wait* for a freshly launched process
+        to surface in the accessibility tree: the lookup polls until the app
+        becomes reachable through the platform bridge or ``timeout``
+        (seconds) elapses, covering the gap between the process starting and
+        its accessibility registration completing. There is no need to
+        hand-roll a poll over ``App.list()``. Where the platform supports it
+        (macOS AX, Windows UIA), the lookup attaches to the process directly
+        instead of filtering app enumeration, so an app whose window is
+        still unnamed mid-startup is found as soon as the accessibility API
+        can reach it. See ``by_name`` for ``timeout`` semantics.
+        """
     @staticmethod
     def list() -> list[App]:
-        """List all running applications."""
+        """List all running applications.
+
+        Single enumeration, no polling. To wait for an app that is still
+        starting up, use ``by_pid`` / ``by_name`` / ``find`` with a
+        ``timeout`` instead of polling this in a loop.
+        """
     def locator(self, selector: str) -> Locator:
         """Create a Locator scoped to this application's accessibility tree."""
     def subscribe(self) -> Subscription:

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -1074,6 +1074,19 @@ impl App {
 
     /// Find an application by process ID.
     ///
+    /// This is the supported way to *wait* for a freshly launched process to
+    /// surface in the accessibility tree: the lookup polls until the app
+    /// becomes reachable through the platform bridge or `timeout` (in
+    /// seconds) elapses, covering the gap between the process starting and
+    /// its accessibility registration completing (slow CI runners, toolkits
+    /// that initialise accessibility lazily). There is no need to hand-roll
+    /// a poll over `App.list()`.
+    ///
+    /// Where the platform supports it (macOS AX, Windows UIA), the lookup
+    /// attaches to the process directly instead of filtering app
+    /// enumeration, so an app whose window is still unnamed mid-startup is
+    /// found as soon as the accessibility API can reach it.
+    ///
     /// See [`by_name`] for `timeout` semantics.
     #[staticmethod]
     #[pyo3(signature = (pid, *, timeout=5.0))]
@@ -1087,6 +1100,10 @@ impl App {
     }
 
     /// List all running applications.
+    ///
+    /// Single enumeration, no polling. To wait for an app that is still
+    /// starting up, use `by_pid` / `by_name` / `find` with a `timeout`
+    /// instead of polling this in a loop.
     #[staticmethod]
     fn list(py: Python<'_>) -> PyResult<Vec<Self>> {
         let provider = get_provider()?;

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -677,6 +677,54 @@ impl Provider for WindowsProvider {
         self.get_children(None)
     }
 
+    /// Attach to an application directly by pid via a UIA `ProcessId`
+    /// property search over the desktop root's children.
+    ///
+    /// `list_apps()` enumerates desktop-root children of control type
+    /// `Window` and skips windows whose name is still empty — which is
+    /// exactly the state a freshly launched app's top-level window is in
+    /// while the process boots. Matching on the pid property alone closes
+    /// that blind spot: any top-level element owned by the process counts,
+    /// named or not.
+    fn app_by_pid(&self, pid: u32) -> Result<ElementData> {
+        let root = uia_call(|| unsafe { self.automation.GetRootElement() })?;
+        let condition = uia_call(|| unsafe {
+            self.automation
+                .CreatePropertyCondition(UIA_ProcessIdPropertyId, &VARIANT::from(pid as i32))
+        })?;
+        // FindFirstBuildCache returns S_OK with a null element when nothing
+        // matches; windows-rs surfaces that null as an `Err` carrying the
+        // S_OK HRESULT. That case is "process not in the UIA tree yet" —
+        // SelectorNotMatched, so the core poll loop retries — while a
+        // failing HRESULT is a genuine UIA error and short-circuits.
+        let el = match unsafe {
+            root.FindFirstBuildCache(TreeScope_Children, &condition, &self.batch_request)
+        } {
+            Ok(el) => el,
+            Err(e) if e.code().is_ok() => {
+                return Err(Error::SelectorNotMatched {
+                    selector: format!(
+                        "application with pid={pid} (no top-level UIA element owned by the \
+                         process yet)"
+                    ),
+                });
+            }
+            Err(e) => {
+                return Err(Error::Platform {
+                    code: e.code().0 as i64,
+                    message: format!("FindFirstBuildCache(ProcessId={pid}) failed: {e}"),
+                });
+            }
+        };
+        // Mirror get_children(None): re-acquire via HWND to activate
+        // AccessKit's UIA provider, then repopulate the property snapshot.
+        let el = self
+            .reacquire_via_hwnd(&el)
+            .and_then(|e| self.populate_cache(&e).map_err(|_| ()))
+            .unwrap_or(el);
+        Ok(self.build_element_data(&el, Some(pid)))
+    }
+
     /// Override the default `narrow_multi_segment` so that the Descendant
     /// combinator uses `find_elements_in_tree` (tree-walking via `get_children`)
     /// rather than `self.find_elements` (which would invoke `find_all_subtree`).

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -248,8 +248,14 @@ mod app_ext {
         /// [`App::by_name_with`] for retry semantics.
         fn by_name(name: &str, timeout: Duration) -> Result<Self>;
         /// Find an application by process ID using the global singleton
-        /// provider, polling until it appears or `timeout` elapses. See
-        /// [`by_name`](Self::by_name) for retry semantics.
+        /// provider, polling until it appears or `timeout` elapses.
+        ///
+        /// This is the supported way to wait for a freshly launched process
+        /// to surface in the accessibility tree — the poll covers the window
+        /// between process spawn and the platform bridge registering the
+        /// app, so callers don't need a hand-rolled loop over
+        /// [`list`](Self::list). See [`App::by_pid_with`] for the full
+        /// contract and [`by_name`](Self::by_name) for retry semantics.
         fn by_pid(pid: u32, timeout: Duration) -> Result<Self>;
         /// List all running applications using the global singleton provider.
         fn list() -> Result<Vec<Self>>;

--- a/xa11y/tests/integ/tree.rs
+++ b/xa11y/tests/integ/tree.rs
@@ -11,7 +11,7 @@ mod tests {
     use xa11y::*;
 
     // ════════════════════════════════════════════════════════════════
-    // Provider Operations (2 tests)
+    // Provider Operations (4 tests)
     // ════════════════════════════════════════════════════════════════
 
     #[test]
@@ -34,6 +34,37 @@ mod tests {
             "apps should include the test app. Apps: {:?}",
             apps.iter().map(|a| &a.name).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    #[ignore]
+    fn app_by_pid_attaches_to_running_app() {
+        // Exercises each backend's PID-direct attach path (AX on macOS, UIA
+        // ProcessId search on Windows, AT-SPI registry match on Linux).
+        let app = h::app_root();
+        let pid = app.pid.expect("test app should report a pid");
+        let by_pid = App::by_pid(pid, std::time::Duration::from_secs(2))
+            .unwrap_or_else(|e| panic!("by_pid({pid}) failed for a running app: {e}"));
+        assert_eq!(by_pid.pid, Some(pid));
+    }
+
+    #[test]
+    #[ignore]
+    fn app_by_pid_unknown_pid_is_selector_not_matched() {
+        // A pid that can't belong to a running process: not-attached must
+        // surface as SelectorNotMatched (the retryable "not found" signal),
+        // never as a platform error, and the diagnostic must name the pid.
+        let result = App::by_pid(999_999_999, std::time::Duration::ZERO);
+        match result {
+            Ok(_) => panic!("by_pid for a nonexistent process must fail"),
+            Err(Error::SelectorNotMatched { selector }) => {
+                assert!(
+                    selector.contains("pid=999999999"),
+                    "diagnostic should name the pid, got: {selector}"
+                );
+            }
+            Err(e) => panic!("expected SelectorNotMatched, got: {e}"),
+        }
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -1451,3 +1451,257 @@ fn by_pid_with_polls_until_app_appears() {
     assert_eq!(app.pid, Some(100));
     assert!(p.root_call_count() > 2);
 }
+
+// ── Provider::app_by_pid routing ─────────────────────────────────────────────
+
+/// Wrapper whose `app_by_pid` override is injected by the test, mimicking a
+/// backend with a PID-direct attach path (macOS AX / Windows UIA).
+/// `list_apps` deliberately returns an empty list so a lookup that wrongly
+/// routes through enumeration can never match.
+struct AppByPidOverrideProvider {
+    inner: Arc<dyn Provider>,
+    app_by_pid_calls: std::sync::atomic::AtomicUsize,
+    on_app_by_pid: Box<dyn Fn(u32) -> Result<ElementData> + Send + Sync>,
+}
+
+impl Provider for AppByPidOverrideProvider {
+    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
+        self.inner.get_children(element)
+    }
+    fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {
+        self.inner.get_parent(element)
+    }
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        Ok(vec![])
+    }
+    fn app_by_pid(&self, pid: u32) -> Result<ElementData> {
+        self.app_by_pid_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        (self.on_app_by_pid)(pid)
+    }
+    fn press(&self, e: &ElementData) -> Result<()> {
+        self.inner.press(e)
+    }
+    fn focus(&self, e: &ElementData) -> Result<()> {
+        self.inner.focus(e)
+    }
+    fn blur(&self, e: &ElementData) -> Result<()> {
+        self.inner.blur(e)
+    }
+    fn toggle(&self, e: &ElementData) -> Result<()> {
+        self.inner.toggle(e)
+    }
+    fn select(&self, e: &ElementData) -> Result<()> {
+        self.inner.select(e)
+    }
+    fn expand(&self, e: &ElementData) -> Result<()> {
+        self.inner.expand(e)
+    }
+    fn collapse(&self, e: &ElementData) -> Result<()> {
+        self.inner.collapse(e)
+    }
+    fn show_menu(&self, e: &ElementData) -> Result<()> {
+        self.inner.show_menu(e)
+    }
+    fn increment(&self, e: &ElementData) -> Result<()> {
+        self.inner.increment(e)
+    }
+    fn decrement(&self, e: &ElementData) -> Result<()> {
+        self.inner.decrement(e)
+    }
+    fn scroll_into_view(&self, e: &ElementData) -> Result<()> {
+        self.inner.scroll_into_view(e)
+    }
+    fn set_value(&self, e: &ElementData, v: &str) -> Result<()> {
+        self.inner.set_value(e, v)
+    }
+    fn set_numeric_value(&self, e: &ElementData, v: f64) -> Result<()> {
+        self.inner.set_numeric_value(e, v)
+    }
+    fn type_text(&self, e: &ElementData, t: &str) -> Result<()> {
+        self.inner.type_text(e, t)
+    }
+    fn set_text_selection(&self, e: &ElementData, s: u32, en: u32) -> Result<()> {
+        self.inner.set_text_selection(e, s, en)
+    }
+    fn perform_action(&self, e: &ElementData, a: &str) -> Result<()> {
+        self.inner.perform_action(e, a)
+    }
+    fn subscribe(&self, e: &ElementData) -> Result<Subscription> {
+        self.inner.subscribe(e)
+    }
+}
+
+#[test]
+fn by_pid_with_routes_through_provider_app_by_pid() {
+    let inner = multi_app_provider();
+    let app1 = inner.list_apps().expect("mock list_apps")[0].clone();
+    assert_eq!(app1.pid, Some(100), "fixture: App1 has pid 100");
+    let p = Arc::new(AppByPidOverrideProvider {
+        inner,
+        app_by_pid_calls: std::sync::atomic::AtomicUsize::new(0),
+        on_app_by_pid: Box::new(move |pid| {
+            if pid == 100 {
+                Ok(app1.clone())
+            } else {
+                Err(Error::SelectorNotMatched {
+                    selector: format!("application with pid={pid}"),
+                })
+            }
+        }),
+    });
+    // list_apps returns nothing, so success proves the lookup consulted the
+    // provider's app_by_pid override rather than filtering enumeration.
+    let app = App::by_pid_with(
+        Arc::clone(&p) as Arc<dyn Provider>,
+        100,
+        std::time::Duration::ZERO,
+    )
+    .expect("PID-direct override should resolve the app");
+    assert_eq!(app.pid, Some(100));
+    assert_eq!(
+        p.app_by_pid_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+}
+
+#[test]
+fn by_pid_with_short_circuits_on_app_by_pid_platform_error() {
+    let p = Arc::new(AppByPidOverrideProvider {
+        inner: multi_app_provider(),
+        app_by_pid_calls: std::sync::atomic::AtomicUsize::new(0),
+        on_app_by_pid: Box::new(|_| {
+            Err(Error::Platform {
+                code: -25211,
+                message: "accessibility API disabled".to_string(),
+            })
+        }),
+    });
+    let start = std::time::Instant::now();
+    let result = App::by_pid_with(
+        Arc::clone(&p) as Arc<dyn Provider>,
+        100,
+        std::time::Duration::from_secs(10),
+    );
+    assert!(matches!(result, Err(Error::Platform { .. })));
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(1),
+        "platform error must fail fast, took {:?}",
+        start.elapsed()
+    );
+    assert_eq!(
+        p.app_by_pid_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "non-retryable error must not be retried"
+    );
+}
+
+/// Wrapper that adds a "ghost" app with no resolvable pid to the inner
+/// provider's enumeration — models the AT-SPI bridge quirk where an app's
+/// pid can't be determined.
+struct GhostAppProvider {
+    inner: Arc<dyn Provider>,
+}
+
+impl Provider for GhostAppProvider {
+    fn get_children(&self, element: Option<&ElementData>) -> Result<Vec<ElementData>> {
+        self.inner.get_children(element)
+    }
+    fn get_parent(&self, element: &ElementData) -> Result<Option<ElementData>> {
+        self.inner.get_parent(element)
+    }
+    fn list_apps(&self) -> Result<Vec<ElementData>> {
+        let mut apps = self.inner.list_apps()?;
+        let mut ghost = apps[0].clone();
+        ghost.name = Some("Ghost".to_string());
+        ghost.pid = None;
+        apps.push(ghost);
+        Ok(apps)
+    }
+    fn press(&self, e: &ElementData) -> Result<()> {
+        self.inner.press(e)
+    }
+    fn focus(&self, e: &ElementData) -> Result<()> {
+        self.inner.focus(e)
+    }
+    fn blur(&self, e: &ElementData) -> Result<()> {
+        self.inner.blur(e)
+    }
+    fn toggle(&self, e: &ElementData) -> Result<()> {
+        self.inner.toggle(e)
+    }
+    fn select(&self, e: &ElementData) -> Result<()> {
+        self.inner.select(e)
+    }
+    fn expand(&self, e: &ElementData) -> Result<()> {
+        self.inner.expand(e)
+    }
+    fn collapse(&self, e: &ElementData) -> Result<()> {
+        self.inner.collapse(e)
+    }
+    fn show_menu(&self, e: &ElementData) -> Result<()> {
+        self.inner.show_menu(e)
+    }
+    fn increment(&self, e: &ElementData) -> Result<()> {
+        self.inner.increment(e)
+    }
+    fn decrement(&self, e: &ElementData) -> Result<()> {
+        self.inner.decrement(e)
+    }
+    fn scroll_into_view(&self, e: &ElementData) -> Result<()> {
+        self.inner.scroll_into_view(e)
+    }
+    fn set_value(&self, e: &ElementData, v: &str) -> Result<()> {
+        self.inner.set_value(e, v)
+    }
+    fn set_numeric_value(&self, e: &ElementData, v: f64) -> Result<()> {
+        self.inner.set_numeric_value(e, v)
+    }
+    fn type_text(&self, e: &ElementData, t: &str) -> Result<()> {
+        self.inner.type_text(e, t)
+    }
+    fn set_text_selection(&self, e: &ElementData, s: u32, en: u32) -> Result<()> {
+        self.inner.set_text_selection(e, s, en)
+    }
+    fn perform_action(&self, e: &ElementData, a: &str) -> Result<()> {
+        self.inner.perform_action(e, a)
+    }
+    fn subscribe(&self, e: &ElementData) -> Result<Subscription> {
+        self.inner.subscribe(e)
+    }
+}
+
+#[test]
+fn by_pid_timeout_reports_enumeration_diagnostics() {
+    // The default app_by_pid goes through list_apps; on a miss, the error
+    // must say how many apps were visible and how many had no resolvable
+    // pid, so a CI timeout is diagnosable from the message alone.
+    let p = Arc::new(GhostAppProvider {
+        inner: multi_app_provider(),
+    });
+    let err = match App::by_pid_with(
+        Arc::clone(&p) as Arc<dyn Provider>,
+        999,
+        std::time::Duration::ZERO,
+    ) {
+        Ok(_) => panic!("lookup for an unknown pid must fail"),
+        Err(e) => e,
+    };
+    match err {
+        Error::SelectorNotMatched { selector } => {
+            assert!(
+                selector.contains("pid=999"),
+                "diagnostic should name the pid, got: {selector}"
+            );
+            assert!(
+                selector.contains("3 running apps"),
+                "diagnostic should report enumeration size, got: {selector}"
+            );
+            assert!(
+                selector.contains("1 without a resolvable pid"),
+                "diagnostic should count unresolved pids, got: {selector}"
+            );
+        }
+        other => panic!("expected SelectorNotMatched, got {other:?}"),
+    }
+}


### PR DESCRIPTION
App.by_pid(pid, timeout) is now the first-class robust-attach primitive
the issue asks for. The poll loop already covered "process exists but
the bridge hasn't registered it yet", but discovery itself was blind
during app startup because every backend routed through window/registry
enumeration. Addressed by a new Provider::app_by_pid primitive:

- Core: Provider::app_by_pid (default: filter list_apps with
  enumeration diagnostics in the not-matched error), App::by_pid_with
  polls it, contract documented in Rust/Python/JS-visible docs.
- macOS: attach directly via AXUIElementCreateApplication + AXRole
  reachability probe — no CGWindowList dependency, works pre-window and
  without Screen Recording permission. Launch-transient AXError codes
  map to SelectorNotMatched so the poll loop retries.
- Windows: UIA ProcessId property search over desktop-root children —
  no Window control-type or non-empty-name requirement, so a still
  unnamed top-level window mid-startup is found.
- Linux: AT-SPI registry match without the empty-name filter, with
  diagnostics counting entries whose pid can't be resolved; the
  Application.Id fallback now requires the process to exist (registry
  index misreport quirk, e.g. "pid 1").
- macOS subscribe: bounded (2s) explicit retry of notification
  registration on kAXErrorCannotComplete / kAXErrorInvalidUIElement so
  the #256 strictness doesn't make cold-runner attach less tolerant;
  the original AXError still surfaces on exhaustion.

Unit tests cover override routing, fail-fast on platform errors, and
the diagnostics message; integration tests exercise each backend's
PID-direct path and the unknown-pid contract.

https://claude.ai/code/session_0156zEuczrueox4CwY9ThGdb