### PR TITLE
Add global default-timeout override (set_default_timeout / XA11Y_DEFAULT_TIMEOUT)

### DIFF
--- a/bindings/parity_allowlist.toml
+++ b/bindings/parity_allowlist.toml
@@ -31,7 +31,7 @@ rust_only = [
     { method = "Subscription::new", reason = "Internal Rust constructor; bindings create Subscriptions via App.subscribe() / Element.subscribe()." },
 
     # ── Wait / event-loop idiom differences ───────────────────────────────
-    { method = "Locator::with_timeout", reason = "Rust Locator uses builder-set default timeout; Python uses per-call timeout parameters on every wait_* / action method instead." },
+    { method = "Locator::with_timeout", reason = "Rust-only builder for a per-locator timeout override; Python uses per-call timeout parameters on every wait_* method plus the process-wide set_default_timeout() instead." },
     { method = "Locator::wait_for_state", reason = "Rust generic state-enum wait; Python exposes specific wait_visible/wait_enabled/etc. plus predicate-based wait_until." },
     { method = "Subscription::recv_status", reason = "Rust explicit disconnected-vs-timeout polling variant; Python uses predicate-based wait_for over typed Event receiver." },
     { method = "Subscription::iter", reason = "Python exposes __iter__/__next__ context-manager idiom instead of an explicit blocking iterator." },
@@ -98,7 +98,7 @@ rust_only = [
     { method = "Subscription::new", reason = "Internal Rust constructor; bindings create Subscriptions via App.subscribe() / Element.subscribe()." },
 
     # ── Wait / event-loop idiom differences ───────────────────────────────
-    { method = "Locator::with_timeout", reason = "Rust Locator uses builder-set default timeout; JS uses per-call timeout option on every wait* / action method instead." },
+    { method = "Locator::with_timeout", reason = "Rust-only builder for a per-locator timeout override; JS uses per-call timeout options on every wait* method plus the process-wide setDefaultTimeout() instead." },
     { method = "Locator::wait_for_state", reason = "Rust generic state-enum wait; JS exposes specific wait* helpers plus predicate-based waitUntil." },
     { method = "Subscription::recv_status", reason = "Rust explicit disconnected-vs-timeout polling variant; JS uses predicate-based waitFor and EventEmitter model over blocking recv." },
     { method = "Subscription::try_recv", reason = "JS exposes async EventEmitter + `start`/`drain` worker pattern instead of blocking recv/try_recv." },

--- a/docs/site/src/content/docs/guides/desktop-testing.mdx
+++ b/docs/site/src/content/docs/guides/desktop-testing.mdx
@@ -23,6 +23,24 @@ Desktop UIs update asynchronously. After pressing a button, the result might not
 
 Always use waits instead of sleeping — they're faster (resolve as soon as the condition is met) and more reliable (won't flake on slow machines).
 
+### The default timeout
+
+Auto-waiting action methods (`press()`, `set_value()`, …), the `wait_*()` family, and app lookup (`App.by_name` / `App.by_pid`) all share one process-wide default timeout: **5 seconds**. When that's too tight — cold CI runners are the classic case — raise it once instead of threading `timeout=` through every call site:
+
+```python
+xa11y.set_default_timeout(30.0)        # Python (seconds)
+```
+
+```js
+setDefaultTimeout(30);                 // JavaScript (seconds)
+```
+
+```rust
+xa11y::set_default_timeout(Duration::from_secs(30));   // Rust
+```
+
+Or set the `XA11Y_DEFAULT_TIMEOUT` environment variable (seconds, read once at startup). Resolution order: an explicit per-call `timeout=` always wins, then the programmatic `set_default_timeout()` value, then the environment variable, then the built-in 5 seconds. A timeout of `0` means a single attempt with no polling.
+
 ## Example: testing a calculator
 
 This test opens Calculator, performs `7 × 8`, and asserts the result is `56`.
@@ -188,4 +206,4 @@ See the [Overview](/guides/overview/#cli) for the full CLI reference.
 - **Be specific with selectors.** `button[name='7']` is better than `button` — it won't break when the UI adds more buttons.
 - **Use locators, not elements, for interactions.** Locators re-resolve their selector on every operation, making them resilient to UI changes.
 - **Prefer `wait_until` for complex assertions.** Instead of sleeping then asserting, combine the wait and the condition — the test passes as soon as the UI is ready.
-- **Keep timeouts generous in CI.** CI machines are slower. Use 5–10 seconds for waits even if your local machine resolves in milliseconds.
+- **Keep timeouts generous in CI.** CI machines are slower. Use 5–10 seconds for waits even if your local machine resolves in milliseconds — or raise the process-wide default once with `set_default_timeout()` / `XA11Y_DEFAULT_TIMEOUT` instead of touching every call site.

--- a/xa11y-core/src/config.rs
+++ b/xa11y-core/src/config.rs
@@ -1,0 +1,195 @@
+//! Process-wide configuration.
+//!
+//! Holds the global **default timeout** used wherever an operation waits but
+//! the caller did not pass an explicit timeout: `Locator` auto-wait before
+//! action methods, and the language bindings' `wait_*` / app-lookup defaults.
+//!
+//! Resolution order (first match wins):
+//! 1. An explicit per-call timeout (`Locator::with_timeout`, a `timeout=`
+//!    argument in the bindings).
+//! 2. The programmatic global set via [`set_default_timeout`].
+//! 3. The `XA11Y_DEFAULT_TIMEOUT` environment variable (seconds, e.g. `30`
+//!    or `2.5`), read and parsed once on first use.
+//! 4. The built-in default of 5 seconds.
+//!
+//! An invalid `XA11Y_DEFAULT_TIMEOUT` value is an error
+//! ([`Error::InvalidConfig`]), not a silent fall-through to the built-in
+//! default — see the "no silent fallbacks" design tenet.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+
+/// Environment variable holding the default timeout in seconds.
+///
+/// Read once, on the first call to [`default_timeout`] — later changes to the
+/// process environment have no effect.
+pub const DEFAULT_TIMEOUT_ENV_VAR: &str = "XA11Y_DEFAULT_TIMEOUT";
+
+/// Built-in default used when neither [`set_default_timeout`] nor
+/// [`DEFAULT_TIMEOUT_ENV_VAR`] provides a value.
+const BUILTIN_DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Programmatic override set by [`set_default_timeout`]. Takes precedence
+/// over the environment variable.
+static PROGRAMMATIC_DEFAULT: Mutex<Option<Duration>> = Mutex::new(None);
+
+/// Memoized result of reading [`DEFAULT_TIMEOUT_ENV_VAR`]:
+/// `Ok(None)` = unset, `Ok(Some(_))` = parsed value, `Err(_)` = present but
+/// invalid (the message is replayed on every `default_timeout()` call).
+static ENV_DEFAULT: OnceLock<std::result::Result<Option<Duration>, String>> = OnceLock::new();
+
+/// Parse a timeout value in seconds (`"30"`, `"2.5"`, `"0"`).
+fn parse_timeout_secs(raw: &str) -> std::result::Result<Duration, String> {
+    let secs: f64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("expected a number of seconds, got {raw:?}"))?;
+    if !secs.is_finite() || secs < 0.0 {
+        return Err(format!(
+            "expected a finite, non-negative number of seconds, got {raw:?}"
+        ));
+    }
+    Ok(Duration::from_secs_f64(secs))
+}
+
+fn env_default() -> std::result::Result<Option<Duration>, String> {
+    ENV_DEFAULT
+        .get_or_init(|| match std::env::var(DEFAULT_TIMEOUT_ENV_VAR) {
+            Ok(raw) => parse_timeout_secs(&raw)
+                .map(Some)
+                .map_err(|msg| format!("{DEFAULT_TIMEOUT_ENV_VAR}: {msg}")),
+            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(std::env::VarError::NotUnicode(_)) => Err(format!(
+                "{DEFAULT_TIMEOUT_ENV_VAR}: value is not valid Unicode"
+            )),
+        })
+        .clone()
+}
+
+/// Set the process-wide default timeout.
+///
+/// Becomes the timeout for every auto-wait and `wait_*` operation that does
+/// not pass an explicit timeout. Takes effect for *all* subsequent
+/// operations, including on `Locator`s created before this call (the default
+/// is resolved at use time, not construction time). Takes precedence over
+/// [`DEFAULT_TIMEOUT_ENV_VAR`].
+///
+/// `Duration::ZERO` keeps the "single attempt, no polling" semantics.
+pub fn set_default_timeout(timeout: Duration) {
+    *PROGRAMMATIC_DEFAULT
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = Some(timeout);
+}
+
+/// Get the effective process-wide default timeout.
+///
+/// See the [module docs](self) for the resolution order.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidConfig`] if [`DEFAULT_TIMEOUT_ENV_VAR`] is set to
+/// a value that is not a finite, non-negative number of seconds (and no
+/// programmatic default has been set to take precedence over it).
+pub fn default_timeout() -> Result<Duration> {
+    if let Some(t) = *PROGRAMMATIC_DEFAULT
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+    {
+        return Ok(t);
+    }
+    match env_default() {
+        Ok(Some(t)) => Ok(t),
+        Ok(None) => Ok(BUILTIN_DEFAULT_TIMEOUT),
+        Err(message) => Err(Error::InvalidConfig { message }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use crate::locator::Locator;
+    use crate::mock::build_provider;
+    use crate::provider::Provider;
+
+    #[test]
+    fn parse_accepts_integers_floats_and_zero() {
+        assert_eq!(parse_timeout_secs("30").unwrap(), Duration::from_secs(30));
+        assert_eq!(
+            parse_timeout_secs("2.5").unwrap(),
+            Duration::from_secs_f64(2.5)
+        );
+        assert_eq!(parse_timeout_secs("0").unwrap(), Duration::ZERO);
+        assert_eq!(
+            parse_timeout_secs(" 10 ").unwrap(),
+            Duration::from_secs(10),
+            "surrounding whitespace must be tolerated"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_non_numeric_negative_and_non_finite() {
+        for bad in ["abc", "", "-1", "inf", "NaN", "5s", "1,5"] {
+            let err = parse_timeout_secs(bad)
+                .expect_err(&format!("{bad:?} must be rejected as a timeout"));
+            assert!(
+                err.contains("seconds"),
+                "error must explain the expected unit: {err}"
+            );
+        }
+    }
+
+    /// All assertions about the *global* default live in this single test so
+    /// they run sequentially — `set_default_timeout` mutates process-wide
+    /// state and parallel test threads would otherwise race on it.
+    #[test]
+    fn global_default_precedence_and_locator_integration() {
+        // Built-in default applies when nothing is configured. Skip the
+        // assertion if the developer's environment sets the env var — that's
+        // the documented behavior, not a failure.
+        if std::env::var_os(DEFAULT_TIMEOUT_ENV_VAR).is_none() {
+            assert_eq!(default_timeout().unwrap(), BUILTIN_DEFAULT_TIMEOUT);
+        }
+
+        // A locator created *before* set_default_timeout must still honor
+        // it: the default is resolved at use time.
+        let provider: Arc<dyn Provider> = build_provider();
+        let missing = Locator::new(provider.clone(), None, r#"button[name="DoesNotExist"]"#);
+
+        set_default_timeout(Duration::from_millis(150));
+        assert_eq!(default_timeout().unwrap(), Duration::from_millis(150));
+
+        let start = std::time::Instant::now();
+        let err = missing
+            .press()
+            .expect_err("press on a never-matching selector must time out");
+        assert!(matches!(err, Error::Timeout { .. }), "got {err:?}");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "auto-wait must use the 150ms global default, not the 5s built-in; took {:?}",
+            start.elapsed()
+        );
+
+        // An explicit with_timeout wins over the global default.
+        set_default_timeout(Duration::from_secs(30));
+        let start = std::time::Instant::now();
+        let err = missing
+            .clone()
+            .with_timeout(Duration::from_millis(150))
+            .press()
+            .expect_err("press on a never-matching selector must time out");
+        assert!(matches!(err, Error::Timeout { .. }), "got {err:?}");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "explicit with_timeout must beat the 30s global default; took {:?}",
+            start.elapsed()
+        );
+
+        // Restore the built-in value so other tests in this process see the
+        // documented default.
+        set_default_timeout(BUILTIN_DEFAULT_TIMEOUT);
+    }
+}

--- a/xa11y-core/src/error.rs
+++ b/xa11y-core/src/error.rs
@@ -181,6 +181,11 @@ pub enum Error {
     #[error("Invalid action data: {message}")]
     InvalidActionData { message: String },
 
+    /// Process-wide configuration is invalid (e.g. an unparsable
+    /// `XA11Y_DEFAULT_TIMEOUT` environment variable).
+    #[error("Invalid configuration: {message}")]
+    InvalidConfig { message: String },
+
     /// The element has no bounds (e.g. an off-screen or virtual node), so a
     /// screen point can't be computed for input simulation.
     #[error("Element has no bounds")]

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod config;
 pub mod element;
 pub mod error;
 pub mod event;
@@ -20,6 +21,7 @@ pub mod mock;
 
 // Re-export primary types at the crate root for convenience.
 pub use app::App;
+pub use config::{default_timeout, set_default_timeout, DEFAULT_TIMEOUT_ENV_VAR};
 pub use element::{Element, ElementData, RawPlatformData, Rect, StateSet, Toggled, TreeNode};
 pub use error::{Diagnosis, Error, Result};
 pub use event::{ElementState, Event, EventKind, StateFlag};

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -10,27 +10,6 @@ use crate::selector::{
     SimpleSelector,
 };
 
-/// A lazy element descriptor that re-resolves against a fresh accessibility
-/// tree on every operation.
-///
-/// Inspired by Playwright's `Locator` pattern: a Locator never holds a live
-/// reference to a UI element. Instead, it stores a selector and resolves it
-/// on demand, making it immune to staleness.
-///
-/// # Example
-/// ```ignore
-/// # use std::time::Duration;
-/// # use xa11y::*;
-/// # fn example() -> Result<()> {
-/// let app = App::by_name("MyApp", Duration::from_secs(5))?;
-/// let save_btn = app.locator(r#"button[name="Save"]"#);
-/// save_btn.press()?;
-/// # Ok(())
-/// # }
-/// ```
-/// Default auto-wait timeout for Locator action methods (5 seconds).
-const DEFAULT_ACTION_TIMEOUT: Duration = Duration::from_secs(5);
-
 // ── Diagnosis bounds (tenet 6) ──────────────────────────────────────
 //
 // Diagnosis collection runs only on the failure path, after a wait has
@@ -93,6 +72,24 @@ fn state_label(state: ElementState) -> &'static str {
     }
 }
 
+/// A lazy element descriptor that re-resolves against a fresh accessibility
+/// tree on every operation.
+///
+/// Inspired by Playwright's `Locator` pattern: a Locator never holds a live
+/// reference to a UI element. Instead, it stores a selector and resolves it
+/// on demand, making it immune to staleness.
+///
+/// # Example
+/// ```ignore
+/// # use std::time::Duration;
+/// # use xa11y::*;
+/// # fn example() -> Result<()> {
+/// let app = App::by_name("MyApp", Duration::from_secs(5))?;
+/// let save_btn = app.locator(r#"button[name="Save"]"#);
+/// save_btn.press()?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone)]
 pub struct Locator {
     provider: Arc<dyn Provider>,
@@ -101,8 +98,10 @@ pub struct Locator {
     selector: String,
     /// Which match to select (0-based). `None` means first match.
     nth: Option<usize>,
-    /// Timeout for auto-wait before action methods.
-    timeout: Duration,
+    /// Timeout for auto-wait before action methods. `None` means "resolve
+    /// the process-wide default at use time" (see [`crate::config`]), so
+    /// `set_default_timeout` affects locators created before it was called.
+    timeout: Option<Duration>,
 }
 
 impl Locator {
@@ -116,13 +115,15 @@ impl Locator {
             root,
             selector: selector.to_string(),
             nth: None,
-            timeout: DEFAULT_ACTION_TIMEOUT,
+            timeout: None,
         }
     }
 
-    /// Return a new Locator with a custom auto-wait timeout for action methods.
+    /// Return a new Locator with a custom auto-wait timeout for action
+    /// methods. Takes precedence over the process-wide default set via
+    /// [`crate::config::set_default_timeout`] / `XA11Y_DEFAULT_TIMEOUT`.
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = timeout;
+        self.timeout = Some(timeout);
         self
     }
 
@@ -521,6 +522,16 @@ impl Locator {
 
     // ── Auto-wait ──────────────────────────────────────────────────
 
+    /// Effective auto-wait timeout: the explicit [`with_timeout`] value if
+    /// set, otherwise the process-wide default (resolved at use time so
+    /// [`crate::config::set_default_timeout`] affects existing locators).
+    fn effective_timeout(&self) -> Result<Duration> {
+        match self.timeout {
+            Some(t) => Ok(t),
+            None => crate::config::default_timeout(),
+        }
+    }
+
     /// Poll until the element is attached, visible, and enabled, returning a
     /// live [`Element`] handle. Used by the action methods below to provide
     /// resilience against transient unactionable states.
@@ -528,40 +539,41 @@ impl Locator {
     /// `action` names the calling action for the timeout diagnosis, so a
     /// failed `press()` reports *what* was being attempted and what the
     /// last poll observed.
+    ///
+    /// Always performs at least one attempt before checking the deadline, so
+    /// `Duration::ZERO` means "single attempt, no polling" — the same
+    /// contract as `poll_lookup` in `app.rs`.
     fn auto_wait(&self, action: &str) -> Result<Element> {
+        let timeout = self.effective_timeout()?;
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
-        // Most recent poll's observation, for the timeout diagnosis.
-        let mut last_seen: Option<ElementData> = None;
         let mut ever_matched = false;
 
         loop {
-            let elapsed = start.elapsed();
-            if elapsed >= self.timeout {
-                return Err(self.diagnose_timeout(
-                    elapsed,
-                    format!("{action} target actionable (visible && enabled)"),
-                    last_seen.as_ref(),
-                    ever_matched,
-                ));
-            }
-
-            match self.resolve_data() {
+            // This poll's observation, for the timeout diagnosis.
+            let observed = match self.resolve_data() {
                 Ok(data) if data.states.visible && data.states.enabled => {
                     return Ok(Element::new(data, Arc::clone(&self.provider)));
                 }
                 Ok(data) => {
                     // Matched but not yet actionable — poll again.
                     ever_matched = true;
-                    last_seen = Some(data);
+                    Some(data)
                 }
-                Err(Error::SelectorNotMatched { .. }) => {
-                    // Not yet present — poll again.
-                    last_seen = None;
-                }
+                // Not yet present — poll again.
+                Err(Error::SelectorNotMatched { .. }) => None,
                 Err(e) => return Err(e),
-            }
+            };
 
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                return Err(self.diagnose_timeout(
+                    elapsed,
+                    format!("{action} target actionable (visible && enabled)"),
+                    observed.as_ref(),
+                    ever_matched,
+                ));
+            }
             std::thread::sleep(poll_interval);
         }
     }
@@ -742,6 +754,9 @@ impl Locator {
     ///
     /// `condition` names what is being waited for; on timeout it is embedded
     /// in the error's [`Diagnosis`] together with the last observation.
+    ///
+    /// Always evaluates the predicate at least once before checking the
+    /// deadline, so `Duration::ZERO` means "single check, no polling".
     fn poll_until(
         &self,
         predicate: impl Fn(Option<&ElementData>) -> bool,
@@ -750,21 +765,10 @@ impl Locator {
     ) -> Result<Option<Element>> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
-        // Most recent poll's observation, for the timeout diagnosis.
-        let mut last_seen: Option<ElementData> = None;
         let mut ever_matched = false;
 
         loop {
-            let elapsed = start.elapsed();
-            if elapsed >= timeout {
-                return Err(self.diagnose_timeout(
-                    elapsed,
-                    condition.to_string(),
-                    last_seen.as_ref(),
-                    ever_matched,
-                ));
-            }
-
+            // This poll's observation, for the timeout diagnosis.
             let matched = match self.resolve_data() {
                 Ok(data) => Some(data),
                 Err(Error::SelectorNotMatched { .. }) => None,
@@ -778,7 +782,15 @@ impl Locator {
                 return Ok(matched.map(|data| Element::new(data, Arc::clone(&self.provider))));
             }
 
-            last_seen = matched;
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                return Err(self.diagnose_timeout(
+                    elapsed,
+                    condition.to_string(),
+                    matched.as_ref(),
+                    ever_matched,
+                ));
+            }
             std::thread::sleep(poll_interval);
         }
     }
@@ -917,6 +929,46 @@ mod tests {
     fn group_exists_false_when_no_clause_matches() {
         let loc = root_locator(r#"button[name="Nope"], text_field[name="AlsoNope"]"#);
         assert!(!loc.exists().unwrap());
+    }
+
+    // ── Auto-wait / wait timeout semantics ──────────────────────────
+
+    #[test]
+    fn auto_wait_zero_timeout_performs_single_attempt() {
+        // `Duration::ZERO` must still perform exactly one resolve attempt
+        // (attempt-then-check, matching `poll_lookup` in app.rs) — a visible,
+        // enabled element is acted on immediately, not failed with Timeout.
+        let loc = root_locator(r#"button[name="Back"]"#).with_timeout(Duration::ZERO);
+        loc.press()
+            .expect("zero timeout must still allow one successful attempt");
+    }
+
+    #[test]
+    fn auto_wait_zero_timeout_fails_fast_on_missing_element() {
+        let loc = root_locator(r#"button[name="DoesNotExist"]"#).with_timeout(Duration::ZERO);
+        let start = std::time::Instant::now();
+        let err = loc.press().expect_err("press must time out on a miss");
+        assert!(matches!(err, Error::Timeout { .. }), "got {err:?}");
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "zero timeout must not poll; took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn wait_visible_zero_timeout_performs_single_check() {
+        let el = root_locator(r#"button[name="Back"]"#)
+            .wait_visible(Duration::ZERO)
+            .expect("zero timeout must still allow one successful check");
+        assert_eq!(el.data().name.as_deref(), Some("Back"));
+    }
+
+    #[test]
+    fn wait_detached_zero_timeout_succeeds_when_already_absent() {
+        root_locator(r#"button[name="DoesNotExist"]"#)
+            .wait_detached(Duration::ZERO)
+            .expect("an absent element is already detached");
     }
 
     // ── Rootless search across apps ─────────────────────────────────

--- a/xa11y-js/__test__/unit/app-factories.test.js
+++ b/xa11y-js/__test__/unit/app-factories.test.js
@@ -74,6 +74,8 @@ require.cache[nativePath] = {
     _makeTestLocator: () => {},
     _makeDisconnectedSubscription: () => new NativeSubscriptionStub(),
     locator: () => {},
+    // App.find resolves its default timeout from the process-wide setting.
+    getDefaultTimeout: () => 5,
   },
 };
 

--- a/xa11y-js/__test__/unit/default-timeout.test.js
+++ b/xa11y-js/__test__/unit/default-timeout.test.js
@@ -1,0 +1,134 @@
+// Process-wide default timeout (issue #259): `setDefaultTimeout` /
+// `getDefaultTimeout`, and their effect on auto-waiting actions and the
+// `wait*` defaults. The env-var path (XA11Y_DEFAULT_TIMEOUT) is read once
+// per process, so it is exercised in subprocesses.
+
+'use strict';
+
+const { test, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+
+const {
+  _makeTestLocator,
+  TimeoutError,
+  getDefaultTimeout,
+  setDefaultTimeout,
+} = require('../../index.js');
+
+const BUILTIN_DEFAULT = 5;
+
+// Ceiling for "must not have waited out a long timeout" assertions —
+// generous for slow CI, far below the long timeouts the tests configure.
+const FAST_CEILING_MS = 3000;
+
+afterEach(() => {
+  // The default is process-wide state; reset it after every test.
+  setDefaultTimeout(BUILTIN_DEFAULT);
+});
+
+function missing() {
+  return _makeTestLocator().descendant('button[name="DoesNotExist"]');
+}
+
+test('built-in default is 5 seconds', () => {
+  assert.equal(getDefaultTimeout(), BUILTIN_DEFAULT);
+});
+
+test('set/get round trip', () => {
+  setDefaultTimeout(12.5);
+  assert.equal(getDefaultTimeout(), 12.5);
+});
+
+test('rejects negative and non-finite values, leaving the default unchanged', () => {
+  assert.throws(() => setDefaultTimeout(-1));
+  assert.throws(() => setDefaultTimeout(NaN));
+  assert.throws(() => setDefaultTimeout(Infinity));
+  assert.equal(getDefaultTimeout(), BUILTIN_DEFAULT);
+});
+
+test('auto-waiting actions use the global default', async () => {
+  setDefaultTimeout(0.3);
+  const start = Date.now();
+  await assert.rejects(missing().press(), TimeoutError);
+  assert.ok(
+    Date.now() - start < FAST_CEILING_MS,
+    'auto-wait must use the 0.3s global default, not the built-in 5s',
+  );
+});
+
+test('wait* with no argument uses the global default', async () => {
+  setDefaultTimeout(0.3);
+  const start = Date.now();
+  await assert.rejects(missing().waitVisible(), TimeoutError);
+  assert.ok(Date.now() - start < FAST_CEILING_MS);
+});
+
+test('an explicit per-call timeout beats the global default', async () => {
+  setDefaultTimeout(60);
+  const start = Date.now();
+  await assert.rejects(missing().waitVisible(0.2), TimeoutError);
+  assert.ok(
+    Date.now() - start < FAST_CEILING_MS,
+    'explicit waitVisible(0.2) must win over the 60s global default',
+  );
+});
+
+test('zero default keeps single-attempt semantics', async () => {
+  setDefaultTimeout(0);
+  // One attempt still happens: an actionable element succeeds...
+  await _makeTestLocator().descendant('button[name="Back"]').press();
+  // ...and a miss fails immediately instead of polling.
+  const start = Date.now();
+  await assert.rejects(missing().press(), TimeoutError);
+  assert.ok(Date.now() - start < FAST_CEILING_MS);
+});
+
+test('a negative explicit wait timeout rejects instead of crashing', async () => {
+  // Regression: a negative timeout used to reach Duration::from_secs_f64 in
+  // the wait task and panic; it must reject the promise.
+  await assert.rejects(missing().waitVisible(-1));
+});
+
+// ── Environment variable (read once per process → subprocess tests) ────────
+
+const INDEX_JS = require.resolve('../../index.js');
+
+function runNode(code, envValue) {
+  const env = { ...process.env };
+  delete env.XA11Y_DEFAULT_TIMEOUT;
+  if (envValue !== undefined) env.XA11Y_DEFAULT_TIMEOUT = envValue;
+  return execFileSync(process.execPath, ['-e', code, INDEX_JS], {
+    env,
+    stdio: 'pipe',
+  })
+    .toString()
+    .trim();
+}
+
+test('XA11Y_DEFAULT_TIMEOUT sets the default (subprocess)', () => {
+  const out = runNode(
+    'console.log(require(process.argv[1]).getDefaultTimeout())',
+    '12.5',
+  );
+  assert.equal(out, '12.5');
+});
+
+test('setDefaultTimeout overrides the env var (subprocess)', () => {
+  const out = runNode(
+    'const x = require(process.argv[1]); x.setDefaultTimeout(2); console.log(x.getDefaultTimeout())',
+    '12.5',
+  );
+  assert.equal(out, '2');
+});
+
+test('an invalid XA11Y_DEFAULT_TIMEOUT surfaces as an error (subprocess)', () => {
+  assert.throws(
+    () =>
+      runNode(
+        'require(process.argv[1]).getDefaultTimeout()',
+        'not-a-number',
+      ),
+    /XA11Y_DEFAULT_TIMEOUT/,
+  );
+});

--- a/xa11y-js/index.d.ts
+++ b/xa11y-js/index.d.ts
@@ -47,9 +47,10 @@ export interface SubscribeOptions {
 export interface AppLookupOptions {
   /**
    * Poll the accessibility API until the app appears, up to this many
-   * milliseconds. Defaults to 5000 (5 seconds) — pass `0` for a single
-   * attempt with no waiting. Only "not found" errors trigger a retry;
-   * permission errors and the like fail fast.
+   * milliseconds. Defaults to the process-wide default timeout (see
+   * {@link setDefaultTimeout}; 5000ms unless overridden) — pass `0` for a
+   * single attempt with no waiting. Only "not found" errors trigger a
+   * retry; permission errors and the like fail fast.
    */
   timeout?: number;
 }
@@ -64,7 +65,10 @@ export interface WaitForEventOptions {
 }
 
 export interface WaitUntilOptions {
-  /** Timeout in milliseconds. Default: 5000. Rejects with `TimeoutError`. */
+  /**
+   * Timeout in milliseconds. Defaults to the process-wide default timeout
+   * (see {@link setDefaultTimeout}). Rejects with `TimeoutError`.
+   */
   timeout?: number;
   /** Abort signal for cancellation. Rejects with `AbortError`. */
   signal?: AbortSignal;
@@ -72,7 +76,8 @@ export interface WaitUntilOptions {
 
 export interface FindOptions {
   /**
-   * Timeout in milliseconds. Default: 5000. Rejects with
+   * Timeout in milliseconds. Defaults to the process-wide default timeout
+   * (see {@link setDefaultTimeout}). Rejects with
    * `SelectorNotMatchedError` if no application matches in time.
    */
   timeout?: number;
@@ -248,6 +253,28 @@ export interface ScreenshotOptions {
  * ```
  */
 export declare function screenshot(options?: ScreenshotOptions): Promise<Screenshot>;
+
+/**
+ * Set the process-wide default timeout, in seconds.
+ *
+ * Becomes the default for every auto-waiting action method, `wait*` call,
+ * and app lookup (`App.byName` / `App.byPid` / `App.find`) that doesn't
+ * pass an explicit timeout. An explicit per-call timeout always wins. Takes
+ * precedence over the `XA11Y_DEFAULT_TIMEOUT` environment variable
+ * (seconds, read once on first use).
+ *
+ * Pass `0` for "single attempt, no polling" semantics; negative or
+ * non-finite values throw.
+ */
+export declare function setDefaultTimeout(seconds: number): void;
+
+/**
+ * Get the effective process-wide default timeout, in seconds.
+ *
+ * Resolution order: the {@link setDefaultTimeout} value, else the
+ * `XA11Y_DEFAULT_TIMEOUT` environment variable, else the built-in 5.
+ */
+export declare function getDefaultTimeout(): number;
 
 // ── JS-only: typed error hierarchy ─────────────────────────────────────────
 

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -122,6 +122,10 @@ const CODE_TO_CLASS = {
   XA11Y_PLATFORM: PlatformError,
   XA11Y_NO_ELEMENT_BOUNDS: InvalidActionDataError,
   XA11Y_UNSUPPORTED: ActionNotSupportedError,
+  // Invalid process-wide configuration (e.g. a malformed
+  // XA11Y_DEFAULT_TIMEOUT environment variable) -- an invalid-value error,
+  // same family as a bad per-call timeout argument.
+  XA11Y_INVALID_CONFIG: InvalidActionDataError,
 };
 
 /**
@@ -217,7 +221,9 @@ Object.defineProperty(native.Locator.prototype, 'waitUntil', {
   configurable: true,
   writable: true,
   value: async function waitUntil(predicate, opts = {}) {
-    const { timeout = 5000, signal } = opts;
+    // Default resolves from the process-wide setting (setDefaultTimeout /
+    // XA11Y_DEFAULT_TIMEOUT, else 5s); an explicit opts.timeout wins.
+    const { timeout = native.getDefaultTimeout() * 1000, signal } = opts;
     const deadline = Date.now() + timeout;
 
     if (signal && signal.aborted) {
@@ -444,7 +450,7 @@ class App extends native.App {
    *
    * @param {(app: App) => boolean | Promise<boolean>} predicate
    * @param {object} [options]
-   * @param {number} [options.timeout=5000] - Timeout in milliseconds
+   * @param {number} [options.timeout] - Timeout in milliseconds; defaults to the process-wide default timeout (see `setDefaultTimeout`)
    * @param {AbortSignal} [options.signal] - Abort signal for cancellation
    * @returns {Promise<App>}
    * @example
@@ -456,7 +462,9 @@ class App extends native.App {
    * ```
    */
   static async find(predicate, options = {}) {
-    const { timeout = 5000, signal } = options;
+    // Default resolves from the process-wide setting (setDefaultTimeout /
+    // XA11Y_DEFAULT_TIMEOUT, else 5s); an explicit options.timeout wins.
+    const { timeout = native.getDefaultTimeout() * 1000, signal } = options;
     const deadline = Date.now() + timeout;
 
     if (signal && signal.aborted) {
@@ -565,6 +573,34 @@ function locator(selector) {
 }
 
 /**
+ * Set the process-wide default timeout, in seconds.
+ *
+ * Becomes the default for every auto-waiting action method, `wait*` call,
+ * and app lookup (`App.byName` / `App.byPid`) that doesn't pass an explicit
+ * timeout. An explicit per-call timeout always wins. Takes precedence over
+ * the `XA11Y_DEFAULT_TIMEOUT` environment variable. Pass `0` for "single
+ * attempt, no polling" semantics; negative or non-finite values throw.
+ *
+ * @param {number} seconds
+ */
+function setDefaultTimeout(seconds) {
+  return wrap(native.setDefaultTimeout)(seconds);
+}
+
+/**
+ * Get the effective process-wide default timeout, in seconds.
+ *
+ * Resolution order: the `setDefaultTimeout()` value, else the
+ * `XA11Y_DEFAULT_TIMEOUT` environment variable (seconds, read once on first
+ * use), else the built-in 5.
+ *
+ * @returns {number}
+ */
+function getDefaultTimeout() {
+  return wrap(native.getDefaultTimeout)();
+}
+
+/**
  * Construct an `InputSim` backed by the platform's native input path.
  * Errors are wrapped in typed `XA11yError` subclasses like every other
  * entry point.
@@ -611,9 +647,11 @@ module.exports = {
   Locator: native.Locator,
   Screenshot: native.Screenshot,
   Subscription,
+  getDefaultTimeout,
   inputSim,
   locator,
   screenshot,
+  setDefaultTimeout,
 
   // Error classes
   XA11yError,

--- a/xa11y-js/src/app.rs
+++ b/xa11y-js/src/app.rs
@@ -38,9 +38,11 @@ impl App {
 #[napi(object)]
 pub struct AppLookupOptions {
     /// Poll the accessibility API until the app appears or this many
-    /// milliseconds elapse. Defaults to 5000 (5 seconds) — pass `0` for a
-    /// single attempt with no waiting. Only "not found" errors trigger a
-    /// retry; other errors fail fast.
+    /// milliseconds elapse. When omitted, the process-wide default applies —
+    /// 5000ms (5 seconds) unless overridden via `setDefaultTimeout()` or the
+    /// `XA11Y_DEFAULT_TIMEOUT` environment variable. Pass `0` for a single
+    /// attempt with no waiting. Only "not found" errors trigger a retry;
+    /// other errors fail fast.
     pub timeout: Option<u32>,
 }
 
@@ -49,10 +51,11 @@ impl App {
     /// Find an application by exact name.
     ///
     /// Polls the accessibility API until the app appears or
-    /// `options.timeout` (ms) elapses. Defaults to 5000 (5 seconds) —
-    /// pass `{ timeout: 0 }` for a single attempt with no waiting. Only
-    /// "not found" errors trigger a retry; permission errors and the like
-    /// fail fast.
+    /// `options.timeout` (ms) elapses. When omitted, the process-wide
+    /// default applies — 5 seconds unless overridden via
+    /// `setDefaultTimeout()` / `XA11Y_DEFAULT_TIMEOUT`. Pass `{ timeout: 0 }`
+    /// for a single attempt with no waiting. Only "not found" errors trigger
+    /// a retry; permission errors and the like fail fast.
     ///
     /// Rejects with `PermissionDeniedError` if accessibility is not enabled,
     /// or `SelectorNotMatchedError` if no matching app is found.
@@ -60,7 +63,7 @@ impl App {
     pub fn by_name(name: String, options: Option<AppLookupOptions>) -> AsyncTask<FindByNameTask> {
         AsyncTask::new(FindByNameTask {
             name,
-            timeout: timeout_from(options),
+            timeout_ms: options.and_then(|o| o.timeout),
         })
     }
 
@@ -71,7 +74,7 @@ impl App {
     pub fn by_pid(pid: u32, options: Option<AppLookupOptions>) -> AsyncTask<FindByPidTask> {
         AsyncTask::new(FindByPidTask {
             pid,
-            timeout: timeout_from(options),
+            timeout_ms: options.and_then(|o| o.timeout),
         })
     }
 
@@ -176,20 +179,20 @@ impl App {
 
 // ── Tasks ──────────────────────────────────────────────────────────────
 
-/// 5-second default chosen to match the auto-wait timeout used elsewhere in
-/// the API (e.g. `Locator.wait_attached`).
-const DEFAULT_LOOKUP_TIMEOUT: Duration = Duration::from_millis(5000);
-
-fn timeout_from(options: Option<AppLookupOptions>) -> Duration {
-    match options.and_then(|o| o.timeout) {
-        Some(ms) => Duration::from_millis(ms.into()),
-        None => DEFAULT_LOOKUP_TIMEOUT,
+/// Resolve the optional lookup timeout (ms): an explicit value wins; `None`
+/// falls back to the process-wide default (`setDefaultTimeout()` /
+/// `XA11Y_DEFAULT_TIMEOUT`, else 5 seconds) — matching the auto-wait
+/// timeout used elsewhere in the API (e.g. `Locator.waitAttached`).
+fn effective_timeout_ms(timeout_ms: Option<u32>) -> napi::Result<Duration> {
+    match timeout_ms {
+        Some(ms) => Ok(Duration::from_millis(ms.into())),
+        None => xa11y::default_timeout().map_err(map_err),
     }
 }
 
 pub struct FindByNameTask {
     name: String,
-    timeout: Duration,
+    timeout_ms: Option<u32>,
 }
 
 impl Task for FindByNameTask {
@@ -197,8 +200,9 @@ impl Task for FindByNameTask {
     type JsValue = App;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        let timeout = effective_timeout_ms(self.timeout_ms)?;
         let provider = crate::provider()?;
-        xa11y::App::by_name_with(provider, &self.name, self.timeout).map_err(map_err)
+        xa11y::App::by_name_with(provider, &self.name, timeout).map_err(map_err)
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {
@@ -208,7 +212,7 @@ impl Task for FindByNameTask {
 
 pub struct FindByPidTask {
     pid: u32,
-    timeout: Duration,
+    timeout_ms: Option<u32>,
 }
 
 impl Task for FindByPidTask {
@@ -216,8 +220,9 @@ impl Task for FindByPidTask {
     type JsValue = App;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        let timeout = effective_timeout_ms(self.timeout_ms)?;
         let provider = crate::provider()?;
-        xa11y::App::by_pid_with(provider, self.pid, self.timeout).map_err(map_err)
+        xa11y::App::by_pid_with(provider, self.pid, timeout).map_err(map_err)
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> napi::Result<Self::JsValue> {

--- a/xa11y-js/src/errors.rs
+++ b/xa11y-js/src/errors.rs
@@ -23,6 +23,7 @@ pub mod codes {
     pub const TIMEOUT: &str = "XA11Y_TIMEOUT";
     pub const INVALID_SELECTOR: &str = "XA11Y_INVALID_SELECTOR";
     pub const INVALID_ACTION_DATA: &str = "XA11Y_INVALID_ACTION_DATA";
+    pub const INVALID_CONFIG: &str = "XA11Y_INVALID_CONFIG";
     pub const PLATFORM: &str = "XA11Y_PLATFORM";
     pub const NO_ELEMENT_BOUNDS: &str = "XA11Y_NO_ELEMENT_BOUNDS";
     pub const UNSUPPORTED: &str = "XA11Y_UNSUPPORTED";
@@ -87,6 +88,10 @@ pub fn map_err(e: xa11y::Error) -> Error {
         xa11y::Error::InvalidActionData { message } => (
             codes::INVALID_ACTION_DATA,
             format!("Invalid action data: {message}"),
+        ),
+        xa11y::Error::InvalidConfig { message } => (
+            codes::INVALID_CONFIG,
+            format!("Invalid configuration: {message}"),
         ),
         xa11y::Error::Platform { code, message } => (
             codes::PLATFORM,

--- a/xa11y-js/src/lib.rs
+++ b/xa11y-js/src/lib.rs
@@ -27,6 +27,56 @@ fn provider() -> napi::Result<Arc<dyn xa11y::Provider>> {
     xa11y::provider().map_err(map_err)
 }
 
+/// Resolve an optional per-call timeout (seconds) to a `Duration`: an
+/// explicit value wins; `None` falls back to the process-wide default (see
+/// [`set_default_timeout`] / the `XA11Y_DEFAULT_TIMEOUT` environment
+/// variable).
+pub(crate) fn effective_timeout_secs(
+    timeout_seconds: Option<f64>,
+) -> napi::Result<std::time::Duration> {
+    match timeout_seconds {
+        Some(secs) if secs.is_finite() && secs >= 0.0 => {
+            Ok(std::time::Duration::from_secs_f64(secs))
+        }
+        Some(secs) => Err(napi::Error::new(
+            napi::Status::InvalidArg,
+            format!("timeoutSeconds must be a non-negative, finite number of seconds, got {secs}"),
+        )),
+        None => xa11y::default_timeout().map_err(map_err),
+    }
+}
+
+/// Set the process-wide default timeout, in seconds.
+///
+/// Becomes the default for every auto-waiting action method, `wait*` call,
+/// and app lookup (`App.byName` / `App.byPid`) that doesn't pass an explicit
+/// timeout. An explicit per-call timeout always wins. Takes precedence over
+/// the `XA11Y_DEFAULT_TIMEOUT` environment variable (seconds, read once on
+/// first use).
+///
+/// Pass `0` for "single attempt, no polling" semantics. Throws for negative
+/// or non-finite values.
+#[napi(js_name = "setDefaultTimeout")]
+pub fn set_default_timeout(seconds: f64) -> napi::Result<()> {
+    if !(seconds.is_finite() && seconds >= 0.0) {
+        return Err(napi::Error::new(
+            napi::Status::InvalidArg,
+            format!("seconds must be a non-negative, finite number, got {seconds}"),
+        ));
+    }
+    xa11y::set_default_timeout(std::time::Duration::from_secs_f64(seconds));
+    Ok(())
+}
+
+/// Get the effective process-wide default timeout, in seconds.
+///
+/// Resolution order: the [`set_default_timeout`] value, else the
+/// `XA11Y_DEFAULT_TIMEOUT` environment variable, else the built-in 5.0.
+#[napi(js_name = "getDefaultTimeout")]
+pub fn get_default_timeout() -> napi::Result<f64> {
+    Ok(xa11y::default_timeout().map_err(map_err)?.as_secs_f64())
+}
+
 /// Create a top-level [`Locator`](locator::Locator) that searches from the
 /// system accessibility root (across all applications).
 #[napi(js_name = "locator")]

--- a/xa11y-js/src/locator.rs
+++ b/xa11y-js/src/locator.rs
@@ -1,7 +1,5 @@
 //! JS `Locator` class: resilient element reference with auto-wait.
 
-use std::time::Duration;
-
 use napi::bindgen_prelude::{AsyncTask, Env, Task};
 
 use crate::element::Element;
@@ -13,7 +11,9 @@ use crate::types::TreeNode;
 /// Locators never hold a live reference to a UI element. Instead, they
 /// store a selector and resolve it on demand, making them immune to
 /// staleness. Action methods (`press`, `typeText`, `toggle`, …) auto-wait
-/// for the element to appear (up to 5 seconds by default) before acting.
+/// for the element to appear before acting, up to the process-wide default
+/// timeout — 5 seconds unless overridden via `setDefaultTimeout()` or the
+/// `XA11Y_DEFAULT_TIMEOUT` environment variable.
 ///
 /// Locators are cheap to clone — the chaining methods (`child`, `descendant`,
 /// `nth`, `first`) return new locators rather than mutating in place.
@@ -301,9 +301,12 @@ impl Locator {
     // ── Waits ──────────────────────────────────────────────────────────
     //
     // Each wait polls the provider until its condition is satisfied or
-    // `timeoutSeconds` elapses (default: 5s). Waits that expect the element
-    // to be present resolve with the matched `Element`; waits that expect it
-    // to be gone resolve with `undefined`.
+    // `timeoutSeconds` elapses. When `timeoutSeconds` is omitted, the
+    // process-wide default applies — 5s unless overridden via
+    // `setDefaultTimeout()` or the `XA11Y_DEFAULT_TIMEOUT` environment
+    // variable. Waits that expect the element to be present resolve with the
+    // matched `Element`; waits that expect it to be gone resolve with
+    // `undefined`.
 
     /// Wait for a matching element to become visible.
     /// Rejects with `TimeoutError` if still hidden after `timeoutSeconds`.
@@ -315,7 +318,7 @@ impl Locator {
         AsyncTask::new(WaitTask::returning(
             self.inner.clone(),
             WaitKind::Visible,
-            timeout_seconds.unwrap_or(5.0),
+            timeout_seconds,
         ))
     }
 
@@ -329,7 +332,7 @@ impl Locator {
         AsyncTask::new(WaitTask::returning(
             self.inner.clone(),
             WaitKind::Attached,
-            timeout_seconds.unwrap_or(5.0),
+            timeout_seconds,
         ))
     }
 
@@ -342,7 +345,7 @@ impl Locator {
         AsyncTask::new(WaitTask::absent(
             self.inner.clone(),
             WaitKind::Detached,
-            timeout_seconds.unwrap_or(5.0),
+            timeout_seconds,
         ))
     }
 
@@ -355,7 +358,7 @@ impl Locator {
         AsyncTask::new(WaitTask::returning(
             self.inner.clone(),
             WaitKind::Enabled,
-            timeout_seconds.unwrap_or(5.0),
+            timeout_seconds,
         ))
     }
 
@@ -368,7 +371,7 @@ impl Locator {
         AsyncTask::new(WaitTask::absent(
             self.inner.clone(),
             WaitKind::Hidden,
-            timeout_seconds.unwrap_or(5.0),
+            timeout_seconds,
         ))
     }
 
@@ -381,7 +384,7 @@ impl Locator {
         AsyncTask::new(WaitTask::returning(
             self.inner.clone(),
             WaitKind::Disabled,
-            timeout_seconds.unwrap_or(5.0),
+            timeout_seconds,
         ))
     }
 
@@ -394,7 +397,7 @@ impl Locator {
         AsyncTask::new(WaitTask::returning(
             self.inner.clone(),
             WaitKind::Focused,
-            timeout_seconds.unwrap_or(5.0),
+            timeout_seconds,
         ))
     }
 
@@ -407,7 +410,7 @@ impl Locator {
         AsyncTask::new(WaitTask::returning(
             self.inner.clone(),
             WaitKind::Unfocused,
-            timeout_seconds.unwrap_or(5.0),
+            timeout_seconds,
         ))
     }
 }
@@ -631,7 +634,10 @@ pub enum WaitKind {
 pub struct WaitTask {
     inner: xa11y::Locator,
     kind: WaitKind,
-    timeout: Duration,
+    /// Explicit timeout in seconds; `None` resolves to the process-wide
+    /// default in `compute` (validation happens there too, so a negative
+    /// value rejects the promise instead of panicking).
+    timeout_seconds: Option<f64>,
     /// Whether the JS caller expects the resolved value to be an Element or
     /// undefined. Absent-state waits (Detached/Hidden) always resolve to
     /// undefined.
@@ -639,19 +645,19 @@ pub struct WaitTask {
 }
 
 impl WaitTask {
-    fn returning(inner: xa11y::Locator, kind: WaitKind, secs: f64) -> Self {
+    fn returning(inner: xa11y::Locator, kind: WaitKind, timeout_seconds: Option<f64>) -> Self {
         Self {
             inner,
             kind,
-            timeout: Duration::from_secs_f64(secs),
+            timeout_seconds,
             returns_element: true,
         }
     }
-    fn absent(inner: xa11y::Locator, kind: WaitKind, secs: f64) -> Self {
+    fn absent(inner: xa11y::Locator, kind: WaitKind, timeout_seconds: Option<f64>) -> Self {
         Self {
             inner,
             kind,
-            timeout: Duration::from_secs_f64(secs),
+            timeout_seconds,
             returns_element: false,
         }
     }
@@ -662,15 +668,16 @@ impl Task for WaitTask {
     type JsValue = Option<Element>;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        let timeout = crate::effective_timeout_secs(self.timeout_seconds)?;
         let r = match self.kind {
-            WaitKind::Visible => self.inner.wait_visible(self.timeout).map(Some),
-            WaitKind::Attached => self.inner.wait_attached(self.timeout).map(Some),
-            WaitKind::Detached => self.inner.wait_detached(self.timeout).map(|_| None),
-            WaitKind::Enabled => self.inner.wait_enabled(self.timeout).map(Some),
-            WaitKind::Hidden => self.inner.wait_hidden(self.timeout).map(|_| None),
-            WaitKind::Disabled => self.inner.wait_disabled(self.timeout).map(Some),
-            WaitKind::Focused => self.inner.wait_focused(self.timeout).map(Some),
-            WaitKind::Unfocused => self.inner.wait_unfocused(self.timeout).map(Some),
+            WaitKind::Visible => self.inner.wait_visible(timeout).map(Some),
+            WaitKind::Attached => self.inner.wait_attached(timeout).map(Some),
+            WaitKind::Detached => self.inner.wait_detached(timeout).map(|_| None),
+            WaitKind::Enabled => self.inner.wait_enabled(timeout).map(Some),
+            WaitKind::Hidden => self.inner.wait_hidden(timeout).map(|_| None),
+            WaitKind::Disabled => self.inner.wait_disabled(timeout).map(Some),
+            WaitKind::Focused => self.inner.wait_focused(timeout).map(Some),
+            WaitKind::Unfocused => self.inner.wait_unfocused(timeout).map(Some),
         };
         r.map_err(map_err)
     }

--- a/xa11y-python/python/xa11y/__init__.py
+++ b/xa11y-python/python/xa11y/__init__.py
@@ -27,9 +27,11 @@ from xa11y._native import (
     Subscription,
     TimeoutError,
     XA11yError,
+    get_default_timeout,
     input_sim,
     locator,
     screenshot,
+    set_default_timeout,
 )
 
 __all__ = [
@@ -51,7 +53,9 @@ __all__ = [
     "Subscription",
     "TimeoutError",
     "XA11yError",
+    "get_default_timeout",
     "input_sim",
     "locator",
     "screenshot",
+    "set_default_timeout",
 ]

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -181,16 +181,19 @@ class App:
     @property
     def pid(self) -> int | None: ...
     @staticmethod
-    def by_name(name: str, *, timeout: float = 5.0) -> App:
+    def by_name(name: str, *, timeout: float | None = None) -> App:
         """Find an application by exact name.
 
         Polls the accessibility API until the app appears or ``timeout``
-        (seconds) elapses. Defaults to 5 seconds — pass ``timeout=0`` for a
-        single attempt with no waiting. Only "not found" errors trigger a
-        retry; other errors fail fast.
+        (seconds) elapses. ``timeout=None`` (the default) uses the
+        process-wide default timeout — 5 seconds unless overridden via
+        :func:`set_default_timeout` or the ``XA11Y_DEFAULT_TIMEOUT``
+        environment variable. Pass ``timeout=0`` for a single attempt with
+        no waiting. Only "not found" errors trigger a retry; other errors
+        fail fast.
         """
     @staticmethod
-    def by_pid(pid: int, *, timeout: float = 5.0) -> App:
+    def by_pid(pid: int, *, timeout: float | None = None) -> App:
         """Find an application by process ID.
 
         This is the supported way to *wait* for a freshly launched process
@@ -203,6 +206,16 @@ class App:
         instead of filtering app enumeration, so an app whose window is
         still unnamed mid-startup is found as soon as the accessibility API
         can reach it. See ``by_name`` for ``timeout`` semantics.
+        """
+    @staticmethod
+    def find(predicate: Callable[[App], bool], *, timeout: float | None = None) -> App:
+        """Find an application matching ``predicate``.
+
+        ``predicate`` is called with an :class:`App` for each running
+        application on every poll; the first for which it returns truthy is
+        returned. A falsy return means "not this one, keep polling"; if the
+        predicate *raises*, the search aborts immediately and that exception
+        propagates. See ``by_name`` for ``timeout`` semantics.
         """
     @staticmethod
     def list() -> list[App]:
@@ -376,7 +389,11 @@ class Locator:
 
     Locators never hold a live reference to a UI element. Instead, they store
     a selector and resolve it on demand, making them immune to staleness.
-    Action methods auto-wait for the element to appear before acting.
+    Action methods auto-wait for the element to appear before acting, using
+    the process-wide default timeout (5 seconds unless overridden via
+    :func:`set_default_timeout` or the ``XA11Y_DEFAULT_TIMEOUT`` environment
+    variable). ``wait_*`` methods use the same default when no explicit
+    ``timeout=`` is passed.
     """
 
     @property
@@ -447,23 +464,31 @@ class Locator:
         """Select a text range within the matched element (0-based offsets)."""
     def perform_action(self, action: str) -> None:
         """Perform an action by snake_case name."""
-    def wait_visible(self, timeout: float = 5.0) -> Element:
-        """Wait until the element is visible, polling the provider."""
-    def wait_attached(self, timeout: float = 5.0) -> Element:
+    def wait_visible(self, timeout: float | None = None) -> Element:
+        """Wait until the element is visible, polling the provider.
+
+        ``timeout=None`` (the default) uses the process-wide default timeout
+        — see :func:`set_default_timeout`. Applies to all ``wait_*`` methods.
+        """
+    def wait_attached(self, timeout: float | None = None) -> Element:
         """Wait until the element exists in the tree."""
-    def wait_detached(self, timeout: float = 5.0) -> None:
+    def wait_detached(self, timeout: float | None = None) -> None:
         """Wait until the element is removed from the tree."""
-    def wait_enabled(self, timeout: float = 5.0) -> Element:
+    def wait_enabled(self, timeout: float | None = None) -> Element:
         """Wait until the element is enabled."""
-    def wait_hidden(self, timeout: float = 5.0) -> None:
+    def wait_hidden(self, timeout: float | None = None) -> None:
         """Wait until the element is hidden or removed."""
-    def wait_disabled(self, timeout: float = 5.0) -> Element:
+    def wait_disabled(self, timeout: float | None = None) -> Element:
         """Wait until the element is disabled."""
-    def wait_focused(self, timeout: float = 5.0) -> Element:
+    def wait_focused(self, timeout: float | None = None) -> Element:
         """Wait until the element has keyboard focus."""
-    def wait_unfocused(self, timeout: float = 5.0) -> Element:
+    def wait_unfocused(self, timeout: float | None = None) -> Element:
         """Wait until the element does not have keyboard focus."""
-    def wait_until(self, predicate: Callable[[Element | None], bool], timeout: float = 5.0) -> None:
+    def wait_until(
+        self,
+        predicate: Callable[[Element | None], bool],
+        timeout: float | None = None,
+    ) -> None:
         """Wait until an arbitrary predicate is satisfied.
 
         A predicate that *raises* aborts the wait immediately and propagates
@@ -546,6 +571,27 @@ class Screenshot:
 
 def locator(selector: str) -> Locator:
     """Create a top-level Locator searching from the system root."""
+
+def set_default_timeout(timeout: float) -> None:
+    """Set the process-wide default timeout, in seconds.
+
+    Becomes the default for every auto-waiting action method, ``wait_*``
+    call, and app lookup (``App.by_name`` / ``App.by_pid`` / ``App.find``)
+    that doesn't pass an explicit ``timeout=``. An explicit per-call
+    ``timeout=`` always wins. Takes precedence over the
+    ``XA11Y_DEFAULT_TIMEOUT`` environment variable (seconds, read once at
+    import).
+
+    Pass ``0`` for "single attempt, no polling" semantics. Raises
+    ``ValueError`` for negative or non-finite values.
+    """
+
+def get_default_timeout() -> float:
+    """Get the effective process-wide default timeout, in seconds.
+
+    Resolution order: the :func:`set_default_timeout` value, else the
+    ``XA11Y_DEFAULT_TIMEOUT`` environment variable, else the built-in 5.0.
+    """
 
 def input_sim() -> InputSim:
     """Construct an ``InputSim`` backed by the platform's native input path."""

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -128,6 +128,12 @@ fn to_py_err(e: xa11y::Error) -> PyErr {
         xa11y::Error::InvalidActionData { message } => {
             InvalidActionDataError::new_err(format!("Invalid action data: {message}"))
         }
+        // Config errors are value errors (e.g. an unparsable
+        // XA11Y_DEFAULT_TIMEOUT), matching the ValueError raised for an
+        // invalid per-call timeout argument.
+        xa11y::Error::InvalidConfig { message } => {
+            PyValueError::new_err(format!("Invalid configuration: {message}"))
+        }
         xa11y::Error::Platform { code, message } => {
             PlatformError::new_err(format!("Platform error ({code}): {message}"))
         }
@@ -732,71 +738,84 @@ impl Locator {
     }
 
     // ── Wait operations ──
+    //
+    // `timeout=None` (the default) resolves to the process-wide default —
+    // 5 seconds unless overridden via `set_default_timeout()` or the
+    // `XA11Y_DEFAULT_TIMEOUT` environment variable. An explicit per-call
+    // `timeout=` always wins.
 
-    #[pyo3(signature = (timeout=5.0))]
-    fn wait_visible(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
+    #[pyo3(signature = (timeout=None))]
+    fn wait_visible(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<Element>> {
+        let timeout = effective_timeout(timeout)?;
         let inner = self.inner.clone();
         let el = py
-            .allow_threads(move || inner.wait_visible(Duration::from_secs_f64(timeout)))
+            .allow_threads(move || inner.wait_visible(timeout))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
-    #[pyo3(signature = (timeout=5.0))]
-    fn wait_attached(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
+    #[pyo3(signature = (timeout=None))]
+    fn wait_attached(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<Element>> {
+        let timeout = effective_timeout(timeout)?;
         let inner = self.inner.clone();
         let el = py
-            .allow_threads(move || inner.wait_attached(Duration::from_secs_f64(timeout)))
+            .allow_threads(move || inner.wait_attached(timeout))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
-    #[pyo3(signature = (timeout=5.0))]
-    fn wait_detached(&self, py: Python<'_>, timeout: f64) -> PyResult<()> {
+    #[pyo3(signature = (timeout=None))]
+    fn wait_detached(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<()> {
+        let timeout = effective_timeout(timeout)?;
         let inner = self.inner.clone();
-        py.allow_threads(move || inner.wait_detached(Duration::from_secs_f64(timeout)))
+        py.allow_threads(move || inner.wait_detached(timeout))
             .map_err(to_py_err)
     }
 
-    #[pyo3(signature = (timeout=5.0))]
-    fn wait_enabled(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
+    #[pyo3(signature = (timeout=None))]
+    fn wait_enabled(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<Element>> {
+        let timeout = effective_timeout(timeout)?;
         let inner = self.inner.clone();
         let el = py
-            .allow_threads(move || inner.wait_enabled(Duration::from_secs_f64(timeout)))
+            .allow_threads(move || inner.wait_enabled(timeout))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
-    #[pyo3(signature = (timeout=5.0))]
-    fn wait_hidden(&self, py: Python<'_>, timeout: f64) -> PyResult<()> {
+    #[pyo3(signature = (timeout=None))]
+    fn wait_hidden(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<()> {
+        let timeout = effective_timeout(timeout)?;
         let inner = self.inner.clone();
-        py.allow_threads(move || inner.wait_hidden(Duration::from_secs_f64(timeout)))
+        py.allow_threads(move || inner.wait_hidden(timeout))
             .map_err(to_py_err)
     }
 
-    #[pyo3(signature = (timeout=5.0))]
-    fn wait_disabled(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
+    #[pyo3(signature = (timeout=None))]
+    fn wait_disabled(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<Element>> {
+        let timeout = effective_timeout(timeout)?;
         let inner = self.inner.clone();
         let el = py
-            .allow_threads(move || inner.wait_disabled(Duration::from_secs_f64(timeout)))
+            .allow_threads(move || inner.wait_disabled(timeout))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
-    #[pyo3(signature = (timeout=5.0))]
-    fn wait_focused(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
+    #[pyo3(signature = (timeout=None))]
+    fn wait_focused(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<Element>> {
+        let timeout = effective_timeout(timeout)?;
         let inner = self.inner.clone();
         let el = py
-            .allow_threads(move || inner.wait_focused(Duration::from_secs_f64(timeout)))
+            .allow_threads(move || inner.wait_focused(timeout))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
-    #[pyo3(signature = (timeout=5.0))]
-    fn wait_unfocused(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
+    #[pyo3(signature = (timeout=None))]
+    fn wait_unfocused(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<Element>> {
+        let timeout = effective_timeout(timeout)?;
         let inner = self.inner.clone();
         let el = py
-            .allow_threads(move || inner.wait_unfocused(Duration::from_secs_f64(timeout)))
+            .allow_threads(move || inner.wait_unfocused(timeout))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
@@ -806,8 +825,14 @@ impl Locator {
     /// A predicate that *raises* aborts the wait immediately and propagates
     /// the exception — it is not swallowed as "not yet" (which would
     /// resurface later as a misleading timeout). Mirrors `App.find`.
-    #[pyo3(signature = (predicate, timeout=5.0))]
-    fn wait_until(&self, py: Python<'_>, predicate: PyObject, timeout: f64) -> PyResult<()> {
+    #[pyo3(signature = (predicate, timeout=None))]
+    fn wait_until(
+        &self,
+        py: Python<'_>,
+        predicate: PyObject,
+        timeout: Option<f64>,
+    ) -> PyResult<()> {
+        let timeout = effective_timeout(timeout)?;
         let provider = self.inner.provider().clone();
         let inner = self.inner.clone();
         // The poll loop runs with the GIL released (tenet 5); the predicate
@@ -847,7 +872,7 @@ impl Locator {
                         }
                     })
                 },
-                Duration::from_secs_f64(timeout),
+                timeout,
             )
         });
         // A stashed predicate error takes precedence — re-raise the exact
@@ -1158,6 +1183,16 @@ fn timeout_from(timeout: f64) -> PyResult<Duration> {
     }
 }
 
+/// Resolve an optional per-call `timeout` (seconds) to a [`Duration`]: an
+/// explicit value wins; `None` falls back to the process-wide default (see
+/// `set_default_timeout` / the `XA11Y_DEFAULT_TIMEOUT` environment variable).
+fn effective_timeout(timeout: Option<f64>) -> PyResult<Duration> {
+    match timeout {
+        Some(secs) => timeout_from(secs),
+        None => xa11y::default_timeout().map_err(to_py_err),
+    }
+}
+
 /// `App` is **not** an `Element`. It represents the application as a whole
 /// and provides a `locator()` to search its accessibility tree.
 #[pyclass(frozen)]
@@ -1175,15 +1210,17 @@ impl App {
     /// Find an application by exact name.
     ///
     /// Polls the accessibility API until the app appears or `timeout`
-    /// (in seconds) elapses. Defaults to 5 seconds — pass `timeout=0`
-    /// for a single attempt with no waiting. Only "not found" errors
-    /// trigger a retry; other errors fail fast.
+    /// (in seconds) elapses. Defaults to the process-wide default timeout
+    /// (5 seconds unless overridden via `set_default_timeout()` /
+    /// `XA11Y_DEFAULT_TIMEOUT`) — pass `timeout=0` for a single attempt
+    /// with no waiting. Only "not found" errors trigger a retry; other
+    /// errors fail fast.
     #[staticmethod]
-    #[pyo3(signature = (name, *, timeout=5.0))]
-    fn by_name(py: Python<'_>, name: &str, timeout: f64) -> PyResult<Self> {
+    #[pyo3(signature = (name, *, timeout=None))]
+    fn by_name(py: Python<'_>, name: &str, timeout: Option<f64>) -> PyResult<Self> {
         // Validate `timeout` before touching the provider so callers get a
         // crisp `ValueError` regardless of whether accessibility is set up.
-        let timeout = timeout_from(timeout)?;
+        let timeout = effective_timeout(timeout)?;
         let provider = get_provider()?;
         let app = py
             .allow_threads(move || xa11y::App::by_name_with(provider, name, timeout))
@@ -1208,9 +1245,9 @@ impl App {
     ///
     /// See [`by_name`] for `timeout` semantics.
     #[staticmethod]
-    #[pyo3(signature = (pid, *, timeout=5.0))]
-    fn by_pid(py: Python<'_>, pid: u32, timeout: f64) -> PyResult<Self> {
-        let timeout = timeout_from(timeout)?;
+    #[pyo3(signature = (pid, *, timeout=None))]
+    fn by_pid(py: Python<'_>, pid: u32, timeout: Option<f64>) -> PyResult<Self> {
+        let timeout = effective_timeout(timeout)?;
         let provider = get_provider()?;
         let app = py
             .allow_threads(move || xa11y::App::by_pid_with(provider, pid, timeout))
@@ -1250,9 +1287,9 @@ impl App {
     /// )
     /// ```
     #[staticmethod]
-    #[pyo3(signature = (predicate, *, timeout=5.0))]
-    fn find(predicate: PyObject, timeout: f64) -> PyResult<Self> {
-        let timeout = timeout_from(timeout)?;
+    #[pyo3(signature = (predicate, *, timeout=None))]
+    fn find(predicate: PyObject, timeout: Option<f64>) -> PyResult<Self> {
+        let timeout = effective_timeout(timeout)?;
         let provider = get_provider()?;
         // The predicate is Python, so the poll loop must hold the GIL to call
         // it (mirrors `Locator.wait_until`). We route through `try_find_with`
@@ -1641,10 +1678,41 @@ fn locator_fn(selector: &str) -> PyResult<Locator> {
     })
 }
 
+/// Set the process-wide default timeout, in seconds.
+///
+/// Becomes the default for every auto-waiting action method, `wait_*` call,
+/// and app lookup (`App.by_name` / `App.by_pid` / `App.find`) that doesn't
+/// pass an explicit `timeout=`. An explicit per-call `timeout=` always wins.
+/// Takes precedence over the `XA11Y_DEFAULT_TIMEOUT` environment variable.
+///
+/// Pass `0` for "single attempt, no polling" semantics. Raises `ValueError`
+/// for negative or non-finite values.
+#[pyfunction]
+fn set_default_timeout(timeout: f64) -> PyResult<()> {
+    xa11y::set_default_timeout(timeout_from(timeout)?);
+    Ok(())
+}
+
+/// Get the effective process-wide default timeout, in seconds.
+///
+/// Resolution order: `set_default_timeout()` value, else the
+/// `XA11Y_DEFAULT_TIMEOUT` environment variable (read once at import), else
+/// the built-in 5.0.
+#[pyfunction]
+fn get_default_timeout() -> PyResult<f64> {
+    Ok(xa11y::default_timeout().map_err(to_py_err)?.as_secs_f64())
+}
+
 // ── Module definition ───────────────────────────────────────────────────────
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Read and validate XA11Y_DEFAULT_TIMEOUT now, so a malformed value
+    // fails `import xa11y` with a clear ValueError instead of surfacing on
+    // the first auto-wait (tenet 1: no silent fallback to the built-in
+    // default).
+    xa11y::default_timeout().map_err(to_py_err)?;
+
     m.add_class::<App>()?;
     m.add_class::<Element>()?;
     m.add_class::<Event>()?;
@@ -1670,6 +1738,10 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Re-export as "locator" in Python
     let locator_fn_obj = m.getattr("locator_fn")?;
     m.setattr("locator", &locator_fn_obj)?;
+
+    // Process-wide default timeout knobs
+    m.add_function(wrap_pyfunction!(set_default_timeout, m)?)?;
+    m.add_function(wrap_pyfunction!(get_default_timeout, m)?)?;
 
     // Input simulation factory
     m.add_function(wrap_pyfunction!(input_sim, m)?)?;

--- a/xa11y-python/tests/test_default_timeout.py
+++ b/xa11y-python/tests/test_default_timeout.py
@@ -1,0 +1,180 @@
+"""Tests for the process-wide default timeout (issue #259).
+
+`set_default_timeout` / `get_default_timeout` configure the default used by
+every auto-waiting action method, ``wait_*`` call, and app lookup that
+doesn't pass an explicit ``timeout=``. The env-var path
+(``XA11Y_DEFAULT_TIMEOUT``) is read once at import, so it is exercised in
+subprocesses with a controlled environment.
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+import xa11y
+from xa11y._native import _make_test_action_probe
+
+BUILTIN_DEFAULT = 5.0
+
+# Ceiling for "this must not have waited out a long timeout" assertions.
+# Generous so slow CI runners don't flake, while still far below the long
+# timeouts the tests configure.
+FAST_CEILING = 3.0
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_timeout():
+    """Reset the global default after each test — it is process-wide state."""
+    yield
+    xa11y.set_default_timeout(BUILTIN_DEFAULT)
+
+
+def test_builtin_default_is_five_seconds():
+    assert xa11y.get_default_timeout() == BUILTIN_DEFAULT
+
+
+def test_set_and_get_round_trip():
+    xa11y.set_default_timeout(12.5)
+    assert xa11y.get_default_timeout() == 12.5
+
+
+def test_set_default_timeout_rejects_negative():
+    with pytest.raises(ValueError, match="non-negative"):
+        xa11y.set_default_timeout(-1.0)
+
+
+def test_set_default_timeout_rejects_nan():
+    with pytest.raises(ValueError, match="non-negative"):
+        xa11y.set_default_timeout(float("nan"))
+
+
+def test_set_default_timeout_rejects_infinity():
+    with pytest.raises(ValueError, match="non-negative"):
+        xa11y.set_default_timeout(float("inf"))
+
+
+def test_invalid_value_does_not_change_default():
+    with pytest.raises(ValueError):
+        xa11y.set_default_timeout(-1.0)
+    assert xa11y.get_default_timeout() == BUILTIN_DEFAULT
+
+
+def test_auto_wait_action_uses_global_default():
+    """Action methods (which take no timeout parameter) honor the global."""
+    probe = _make_test_action_probe()
+    missing = probe.locator('button[name="DoesNotExist"]')
+
+    xa11y.set_default_timeout(0.3)
+    start = time.monotonic()
+    with pytest.raises(xa11y.TimeoutError):
+        missing.press()
+    assert time.monotonic() - start < FAST_CEILING, (
+        "auto-wait must use the 0.3s global default, not the built-in 5s"
+    )
+
+
+def test_wait_method_uses_global_default_when_no_arg():
+    probe = _make_test_action_probe()
+    missing = probe.locator('button[name="DoesNotExist"]')
+
+    xa11y.set_default_timeout(0.3)
+    start = time.monotonic()
+    with pytest.raises(xa11y.TimeoutError):
+        missing.wait_visible()
+    assert time.monotonic() - start < FAST_CEILING
+
+
+def test_explicit_timeout_beats_global_default():
+    probe = _make_test_action_probe()
+    missing = probe.locator('button[name="DoesNotExist"]')
+
+    xa11y.set_default_timeout(60.0)
+    start = time.monotonic()
+    with pytest.raises(xa11y.TimeoutError):
+        missing.wait_visible(timeout=0.2)
+    assert time.monotonic() - start < FAST_CEILING, (
+        "explicit timeout=0.2 must win over the 60s global default"
+    )
+
+
+def test_zero_default_is_single_attempt():
+    """``0`` keeps "single attempt, no polling": an actionable element still
+    succeeds on the one attempt; a missing one fails immediately."""
+    probe = _make_test_action_probe()
+    xa11y.set_default_timeout(0.0)
+
+    probe.locator('button[name="Back"]').press()
+    assert any(action == "press" for _, action, _ in probe.actions()), (
+        "zero timeout must still allow one successful attempt"
+    )
+
+    start = time.monotonic()
+    with pytest.raises(xa11y.TimeoutError):
+        probe.locator('button[name="DoesNotExist"]').press()
+    assert time.monotonic() - start < FAST_CEILING
+
+
+def test_wait_visible_rejects_negative_timeout():
+    # Regression: a negative explicit timeout used to reach
+    # Duration::from_secs_f64 and panic; it must be a ValueError.
+    probe = _make_test_action_probe()
+    with pytest.raises(ValueError, match="non-negative"):
+        probe.locator("button").wait_visible(timeout=-1.0)
+
+
+def test_app_lookup_validates_explicit_timeout_with_global_set():
+    # App.by_name with an explicit bad timeout still raises ValueError
+    # regardless of the global default.
+    xa11y.set_default_timeout(0.1)
+    with pytest.raises(ValueError, match="non-negative"):
+        xa11y.App.by_name("ignored", timeout=-1.0)
+
+
+# ── Environment variable (read once at import → subprocess tests) ────────────
+
+
+def _run_python(code: str, env_value: str | None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("XA11Y_DEFAULT_TIMEOUT", None)
+    if env_value is not None:
+        env["XA11Y_DEFAULT_TIMEOUT"] = env_value
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_env_var_sets_default():
+    result = _run_python("import xa11y; print(xa11y.get_default_timeout())", env_value="12.5")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "12.5"
+
+
+def test_set_default_timeout_overrides_env_var():
+    result = _run_python(
+        "import xa11y; xa11y.set_default_timeout(2.0); print(xa11y.get_default_timeout())",
+        env_value="12.5",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "2.0"
+
+
+def test_invalid_env_var_fails_import():
+    result = _run_python("import xa11y", env_value="not-a-number")
+    assert result.returncode != 0, (
+        "import must fail loudly on a malformed XA11Y_DEFAULT_TIMEOUT, "
+        "not silently fall back to the built-in default"
+    )
+    assert "XA11Y_DEFAULT_TIMEOUT" in result.stderr
+    assert "ValueError" in result.stderr
+
+
+def test_negative_env_var_fails_import():
+    result = _run_python("import xa11y", env_value="-3")
+    assert result.returncode != 0
+    assert "XA11Y_DEFAULT_TIMEOUT" in result.stderr

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -27,6 +27,13 @@ pub use xa11y_core::{
     Toggled, TreeNode,
 };
 
+// Re-export the process-wide default-timeout configuration (see
+// `xa11y_core::config`): the default for every auto-wait / `wait_*` call
+// that doesn't pass an explicit timeout. `set_default_timeout` overrides the
+// `XA11Y_DEFAULT_TIMEOUT` environment variable, which overrides the built-in
+// 5 seconds.
+pub use xa11y_core::{default_timeout, set_default_timeout, DEFAULT_TIMEOUT_ENV_VAR};
+
 // Re-export input simulation surface.
 pub use xa11y_core::input;
 pub use xa11y_core::{


### PR DESCRIPTION
Adds a process-wide default timeout that replaces the hardcoded 5s
auto-wait, so consumers (e.g. slow CI runners) can raise it once instead
of threading timeout= through every call site (#259).

Core (xa11y-core):
- New config module: set_default_timeout(Duration) and
  default_timeout(), with the XA11Y_DEFAULT_TIMEOUT env var (seconds)
  read once on first use. Precedence: explicit per-call timeout >
  programmatic global > env var > built-in 5s.
- An invalid env value surfaces as the new Error::InvalidConfig instead
  of silently falling back (tenet 1).
- Locator.timeout is now Option<Duration> resolved at use time, so
  set_default_timeout affects locators created before the call
  (Playwright semantics); with_timeout still wins.
- auto_wait/poll_until now attempt before checking the deadline, so
  Duration::ZERO performs exactly one attempt — matching poll_lookup's
  documented contract (previously zero timed out without attempting).

Python (xa11y-python):
- xa11y.set_default_timeout(s) / xa11y.get_default_timeout().
- wait_*, wait_until, App.by_name/by_pid/find now default to
  timeout=None, resolving to the global default; explicit values win.
- A malformed XA11Y_DEFAULT_TIMEOUT fails 'import xa11y' with a clear
  ValueError rather than surfacing on the first auto-wait.
- Negative explicit wait_* timeouts now raise ValueError instead of
  panicking in Duration::from_secs_f64.

JS (xa11y-js):
- setDefaultTimeout(s) / getDefaultTimeout(), wait* methods, App
  byName/byPid options, and the JS-layer waitUntil/App.find loops all
  resolve omitted timeouts from the global default.
- Negative explicit wait timeouts now reject instead of crashing.

Docs/tests: guide section on the default timeout, regenerated-stub
docstrings, and unit tests across all three layers (env-var paths
covered via subprocess tests).

Closes #259

https://claude.ai/code/session_01DgffT3AmhiV6u9TaeDVRNN