### PR TITLE
Add tenets 5 & 6: GIL-free waits and self-diagnosing errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,23 @@ Integration tests use shared helpers from `xa11y/tests/integ/mod.rs`:
    - **Tests** may use `.expect("...")` with a descriptive message when failure would indicate a broken test fixture.
    - If you add a new `.unwrap()`, a reviewer should be able to point at an invariant one line above that proves it can't panic.
 
+5. **Blocking calls release the host runtime's lock.** In language bindings, any call that can block, sleep, or poll — waits, auto-waiting actions, attach/discovery loops, event receives — must release the host runtime's global lock (Python's GIL, or the platform equivalent) for the duration of the block. A wait that holds the GIL freezes every other thread in the consumer's process for up to the full timeout, and forces consumers into architectural workarounds (e.g. moving an in-process mock server into a separate process).
+
+   **Anti-patterns that violate this tenet:**
+   - A binding method that calls a core wait/poll loop directly instead of inside `py.allow_threads` (or the platform equivalent).
+   - Holding the lock across a whole poll loop because one step needs it. The only legitimate reason to hold the lock is calling back into the host language (e.g. a Python predicate in `wait_until` / `App.find`) — reacquire it per callback, never for the loop.
+   - Treating this as an optimization. A missing `allow_threads` on a blocking path is a correctness bug, not a style choice.
+
+   Enforced for Python by `xa11y-python/tests/test_gil_release.py`, which asserts that a background thread keeps making progress while a native wait blocks.
+
+6. **Errors carry their own diagnosis.** An error must contain enough context to understand the failure without re-running it under extra logging. If a consumer would need to wrap a call in `try/except` just to print surrounding state — which selector, what condition, what the tree looked like — that state belongs in the error itself. The structured carrier for this context is `Diagnosis` in `xa11y-core/src/error.rs`; new failure paths attach one at the *terminal* failure site (see the module docs there for the pattern).
+
+   **Anti-patterns that violate this tenet:**
+   - A timeout that reports only the duration. `Timeout after 60.0s` is a bug; it must say what it was waiting for (selector + condition) and what it last observed (e.g. "matched but visible=false" vs. "never matched").
+   - "Not found"-class errors that echo only the input. They should describe where they searched and what they *did* find (near-miss candidates, enumeration counts, a bounded snapshot of the search scope).
+   - Rich context that exists only in the message string. Bindings expose it as structured fields (exception attributes in Python, error properties in JS) so harnesses can act on it programmatically, not parse prose.
+   - Unbounded diagnostics. Context is collected on the failure path only and is size-bounded (depth-limited tree snapshots, truncated candidate lists) — rich errors must never slow the success path or emit megabyte messages. In particular, never attach an expensive `Diagnosis` to an error that poll loops use as a retry signal; enrich at the point where the error actually reaches the user.
+
 ### Breaking a tenet
 
 These tenets are firm defaults, not absolutes. If a situation genuinely requires breaking one:

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
             { label: "Overview", slug: "guides/overview" },
             { label: "CLI", slug: "guides/cli" },
             { label: "Desktop Testing", slug: "guides/desktop-testing" },
+            { label: "Errors & Diagnosis", slug: "guides/errors" },
             { label: "Testing in CI", slug: "guides/ci" },
             { label: "Input Simulation", slug: "guides/input" },
             { label: "Screenshots", slug: "guides/screenshots" },

--- a/docs/site/src/content/docs/guides/errors.mdx
+++ b/docs/site/src/content/docs/guides/errors.mdx
@@ -1,0 +1,156 @@
+---
+title: Errors & Diagnosis
+description: xa11y errors carry their own diagnosis — selectors, wait conditions, last observations, and bounded scope snapshots.
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+xa11y errors are designed so you never have to re-run a failure under extra
+logging to understand it. A timeout tells you *what it was waiting for* and
+*what it last saw*; a selector miss tells you *what was actually there*. The
+same information is available two ways:
+
+- **Rendered into the message** — the exception text alone is enough to
+  diagnose a CI failure from the log.
+- **As structured fields** — exception attributes in Python, error
+  properties in JavaScript, and the [`Diagnosis`] struct in Rust — so
+  harnesses can act on them programmatically instead of parsing prose.
+
+## Anatomy of a timeout
+
+A failed `wait_visible(timeout=60)` renders like this:
+
+```text
+xa11y.TimeoutError: Timeout after 60.0s; waiting for: visible; selector:
+dialog[name^="Submit to AWS Deadline Cloud"]; last observed: selector never
+matched; candidates: window "Untitled — Cinema 4D"
+search scope (bounded):
+application "Cinema 4D" (pid=4242)
+application "Finder" (pid=512)
+…
+```
+
+Reading it back:
+
+- **`waiting for`** — the wait condition: `visible`, `attached`,
+  `enabled`, … for the `wait_*` methods; `press target actionable
+  (visible && enabled)` for an auto-waiting action; `event matching
+  predicate` for event waits; `custom predicate` for `wait_until`.
+- **`selector`** — the full selector the locator was resolving.
+- **`last observed`** — the final poll's observation. This is the key
+  distinction when debugging:
+  - `selector never matched` — the element was never there (wrong selector,
+    wrong window, app not ready).
+  - `matched button "Export" (visible=false, enabled=true, focused=false)`
+    — the element *was* there, but in the wrong state. No candidate or
+    scope sweep is attached in this case; the states tell the story.
+  - `selector matched 2 element(s); nth(5) requested` — an `nth()` index
+    out of range.
+- **`candidates`** — near-misses: elements with the selector's target role
+  but different attributes. A typo like `button[name="Exprot"]` lists
+  `button "Export"` right in the error.
+- **`search scope (bounded)`** — a depth-limited, line-capped snapshot of
+  where the search happened: a tree dump for scoped locators, the running
+  application list for rootless ones and app lookups. This replaces the
+  `print(app.dump())` wrapper you'd otherwise write around the failing call.
+
+Selector misses from fail-fast calls (`element()`, `tree()`, `dump()`)
+carry the same context on `SelectorNotMatchedError`.
+
+Diagnosis collection is **bounded and failure-path-only**: candidate lists
+and snapshots are truncated (a miss against a huge tree cannot produce a
+megabyte message), and nothing is collected unless the operation has
+already failed.
+
+## Structured access
+
+<Tabs syncKey="lang">
+  <TabItem label="Python">
+    ```python
+    import xa11y
+
+    try:
+        dialog.wait_visible(timeout=60)
+    except xa11y.TimeoutError as e:
+        e.condition      # "visible"
+        e.selector       # 'dialog[name^="Submit"]'
+        e.last_observed  # 'selector never matched'
+        e.candidates     # ['window "Untitled — Cinema 4D"', ...]
+        e.scope          # bounded tree dump / app list (str)
+        e.elapsed        # 60.0  (seconds, float)
+    ```
+
+    Every attribute is always present (`None` / `[]` when not applicable),
+    so no `hasattr` guards are needed. `SelectorNotMatchedError` exposes
+    the same fields (`elapsed` is always `None` there).
+  </TabItem>
+  <TabItem label="JavaScript">
+    ```js
+    const { TimeoutError } = require('xa11y');
+
+    try {
+      await dialog.waitVisible(60);
+    } catch (e) {
+      if (e instanceof TimeoutError) {
+        e.condition;    // 'visible'
+        e.selector;     // 'dialog[name^="Submit"]'
+        e.lastObserved; // 'selector never matched'
+        e.candidates;   // ['window "Untitled — Cinema 4D"', ...]
+        e.scope;        // bounded tree dump / app list (string)
+        e.elapsedMs;    // 60000
+      }
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use std::time::Duration;
+    use xa11y::{Diagnosis, Error};
+
+    match dialog.wait_visible(Duration::from_secs(60)) {
+        Err(e @ Error::Timeout { .. }) => {
+            if let Some(d) = e.diagnosis() {
+                let _ = (&d.condition, &d.selector, &d.last_observed,
+                         &d.candidates, &d.scope);
+            }
+        }
+        other => { /* ... */ }
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+## App lookups
+
+`App.by_pid` / `App.by_name` / `App.find` timeouts list what *is* running,
+so an attach failure on an opaque CI runner is diagnosable from the message:
+
+```text
+xa11y.SelectorNotMatchedError: No element matched selector:
+application[pid=4242]; waiting for: application discovery; last observed:
+enumerated 12 running apps, 1 without a resolvable pid; candidates:
+"Finder" (pid=512), "Terminal" (pid=890), …
+```
+
+## Event waits
+
+`Subscription.wait_for` timeouts report how many non-matching events
+arrived, and distinguish a quiet stream from a disconnected one:
+
+```text
+Timeout after 5.0s; waiting for: event matching predicate; last observed:
+event source disconnected after 3 non-matching event(s) — no further
+events will arrive
+```
+
+## For contributors
+
+This behavior is governed by design tenet 6 (*errors carry their own
+diagnosis*) in `AGENTS.md`. The structured carrier is the `Diagnosis`
+struct in `xa11y-core/src/error.rs`; its module docs describe the pattern —
+enrich at the terminal failure site, keep poll-loop retry signals cheap,
+bound every payload, and never let diagnosis collection mask the original
+error. New failure paths should attach a `Diagnosis` rather than
+interpolating context into ad-hoc message strings.
+
+[`Diagnosis`]: https://docs.rs/xa11y/latest/xa11y/struct.Diagnosis.html

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -70,9 +70,7 @@ fn wait_for_registration(pid: u32) -> Result<App, Error> {
             }
         }
     }
-    Err(last.unwrap_or(Error::Timeout {
-        elapsed: STARTUP_TIMEOUT,
-    }))
+    Err(last.unwrap_or_else(|| Error::timeout(STARTUP_TIMEOUT)))
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/xa11y-core/src/app.rs
+++ b/xa11y-core/src/app.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::element::{Element, ElementData, TreeNode};
-use crate::error::{Error, Result};
+use crate::error::{Diagnosis, Error, Result};
 use crate::event_provider::Subscription;
 use crate::locator::Locator;
 use crate::provider::Provider;
@@ -10,14 +10,23 @@ use crate::provider::Provider;
 /// Polling interval shared by all timeout-bearing lookups.
 const LOOKUP_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Maximum number of running applications listed in a lookup-failure
+/// diagnosis. Bounded per tenet 6 — diagnostics must not grow with an
+/// unbounded environment.
+const DIAG_APP_LIST_LIMIT: usize = 20;
+
 /// Run `attempt` repeatedly until it succeeds or `timeout` elapses, treating
 /// `SelectorNotMatched` as a "not yet" signal. All other errors short-circuit.
 ///
 /// `Duration::ZERO` performs exactly one attempt — identical to a non-polling
-/// call. On timeout, returns the last `SelectorNotMatched` error.
-fn poll_lookup<F>(timeout: Duration, mut attempt: F) -> Result<App>
+/// call. On timeout, returns the last `SelectorNotMatched` error enriched
+/// with `diagnose()`'s context. `diagnose` runs only on that terminal
+/// failure (tenet 6: enrich at the terminal site, keep the retry signal
+/// cheap).
+fn poll_lookup<F, D>(timeout: Duration, mut attempt: F, diagnose: D) -> Result<App>
 where
     F: FnMut() -> Result<App>,
+    D: FnOnce() -> Diagnosis,
 {
     let start = Instant::now();
     loop {
@@ -25,12 +34,64 @@ where
             Ok(app) => return Ok(app),
             Err(e @ Error::SelectorNotMatched { .. }) => {
                 if start.elapsed() >= timeout {
-                    return Err(e);
+                    return Err(merge_diagnosis(e, diagnose()));
                 }
             }
             Err(e) => return Err(e),
         }
         std::thread::sleep(LOOKUP_POLL_INTERVAL);
+    }
+}
+
+/// Merge terminal-site context into an error that may already carry a cheap
+/// diagnosis from its construction site (e.g. the enumeration counts that
+/// `Provider::app_by_pid` records). Fields already present win — they
+/// describe the actual failing attempt.
+fn merge_diagnosis(err: Error, extra: Diagnosis) -> Error {
+    let mut d = err.diagnosis().cloned().unwrap_or_default();
+    if d.condition.is_none() {
+        d.condition = extra.condition;
+    }
+    if d.last_observed.is_none() {
+        d.last_observed = extra.last_observed;
+    }
+    if d.candidates.is_empty() {
+        d.candidates = extra.candidates;
+    }
+    if d.scope.is_none() {
+        d.scope = extra.scope;
+    }
+    err.diagnose(d)
+}
+
+/// Bounded "what *is* running" snapshot for application-lookup failures:
+/// the candidate list a consumer would otherwise produce by hand-logging
+/// `App::list()` around the failure.
+fn running_apps_diagnosis(provider: &Arc<dyn Provider>) -> Diagnosis {
+    let candidates = match provider.list_apps() {
+        Ok(apps) => {
+            let total = apps.len();
+            let mut out: Vec<String> = apps
+                .iter()
+                .take(DIAG_APP_LIST_LIMIT)
+                .map(|a| {
+                    let pid = a.pid.map(|p| format!(" (pid={p})")).unwrap_or_default();
+                    format!("\"{}\"{pid}", a.name.clone().unwrap_or_default())
+                })
+                .collect();
+            if total > DIAG_APP_LIST_LIMIT {
+                out.push(format!("… (+{} more)", total - DIAG_APP_LIST_LIMIT));
+            }
+            out
+        }
+        // Surface the collection failure inside the diagnosis instead of
+        // dropping it (tenet 1) — the original lookup error still wins.
+        Err(e) => vec![format!("(application enumeration failed: {e})")],
+    };
+    Diagnosis {
+        condition: Some("application discovery".to_string()),
+        candidates,
+        ..Diagnosis::default()
     }
 }
 
@@ -106,27 +167,30 @@ impl App {
         F: Fn(&ElementData) -> Result<bool>,
         D: Fn() -> String,
     {
-        poll_lookup(timeout, || {
-            // Discovery is platform-specific (CGWindowList on macOS, AT-SPI
-            // registry on Linux, UIA desktop root on Windows). `list_apps()`
-            // is the canonical enumeration primitive and we filter in Rust,
-            // so app names containing `"`, `]`, or other characters
-            // significant in the selector grammar don't need escaping.
-            //
-            // Errors from `list_apps()` propagate so callers can distinguish
-            // "app not found" from "accessibility is broken". A predicate
-            // error propagates for the same reason — `poll_lookup` only
-            // retries `SelectorNotMatched`, so anything else fails fast.
-            let apps = provider.list_apps()?;
-            for data in apps {
-                if predicate(&data)? {
-                    return Ok(Self::from_data(Arc::clone(&provider), data));
+        let diag_provider = Arc::clone(&provider);
+        poll_lookup(
+            timeout,
+            || {
+                // Discovery is platform-specific (CGWindowList on macOS, AT-SPI
+                // registry on Linux, UIA desktop root on Windows). `list_apps()`
+                // is the canonical enumeration primitive and we filter in Rust,
+                // so app names containing `"`, `]`, or other characters
+                // significant in the selector grammar don't need escaping.
+                //
+                // Errors from `list_apps()` propagate so callers can distinguish
+                // "app not found" from "accessibility is broken". A predicate
+                // error propagates for the same reason — `poll_lookup` only
+                // retries `SelectorNotMatched`, so anything else fails fast.
+                let apps = provider.list_apps()?;
+                for data in apps {
+                    if predicate(&data)? {
+                        return Ok(Self::from_data(Arc::clone(&provider), data));
+                    }
                 }
-            }
-            Err(Error::SelectorNotMatched {
-                selector: describe(),
-            })
-        })
+                Err(Error::selector_not_matched(describe()))
+            },
+            || running_apps_diagnosis(&diag_provider),
+        )
     }
 
     /// Find an application by exact name, using an explicit provider.
@@ -197,10 +261,15 @@ impl App {
     /// so an app whose window is still unnamed mid-startup is found as soon
     /// as the accessibility API can reach it.
     pub fn by_pid_with(provider: Arc<dyn Provider>, pid: u32, timeout: Duration) -> Result<Self> {
-        poll_lookup(timeout, || {
-            let data = provider.app_by_pid(pid)?;
-            Ok(Self::from_data(Arc::clone(&provider), data))
-        })
+        let diag_provider = Arc::clone(&provider);
+        poll_lookup(
+            timeout,
+            || {
+                let data = provider.app_by_pid(pid)?;
+                Ok(Self::from_data(Arc::clone(&provider), data))
+            },
+            || running_apps_diagnosis(&diag_provider),
+        )
     }
 
     /// List all running applications, using an explicit provider.

--- a/xa11y-core/src/error.rs
+++ b/xa11y-core/src/error.rs
@@ -1,10 +1,133 @@
+//! Error types for xa11y operations.
+//!
+//! # The diagnosis pattern (tenet 6: errors carry their own diagnosis)
+//!
+//! Failure-path errors that a consumer might need to debug — timeouts and
+//! "not found" lookups — carry an optional structured [`Diagnosis`] alongside
+//! their identifying fields. The diagnosis answers the questions a consumer
+//! would otherwise have to answer by wrapping the call in logging: *what was
+//! the operation waiting for*, *what did it last observe*, and *what was
+//! actually there*.
+//!
+//! Rules for attaching a diagnosis to a new failure path:
+//!
+//! 1. **Enrich at the terminal site, not at construction.** Errors like
+//!    [`Error::SelectorNotMatched`] double as cheap retry signals inside poll
+//!    loops (`Locator::auto_wait`, `App::by_pid_with`). Constructing them must
+//!    stay allocation-light. Attach the diagnosis (via
+//!    [`Error::diagnose`]) only where the error escapes to the caller —
+//!    typically when a poll loop exhausts its timeout or a fail-fast query
+//!    returns.
+//! 2. **Bound the cost.** Diagnosis collection runs only on the failure path
+//!    and must be size-bounded: tree snapshots are depth-limited and
+//!    line-capped, candidate lists are truncated. See the `DIAG_*` constants
+//!    in `locator.rs`.
+//! 3. **Never mask the original error.** If collecting a diagnosis itself
+//!    fails (e.g. the scope dump errors because the app quit), record the
+//!    collection failure *inside* the diagnosis instead of dropping it or
+//!    replacing the original error.
+//! 4. **Keep it structured.** Language bindings expose the diagnosis as
+//!    structured fields (exception attributes in Python, error properties in
+//!    JS) in addition to rendering it into the message. New fields belong on
+//!    [`Diagnosis`], not interpolated into ad-hoc message strings.
+
 use crate::role::Role;
 
 /// Result type alias for xa11y operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Structured diagnostic context attached to failure-path errors.
+///
+/// See the [module docs](self) for the pattern governing when and how to
+/// attach one. All fields are optional; renderers skip empty fields.
+///
+/// Always construct with functional-update syntax —
+/// `Diagnosis { condition: ..., ..Diagnosis::default() }` — so adding a new
+/// diagnostic field later doesn't break existing construction sites.
+/// (`#[non_exhaustive]` would enforce that, but it also forbids struct
+/// expressions from the platform crates and bindings that build these.)
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Diagnosis {
+    /// What the operation was waiting for or trying to find, e.g.
+    /// `"visible"`, `"press target actionable (visible && enabled)"`,
+    /// `"event matching predicate"`, `"application with pid 1234"`.
+    pub condition: Option<String>,
+    /// The selector being resolved, when the failing operation had one and
+    /// it is not already part of the error's primary fields.
+    pub selector: Option<String>,
+    /// What was last observed before the failure, e.g.
+    /// `"matched button \"Export\" (visible=false, enabled=true)"`,
+    /// `"selector never matched"`, or
+    /// `"3 event(s) received, none matched"`.
+    pub last_observed: Option<String>,
+    /// Bounded list of near-miss candidates — elements or applications that
+    /// were present in the search scope and partially matched (e.g. same
+    /// role, different name).
+    pub candidates: Vec<String>,
+    /// Depth- and line-bounded rendering of the search scope (an indented
+    /// tree dump or an application list), so the consumer does not need to
+    /// re-run the failure under `print(app.dump())`.
+    pub scope: Option<String>,
+}
+
+impl Diagnosis {
+    /// True when no field carries any information.
+    pub fn is_empty(&self) -> bool {
+        self.condition.is_none()
+            && self.selector.is_none()
+            && self.last_observed.is_none()
+            && self.candidates.is_empty()
+            && self.scope.is_none()
+    }
+}
+
+impl std::fmt::Display for Diagnosis {
+    /// Renders as `; `-separated clauses appended to an error's primary
+    /// message, with the (potentially multi-line) scope on its own lines:
+    ///
+    /// ```text
+    /// ; waiting for: visible; last observed: selector never matched;
+    /// candidates: button "Back", button "Forward"
+    /// search scope (bounded):
+    ///   window "Main"
+    ///     ...
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(condition) = &self.condition {
+            write!(f, "; waiting for: {condition}")?;
+        }
+        if let Some(selector) = &self.selector {
+            write!(f, "; selector: {selector}")?;
+        }
+        if let Some(last) = &self.last_observed {
+            write!(f, "; last observed: {last}")?;
+        }
+        if !self.candidates.is_empty() {
+            write!(f, "; candidates: {}", self.candidates.join(", "))?;
+        }
+        if let Some(scope) = &self.scope {
+            write!(f, "\nsearch scope (bounded):\n{scope}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Render an optional boxed diagnosis as a message suffix ("" when absent or
+/// empty). Used by the `thiserror` display attributes below.
+fn diagnosis_suffix(diagnosis: &Option<Box<Diagnosis>>) -> String {
+    match diagnosis {
+        Some(d) if !d.is_empty() => d.to_string(),
+        _ => String::new(),
+    }
+}
+
 /// Structured error type for xa11y operations.
 /// Designed to be informative across FFI boundaries.
+///
+/// Construct [`SelectorNotMatched`](Error::SelectorNotMatched) and
+/// [`Timeout`](Error::Timeout) through [`Error::selector_not_matched`] /
+/// [`Error::timeout`] and attach context with [`Error::diagnose`] — see the
+/// [module docs](self) for the diagnosis pattern.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Accessibility permissions not granted.
@@ -19,8 +142,14 @@ pub enum Error {
     AccessibilityNotEnabled { app: String, instructions: String },
 
     /// No element matched the selector.
-    #[error("No element matched selector: {selector}")]
-    SelectorNotMatched { selector: String },
+    ///
+    /// Doubles as the "not yet" retry signal inside poll loops, so bare
+    /// construction stays cheap; terminal sites attach a [`Diagnosis`].
+    #[error("No element matched selector: {selector}{}", diagnosis_suffix(.diagnosis))]
+    SelectorNotMatched {
+        selector: String,
+        diagnosis: Option<Box<Diagnosis>>,
+    },
 
     /// The node's platform handle is stale and re-traversal could not relocate it.
     #[error("Element stale: could not relocate element for selector: {selector}")]
@@ -34,9 +163,15 @@ pub enum Error {
     #[error("Text value input not supported for this element")]
     TextValueNotSupported,
 
-    /// A wait_for or wait_for_event call exceeded its timeout.
-    #[error("Timeout after {elapsed:?}")]
-    Timeout { elapsed: std::time::Duration },
+    /// A wait operation exceeded its timeout.
+    ///
+    /// Always carries what the wait was for via its [`Diagnosis`] — a bare
+    /// "Timeout after Ns" tells the consumer nothing actionable (tenet 6).
+    #[error("Timeout after {elapsed:.1?}{}", diagnosis_suffix(.diagnosis))]
+    Timeout {
+        elapsed: std::time::Duration,
+        diagnosis: Option<Box<Diagnosis>>,
+    },
 
     /// The selector string could not be parsed.
     #[error("Invalid selector '{selector}': {message}")]
@@ -59,4 +194,137 @@ pub enum Error {
     /// A platform-specific error occurred.
     #[error("Platform error ({code}): {message}")]
     Platform { code: i64, message: String },
+}
+
+impl Error {
+    /// Construct a bare [`Error::SelectorNotMatched`] (no diagnosis).
+    ///
+    /// This is the cheap form for poll-loop retry signals; attach context at
+    /// the terminal site with [`diagnose`](Self::diagnose).
+    pub fn selector_not_matched(selector: impl Into<String>) -> Self {
+        Self::SelectorNotMatched {
+            selector: selector.into(),
+            diagnosis: None,
+        }
+    }
+
+    /// Construct a bare [`Error::Timeout`] (no diagnosis).
+    ///
+    /// Prefer attaching a [`Diagnosis`] with [`diagnose`](Self::diagnose)
+    /// before the error reaches a consumer — see tenet 6.
+    pub fn timeout(elapsed: std::time::Duration) -> Self {
+        Self::Timeout {
+            elapsed,
+            diagnosis: None,
+        }
+    }
+
+    /// Attach (or replace) a [`Diagnosis`] on errors that carry one.
+    ///
+    /// Supported variants: [`SelectorNotMatched`](Self::SelectorNotMatched)
+    /// and [`Timeout`](Self::Timeout). Other variants are returned unchanged —
+    /// their primary fields already identify the failure, and silently
+    /// growing a diagnosis field on them would not be rendered. An empty
+    /// diagnosis is normalized to `None`.
+    #[must_use]
+    pub fn diagnose(mut self, diagnosis: Diagnosis) -> Self {
+        let normalized = if diagnosis.is_empty() {
+            None
+        } else {
+            Some(Box::new(diagnosis))
+        };
+        match &mut self {
+            Self::SelectorNotMatched { diagnosis: d, .. } | Self::Timeout { diagnosis: d, .. } => {
+                *d = normalized;
+            }
+            _ => {}
+        }
+        self
+    }
+
+    /// The attached [`Diagnosis`], if this error carries one. Bindings use
+    /// this to expose structured fields on their exception types.
+    pub fn diagnosis(&self) -> Option<&Diagnosis> {
+        match self {
+            Self::SelectorNotMatched { diagnosis, .. } | Self::Timeout { diagnosis, .. } => {
+                diagnosis.as_deref()
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn bare_timeout_renders_duration_only() {
+        let err = Error::timeout(Duration::from_secs(5));
+        assert_eq!(format!("{err}"), "Timeout after 5.0s");
+    }
+
+    #[test]
+    fn diagnosed_timeout_renders_condition_selector_and_last_observed() {
+        let err = Error::timeout(Duration::from_secs(60)).diagnose(Diagnosis {
+            condition: Some("visible".into()),
+            selector: Some(r#"dialog[name^="Submit"]"#.into()),
+            last_observed: Some("selector never matched".into()),
+            ..Diagnosis::default()
+        });
+        let msg = format!("{err}");
+        assert!(msg.contains("Timeout after 60.0s"), "{msg}");
+        assert!(msg.contains("waiting for: visible"), "{msg}");
+        assert!(msg.contains(r#"selector: dialog[name^="Submit"]"#), "{msg}");
+        assert!(
+            msg.contains("last observed: selector never matched"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn diagnosed_not_matched_renders_candidates_and_scope() {
+        let err = Error::selector_not_matched(r#"button[name="Exprot"]"#).diagnose(Diagnosis {
+            candidates: vec![r#"button "Export""#.into(), r#"button "Cancel""#.into()],
+            scope: Some("  window \"Main\"\n    button \"Export\"".into()),
+            ..Diagnosis::default()
+        });
+        let msg = format!("{err}");
+        assert!(msg.contains("No element matched selector"), "{msg}");
+        assert!(
+            msg.contains(r#"candidates: button "Export", button "Cancel""#),
+            "{msg}"
+        );
+        assert!(msg.contains("search scope (bounded):"), "{msg}");
+    }
+
+    #[test]
+    fn empty_diagnosis_is_normalized_away() {
+        let err = Error::timeout(Duration::from_secs(1)).diagnose(Diagnosis::default());
+        assert!(err.diagnosis().is_none());
+        assert_eq!(format!("{err}"), "Timeout after 1.0s");
+    }
+
+    #[test]
+    fn diagnose_on_unsupported_variant_is_a_documented_no_op() {
+        let err = Error::NoElementBounds.diagnose(Diagnosis {
+            condition: Some("anything".into()),
+            ..Diagnosis::default()
+        });
+        assert!(err.diagnosis().is_none());
+    }
+
+    #[test]
+    fn diagnosis_accessor_round_trips() {
+        let err = Error::selector_not_matched("button").diagnose(Diagnosis {
+            last_observed: Some("selector matched 1 element(s); nth(3) requested".into()),
+            ..Diagnosis::default()
+        });
+        let d = err.diagnosis().expect("diagnosis must be attached");
+        assert_eq!(
+            d.last_observed.as_deref(),
+            Some("selector matched 1 element(s); nth(3) requested")
+        );
+    }
 }

--- a/xa11y-core/src/event_provider.rs
+++ b/xa11y-core/src/event_provider.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::error::{Error, Result};
+use crate::error::{Diagnosis, Error, Result};
 use crate::event::Event;
 
 /// A live event subscription. Drop to unsubscribe.
@@ -28,9 +28,12 @@ impl Subscription {
 
     /// Block until an event arrives or the timeout expires.
     pub fn recv(&self, timeout: Duration) -> Result<Event> {
-        self.rx
-            .recv_timeout(timeout)
-            .ok_or(Error::Timeout { elapsed: timeout })
+        self.rx.recv_timeout(timeout).ok_or_else(|| {
+            Error::timeout(timeout).diagnose(Diagnosis {
+                condition: Some("any accessibility event".to_string()),
+                ..Diagnosis::default()
+            })
+        })
     }
 
     /// Block until an event arrives, the timeout expires, or the event source
@@ -49,12 +52,15 @@ impl Subscription {
     /// burning the remainder of the timeout in a dead poll loop is pointless.
     pub fn wait_for(&self, predicate: impl Fn(&Event) -> bool, timeout: Duration) -> Result<Event> {
         let start = std::time::Instant::now();
+        let mut seen: usize = 0;
         loop {
             let remaining = timeout.saturating_sub(start.elapsed());
             if remaining.is_zero() {
-                return Err(Error::Timeout {
-                    elapsed: start.elapsed(),
-                });
+                return Err(Error::timeout(start.elapsed()).diagnose(Diagnosis {
+                    condition: Some("event matching predicate".to_string()),
+                    last_observed: Some(format!("{seen} event(s) received, none matched")),
+                    ..Diagnosis::default()
+                }));
             }
             // Poll with short recv timeouts so we can re-check the deadline,
             // and break out early on disconnect instead of polling a dead
@@ -65,12 +71,18 @@ impl Subscription {
                     if predicate(&event) {
                         return Ok(*event);
                     }
+                    seen += 1;
                 }
                 RecvStatus::Timeout => continue,
                 RecvStatus::Disconnected => {
-                    return Err(Error::Timeout {
-                        elapsed: start.elapsed(),
-                    });
+                    return Err(Error::timeout(start.elapsed()).diagnose(Diagnosis {
+                        condition: Some("event matching predicate".to_string()),
+                        last_observed: Some(format!(
+                            "event source disconnected after {seen} non-matching event(s) — \
+                             no further events will arrive"
+                        )),
+                        ..Diagnosis::default()
+                    }));
                 }
             }
         }

--- a/xa11y-core/src/lib.rs
+++ b/xa11y-core/src/lib.rs
@@ -21,7 +21,7 @@ pub mod mock;
 // Re-export primary types at the crate root for convenience.
 pub use app::App;
 pub use element::{Element, ElementData, RawPlatformData, Rect, StateSet, Toggled, TreeNode};
-pub use error::{Error, Result};
+pub use error::{Diagnosis, Error, Result};
 pub use event::{ElementState, Event, EventKind, StateFlag};
 pub use event_provider::{CancelHandle, EventReceiver, RecvStatus, Subscription, SubscriptionIter};
 pub use input::{

--- a/xa11y-core/src/locator.rs
+++ b/xa11y-core/src/locator.rs
@@ -2,10 +2,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::element::{Element, ElementData};
-use crate::error::{Error, Result};
+use crate::error::{Diagnosis, Error, Result};
 use crate::event::ElementState;
 use crate::provider::Provider;
-use crate::selector::{chain_combinator, matches_simple, SelectorGroup};
+use crate::selector::{
+    chain_combinator, matches_simple, Combinator, Selector, SelectorGroup, SelectorSegment,
+    SimpleSelector,
+};
 
 /// A lazy element descriptor that re-resolves against a fresh accessibility
 /// tree on every operation.
@@ -27,6 +30,68 @@ use crate::selector::{chain_combinator, matches_simple, SelectorGroup};
 /// ```
 /// Default auto-wait timeout for Locator action methods (5 seconds).
 const DEFAULT_ACTION_TIMEOUT: Duration = Duration::from_secs(5);
+
+// ── Diagnosis bounds (tenet 6) ──────────────────────────────────────
+//
+// Diagnosis collection runs only on the failure path, after a wait has
+// already burned its timeout or a fail-fast query missed — but it must stay
+// size-bounded so a miss against a huge tree doesn't produce a megabyte
+// error message or a multi-second stall on top of the failure.
+
+/// Maximum number of same-role near-miss candidates listed in a diagnosis.
+const DIAG_CANDIDATE_LIMIT: usize = 8;
+/// Maximum tree depth captured for the scope snapshot in a diagnosis.
+const DIAG_SCOPE_MAX_DEPTH: usize = 5;
+/// Maximum number of lines (tree dump) or entries (application list) kept in
+/// the scope snapshot; the remainder is summarized as a truncation marker.
+const DIAG_SCOPE_MAX_LINES: usize = 40;
+
+/// Short element rendering for candidate lists: `button "Export"`.
+fn short_describe(data: &ElementData) -> String {
+    match &data.name {
+        Some(n) => format!("{} \"{n}\"", data.role.to_snake_case()),
+        None => format!("{} (unnamed)", data.role.to_snake_case()),
+    }
+}
+
+/// Element rendering for `last observed` clauses, including the states the
+/// wait conditions are defined over.
+fn describe_observed(data: &ElementData) -> String {
+    format!(
+        "matched {} (visible={}, enabled={}, focused={})",
+        short_describe(data),
+        data.states.visible,
+        data.states.enabled,
+        data.states.focused
+    )
+}
+
+/// Cap a multi-line string at `max_lines`, appending a truncation marker
+/// that says how much was dropped.
+fn truncate_lines(s: &str, max_lines: usize) -> String {
+    let mut lines = s.lines();
+    let kept: Vec<&str> = lines.by_ref().take(max_lines).collect();
+    let remaining = lines.count();
+    if remaining == 0 {
+        kept.join("\n")
+    } else {
+        format!("{}\n… (+{remaining} more lines truncated)", kept.join("\n"))
+    }
+}
+
+/// Human label for a wait condition, used in timeout diagnoses.
+fn state_label(state: ElementState) -> &'static str {
+    match state {
+        ElementState::Attached => "attached",
+        ElementState::Detached => "detached",
+        ElementState::Visible => "visible",
+        ElementState::Hidden => "hidden",
+        ElementState::Enabled => "enabled",
+        ElementState::Disabled => "disabled",
+        ElementState::Focused => "focused",
+        ElementState::Unfocused => "unfocused",
+    }
+}
 
 #[derive(Clone)]
 pub struct Locator {
@@ -233,12 +298,166 @@ impl Locator {
         };
         let matches = self.resolve_group(&group, provider_limit)?;
         let idx = self.nth.unwrap_or(0);
-        matches
-            .into_iter()
-            .nth(idx)
-            .ok_or_else(|| Error::SelectorNotMatched {
-                selector: self.selector.clone(),
-            })
+        let total = matches.len();
+        matches.into_iter().nth(idx).ok_or_else(|| {
+            let err = Error::selector_not_matched(self.selector.clone());
+            if total > 0 {
+                // The selector itself matched but not enough times for `nth`.
+                // This is exact even under limit pushdown: the limit is
+                // `idx + 1`, and we only get here when fewer were returned.
+                err.diagnose(Diagnosis {
+                    last_observed: Some(format!(
+                        "selector matched {total} element(s); nth({}) requested",
+                        idx + 1
+                    )),
+                    ..Diagnosis::default()
+                })
+            } else {
+                // Bare miss: poll loops use this as their retry signal, so
+                // it stays cheap. Terminal sites enrich via `enrich_miss`.
+                err
+            }
+        })
+    }
+
+    // ── Diagnosis collection (tenet 6, failure path only) ───────────
+
+    /// Attach bounded scope context (same-role candidates + scope snapshot)
+    /// to a `SelectorNotMatched` that is about to reach the caller. Other
+    /// errors pass through unchanged.
+    fn enrich_miss(&self, err: Error) -> Error {
+        match err {
+            Error::SelectorNotMatched {
+                selector,
+                diagnosis,
+            } => {
+                let mut d = diagnosis.map(|b| *b).unwrap_or_default();
+                self.fill_miss_context(&mut d);
+                Error::selector_not_matched(selector).diagnose(d)
+            }
+            other => other,
+        }
+    }
+
+    /// Populate the expensive miss-context fields of a diagnosis (candidate
+    /// list, scope snapshot) if they are not already set.
+    fn fill_miss_context(&self, d: &mut Diagnosis) {
+        if d.candidates.is_empty() {
+            d.candidates = self.role_candidates();
+        }
+        if d.scope.is_none() {
+            d.scope = Some(self.scope_summary());
+        }
+    }
+
+    /// Near-miss candidates: elements in scope whose role matches the
+    /// selector's target role (last segment of the first clause) regardless
+    /// of attribute filters. Bounded by [`DIAG_CANDIDATE_LIMIT`].
+    ///
+    /// A failure to *collect* candidates is recorded as a candidate entry
+    /// rather than dropped, so the original error keeps surfacing while the
+    /// collection failure stays visible (tenet 1: no silent fallbacks).
+    fn role_candidates(&self) -> Vec<String> {
+        let Ok(group) = SelectorGroup::parse(&self.selector) else {
+            // Unparseable selectors fail earlier with `InvalidSelector`;
+            // a miss can't be reached without a parsed selector.
+            return Vec::new();
+        };
+        let role = group
+            .clauses
+            .first()
+            .and_then(|c| c.segments.last())
+            .and_then(|s| s.simple.role.clone());
+        let Some(role) = role else {
+            // Role-less selectors (pure attribute filters) have no
+            // meaningful "same role" candidate set.
+            return Vec::new();
+        };
+        let role_only = SelectorGroup {
+            clauses: vec![Selector {
+                segments: vec![SelectorSegment {
+                    combinator: Combinator::Root,
+                    simple: SimpleSelector {
+                        role: Some(role),
+                        filters: Vec::new(),
+                        nth: None,
+                    },
+                }],
+            }],
+        };
+        match self.resolve_group(&role_only, Some(DIAG_CANDIDATE_LIMIT)) {
+            Ok(matches) => matches.iter().map(short_describe).collect(),
+            Err(e) => vec![format!("(candidate search failed: {e})")],
+        }
+    }
+
+    /// Bounded rendering of the search scope: a depth-limited, line-capped
+    /// dump of the scope root, or the application list for rootless
+    /// locators. Collection failures are recorded in place of the snapshot.
+    fn scope_summary(&self) -> String {
+        match self.root.as_ref() {
+            Some(root) => {
+                let el = Element::new(root.clone(), Arc::clone(&self.provider));
+                match el.dump(Some(DIAG_SCOPE_MAX_DEPTH)) {
+                    Ok(dump) => truncate_lines(&dump, DIAG_SCOPE_MAX_LINES),
+                    Err(e) => format!("(scope dump failed: {e})"),
+                }
+            }
+            None => match self.provider.list_apps() {
+                Ok(apps) => {
+                    let total = apps.len();
+                    let mut lines: Vec<String> = apps
+                        .iter()
+                        .take(DIAG_SCOPE_MAX_LINES)
+                        .map(|a| {
+                            let pid = a.pid.map(|p| format!(" (pid={p})")).unwrap_or_default();
+                            format!(
+                                "application \"{}\"{pid}",
+                                a.name.clone().unwrap_or_default()
+                            )
+                        })
+                        .collect();
+                    if total > DIAG_SCOPE_MAX_LINES {
+                        lines.push(format!(
+                            "… (+{} more applications)",
+                            total - DIAG_SCOPE_MAX_LINES
+                        ));
+                    }
+                    lines.join("\n")
+                }
+                Err(e) => format!("(application enumeration failed: {e})"),
+            },
+        }
+    }
+
+    /// Build the diagnosed timeout error shared by `auto_wait` and
+    /// `poll_until`. `last` is the most recent poll's observation; the
+    /// expensive miss context is collected only when the selector never
+    /// matched during the entire wait.
+    fn diagnose_timeout(
+        &self,
+        elapsed: Duration,
+        condition: String,
+        last: Option<&ElementData>,
+        ever_matched: bool,
+    ) -> Error {
+        let mut d = Diagnosis {
+            condition: Some(condition),
+            selector: Some(self.selector.clone()),
+            ..Diagnosis::default()
+        };
+        match last {
+            Some(data) => d.last_observed = Some(describe_observed(data)),
+            None if ever_matched => {
+                d.last_observed =
+                    Some("selector matched earlier in the wait but no longer matches".to_string());
+            }
+            None => {
+                d.last_observed = Some("selector never matched".to_string());
+                self.fill_miss_context(&mut d);
+            }
+        }
+        Error::timeout(elapsed).diagnose(d)
     }
 
     // ── Queries (each re-queries the provider) ─────────────────────
@@ -260,9 +479,19 @@ impl Locator {
     }
 
     /// Get a single [`Element`] handle.
+    ///
+    /// Fails fast with [`Error::SelectorNotMatched`] on a miss; the error
+    /// carries a bounded [`Diagnosis`] of the search scope (same-role
+    /// candidates and a depth-limited scope snapshot) so the caller doesn't
+    /// need to re-run the failure under manual tree dumps.
     pub fn element(&self) -> Result<Element> {
-        let data = self.resolve_data()?;
-        Ok(Element::new(data, Arc::clone(&self.provider)))
+        match self.resolve_data() {
+            Ok(data) => Ok(Element::new(data, Arc::clone(&self.provider))),
+            // Terminal site: this miss reaches the caller, so spend the
+            // bounded diagnosis cost here (not in `resolve_data`, which
+            // poll loops call on every tick).
+            Err(e) => Err(self.enrich_miss(e)),
+        }
     }
 
     /// Get all matching elements.
@@ -295,22 +524,40 @@ impl Locator {
     /// Poll until the element is attached, visible, and enabled, returning a
     /// live [`Element`] handle. Used by the action methods below to provide
     /// resilience against transient unactionable states.
-    fn auto_wait(&self) -> Result<Element> {
+    ///
+    /// `action` names the calling action for the timeout diagnosis, so a
+    /// failed `press()` reports *what* was being attempted and what the
+    /// last poll observed.
+    fn auto_wait(&self, action: &str) -> Result<Element> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
+        // Most recent poll's observation, for the timeout diagnosis.
+        let mut last_seen: Option<ElementData> = None;
+        let mut ever_matched = false;
 
         loop {
             let elapsed = start.elapsed();
             if elapsed >= self.timeout {
-                return Err(Error::Timeout { elapsed });
+                return Err(self.diagnose_timeout(
+                    elapsed,
+                    format!("{action} target actionable (visible && enabled)"),
+                    last_seen.as_ref(),
+                    ever_matched,
+                ));
             }
 
             match self.resolve_data() {
                 Ok(data) if data.states.visible && data.states.enabled => {
                     return Ok(Element::new(data, Arc::clone(&self.provider)));
                 }
-                Ok(_) | Err(Error::SelectorNotMatched { .. }) => {
-                    // Not yet actionable — poll again
+                Ok(data) => {
+                    // Matched but not yet actionable — poll again.
+                    ever_matched = true;
+                    last_seen = Some(data);
+                }
+                Err(Error::SelectorNotMatched { .. }) => {
+                    // Not yet present — poll again.
+                    last_seen = None;
                 }
                 Err(e) => return Err(e),
             }
@@ -329,62 +576,62 @@ impl Locator {
 
     /// Click / invoke the matched element.
     pub fn press(&self) -> Result<()> {
-        self.auto_wait()?.press()
+        self.auto_wait("press")?.press()
     }
 
     /// Set keyboard focus on the matched element.
     pub fn focus(&self) -> Result<()> {
-        self.auto_wait()?.focus()
+        self.auto_wait("focus")?.focus()
     }
 
     /// Remove keyboard focus from the matched element.
     pub fn blur(&self) -> Result<()> {
-        self.auto_wait()?.blur()
+        self.auto_wait("blur")?.blur()
     }
 
     /// Toggle the matched element (checkbox, switch).
     pub fn toggle(&self) -> Result<()> {
-        self.auto_wait()?.toggle()
+        self.auto_wait("toggle")?.toggle()
     }
 
     /// Select the matched element (list item, etc.).
     pub fn select(&self) -> Result<()> {
-        self.auto_wait()?.select()
+        self.auto_wait("select")?.select()
     }
 
     /// Expand the matched element.
     pub fn expand(&self) -> Result<()> {
-        self.auto_wait()?.expand()
+        self.auto_wait("expand")?.expand()
     }
 
     /// Collapse the matched element.
     pub fn collapse(&self) -> Result<()> {
-        self.auto_wait()?.collapse()
+        self.auto_wait("collapse")?.collapse()
     }
 
     /// Show the context menu for the matched element.
     pub fn show_menu(&self) -> Result<()> {
-        self.auto_wait()?.show_menu()
+        self.auto_wait("show_menu")?.show_menu()
     }
 
     /// Increment the matched element (slider, spinner).
     pub fn increment(&self) -> Result<()> {
-        self.auto_wait()?.increment()
+        self.auto_wait("increment")?.increment()
     }
 
     /// Decrement the matched element (slider, spinner).
     pub fn decrement(&self) -> Result<()> {
-        self.auto_wait()?.decrement()
+        self.auto_wait("decrement")?.decrement()
     }
 
     /// Scroll the matched element into view.
     pub fn scroll_into_view(&self) -> Result<()> {
-        self.auto_wait()?.scroll_into_view()
+        self.auto_wait("scroll_into_view")?.scroll_into_view()
     }
 
     /// Set the text value of the matched element.
     pub fn set_value(&self, value: &str) -> Result<()> {
-        self.auto_wait()?.set_value(value)
+        self.auto_wait("set_value")?.set_value(value)
     }
 
     /// Set the numeric value of the matched element (slider, spinner).
@@ -396,12 +643,13 @@ impl Locator {
                 message: format!("set_numeric_value requires a finite value, got {}", value),
             });
         }
-        self.auto_wait()?.set_numeric_value(value)
+        self.auto_wait("set_numeric_value")?
+            .set_numeric_value(value)
     }
 
     /// Type text at the current cursor position on the matched element.
     pub fn type_text(&self, text: &str) -> Result<()> {
-        self.auto_wait()?.type_text(text)
+        self.auto_wait("type_text")?.type_text(text)
     }
 
     /// Select a text range within the matched element.
@@ -411,7 +659,7 @@ impl Locator {
                 message: format!("select_text start ({}) must be <= end ({})", start, end),
             });
         }
-        self.auto_wait()?.select_text(start, end)
+        self.auto_wait("select_text")?.select_text(start, end)
     }
 
     /// Perform an action by name (with auto-wait).
@@ -419,7 +667,7 @@ impl Locator {
     /// This is the escape hatch for platform-specific actions not covered
     /// by the named methods above. Also works for well-known action names.
     pub fn perform_action(&self, action: &str) -> Result<()> {
-        self.auto_wait()?.perform_action(action)
+        self.auto_wait("perform_action")?.perform_action(action)
     }
 
     // ── Wait operations ─────────────────────────────────────────────
@@ -478,7 +726,7 @@ impl Locator {
         state: ElementState,
         timeout: Duration,
     ) -> Result<Option<Element>> {
-        self.poll_until(|element| state.is_met(element), timeout)
+        self.poll_until(|element| state.is_met(element), timeout, state_label(state))
     }
 
     /// Wait until an arbitrary predicate is satisfied, polling at ~100 ms intervals.
@@ -487,22 +735,34 @@ impl Locator {
         predicate: impl Fn(Option<&ElementData>) -> bool,
         timeout: Duration,
     ) -> Result<Option<Element>> {
-        self.poll_until(&predicate, timeout)
+        self.poll_until(&predicate, timeout, "custom predicate")
     }
 
     /// Core polling loop shared by `wait_for_state` and `wait_until`.
+    ///
+    /// `condition` names what is being waited for; on timeout it is embedded
+    /// in the error's [`Diagnosis`] together with the last observation.
     fn poll_until(
         &self,
         predicate: impl Fn(Option<&ElementData>) -> bool,
         timeout: Duration,
+        condition: &str,
     ) -> Result<Option<Element>> {
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(100);
+        // Most recent poll's observation, for the timeout diagnosis.
+        let mut last_seen: Option<ElementData> = None;
+        let mut ever_matched = false;
 
         loop {
             let elapsed = start.elapsed();
             if elapsed >= timeout {
-                return Err(Error::Timeout { elapsed });
+                return Err(self.diagnose_timeout(
+                    elapsed,
+                    condition.to_string(),
+                    last_seen.as_ref(),
+                    ever_matched,
+                ));
             }
 
             let matched = match self.resolve_data() {
@@ -510,11 +770,15 @@ impl Locator {
                 Err(Error::SelectorNotMatched { .. }) => None,
                 Err(e) => return Err(e),
             };
+            if matched.is_some() {
+                ever_matched = true;
+            }
 
             if predicate(matched.as_ref()) {
                 return Ok(matched.map(|data| Element::new(data, Arc::clone(&self.provider))));
             }
 
+            last_seen = matched;
             std::thread::sleep(poll_interval);
         }
     }
@@ -980,5 +1244,139 @@ mod tests {
             names(&loc.elements().unwrap()),
             vec!["Navigation", "Agree", "Volume"]
         );
+    }
+
+    // ── Error diagnosis (tenet 6) ────────────────────────────────────
+    //
+    // Failure-path errors must carry what the operation was waiting for,
+    // what it last observed, and bounded scope context — without the caller
+    // wrapping the call in manual tree dumps.
+
+    /// Short wait that exceeds at least one 100 ms poll tick.
+    const SHORT_WAIT: Duration = Duration::from_millis(250);
+
+    #[test]
+    fn wait_visible_timeout_diagnosis_never_matched() {
+        let loc = root_locator(r#"button[name="DoesNotExist"]"#);
+        let err = loc
+            .wait_visible(SHORT_WAIT)
+            .expect_err("missing selector must time out");
+        let d = err.diagnosis().expect("timeout must carry a diagnosis");
+        assert_eq!(d.condition.as_deref(), Some("visible"));
+        assert_eq!(
+            d.selector.as_deref(),
+            Some(r#"button[name="DoesNotExist"]"#)
+        );
+        assert_eq!(d.last_observed.as_deref(), Some("selector never matched"));
+        // Same-role candidates: the mock tree's two buttons.
+        assert_eq!(
+            d.candidates,
+            vec![r#"button "Back""#, r#"button "Forward""#]
+        );
+        // Scope for a rootless locator is the application list.
+        assert!(
+            d.scope.as_deref().unwrap_or_default().contains("TestApp"),
+            "scope should list running applications, got: {:?}",
+            d.scope
+        );
+        // And everything must render into the message — the consumer's
+        // first contact with the diagnosis is the exception text.
+        let msg = format!("{err}");
+        assert!(msg.contains("waiting for: visible"), "{msg}");
+        assert!(msg.contains("selector never matched"), "{msg}");
+        assert!(msg.contains(r#"button "Back""#), "{msg}");
+    }
+
+    #[test]
+    fn wait_visible_timeout_diagnosis_matched_but_invisible() {
+        // static_text "Status" exists but visible=false: the diagnosis must
+        // distinguish "matched in the wrong state" from "never matched".
+        let loc = root_locator(r#"static_text[name="Status"]"#);
+        let err = loc
+            .wait_visible(SHORT_WAIT)
+            .expect_err("invisible element must time out");
+        let d = err.diagnosis().expect("timeout must carry a diagnosis");
+        let last = d.last_observed.as_deref().unwrap_or_default();
+        assert!(
+            last.contains(r#"static_text "Status""#) && last.contains("visible=false"),
+            "last observed should describe the matched element's state, got: {last}"
+        );
+        // A matched element needs no candidate/scope sweep.
+        assert!(d.candidates.is_empty(), "{:?}", d.candidates);
+        assert!(d.scope.is_none(), "{:?}", d.scope);
+    }
+
+    #[test]
+    fn action_timeout_diagnosis_names_action_and_blocking_state() {
+        // button "Forward" is disabled: press() must time out with a
+        // diagnosis naming the attempted action and enabled=false.
+        let loc = root_locator(r#"button[name="Forward"]"#).with_timeout(SHORT_WAIT);
+        let err = loc.press().expect_err("disabled button must time out");
+        let d = err.diagnosis().expect("timeout must carry a diagnosis");
+        assert_eq!(
+            d.condition.as_deref(),
+            Some("press target actionable (visible && enabled)")
+        );
+        let last = d.last_observed.as_deref().unwrap_or_default();
+        assert!(
+            last.contains("enabled=false"),
+            "last observed should expose the blocking state, got: {last}"
+        );
+    }
+
+    #[test]
+    fn element_miss_diagnosis_includes_candidates_and_scope_dump() {
+        // Scoped miss: the scope snapshot is a depth-limited dump of the
+        // search root, so the caller doesn't need print(app.dump()).
+        let provider = build_provider();
+        let provider_dyn: Arc<dyn Provider> = provider;
+        let app_root = provider_dyn.list_apps().expect("list_apps")[0].clone();
+        let loc = Locator::new(provider_dyn, Some(app_root), r#"button[name="Exprot"]"#);
+        let err = loc.element().expect_err("miss must fail fast");
+        assert!(matches!(err, Error::SelectorNotMatched { .. }), "{err:?}");
+        let d = err
+            .diagnosis()
+            .expect("terminal miss must carry a diagnosis");
+        assert_eq!(
+            d.candidates,
+            vec![r#"button "Back""#, r#"button "Forward""#]
+        );
+        let scope = d.scope.as_deref().expect("miss must include scope");
+        assert!(
+            scope.contains("window") && scope.contains("Main Window"),
+            "scope should be a tree dump of the search root, got: {scope}"
+        );
+    }
+
+    #[test]
+    fn nth_miss_diagnosis_reports_match_count() {
+        let loc = root_locator("button").nth(5);
+        let err = loc.element().expect_err("nth(5) of 2 buttons must miss");
+        let d = err.diagnosis().expect("nth miss must carry a diagnosis");
+        assert_eq!(
+            d.last_observed.as_deref(),
+            Some("selector matched 2 element(s); nth(5) requested")
+        );
+    }
+
+    #[test]
+    fn exists_stays_cheap_and_unenriched() {
+        // exists() consumes the miss as a boolean — it must not pay the
+        // diagnosis cost, and must keep returning Ok(false).
+        let loc = root_locator(r#"button[name="DoesNotExist"]"#);
+        assert!(!loc.exists().unwrap());
+    }
+
+    #[test]
+    fn truncate_lines_caps_and_counts() {
+        let text = (0..10)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let capped = truncate_lines(&text, 3);
+        assert!(capped.starts_with("line0\nline1\nline2\n"), "{capped}");
+        assert!(capped.ends_with("… (+7 more lines truncated)"), "{capped}");
+        // Under the cap: unchanged, no marker.
+        assert_eq!(truncate_lines("a\nb", 3), "a\nb");
     }
 }

--- a/xa11y-core/src/provider.rs
+++ b/xa11y-core/src/provider.rs
@@ -73,12 +73,21 @@ pub trait Provider: Send + Sync {
         if let Some(data) = apps.into_iter().find(|a| a.pid == Some(pid)) {
             return Ok(data);
         }
-        Err(Error::SelectorNotMatched {
-            selector: format!(
-                "application with pid={pid} (enumerated {total} running apps, \
-                 {unresolved} without a resolvable pid)"
+        // The enumeration counts are structured diagnosis fields (tenet 6),
+        // not prose baked into the selector — bindings expose them as
+        // attributes, and `App::by_pid_with` merges in the full candidate
+        // list at its terminal failure site. Cheap to build (two counters),
+        // so attaching it per poll tick is fine.
+        Err(
+            Error::selector_not_matched(format!("application[pid={pid}]")).diagnose(
+                crate::error::Diagnosis {
+                    last_observed: Some(format!(
+                        "enumerated {total} running apps, {unresolved} without a resolvable pid"
+                    )),
+                    ..Default::default()
+                },
             ),
-        })
+        )
     }
 
     /// Search for elements matching a selector.

--- a/xa11y-js/Cargo.lock
+++ b/xa11y-js/Cargo.lock
@@ -1557,7 +1557,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xa11y"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "xa11y-core",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-core"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "png",
  "serde",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-js"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "napi",
  "napi-build",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-linux"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "evdev",
  "png",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-macos"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "cc",
  "core-foundation",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-windows"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "windows",

--- a/xa11y-js/__test__/unit/errors.test.js
+++ b/xa11y-js/__test__/unit/errors.test.js
@@ -117,3 +117,62 @@ test('PlatformError from mock subscribe() is instanceof public class', async () 
     },
   );
 });
+
+// ── Structured diagnosis (tenet 6) ──────────────────────────────────────────
+//
+// Timeouts and selector misses carry structured fields (`selector`,
+// `condition`, `lastObserved`, `candidates`, `scope`, `elapsedMs`) parsed
+// from the native payload, so a harness never needs to wrap a call in
+// try/catch just to dump the tree. The same content is rendered into the
+// message.
+
+test('TimeoutError carries a structured diagnosis when the selector never matched', async () => {
+  await assert.rejects(
+    _makeTestLocator().descendant('button[name="Nope"]').waitVisible(0.3),
+    (err) => {
+      assert.ok(err instanceof TimeoutError);
+      assert.equal(err.condition, 'visible');
+      assert.equal(err.selector, 'application button[name="Nope"]');
+      assert.equal(err.lastObserved, 'selector never matched');
+      assert.ok(err.candidates.includes('button "Back"'), `candidates: ${err.candidates}`);
+      assert.ok(err.scope.includes('TestApp'), `scope: ${err.scope}`);
+      assert.ok(err.elapsedMs >= 300, `elapsedMs: ${err.elapsedMs}`);
+      // The message renders the same content — no separator bytes leak in.
+      assert.ok(err.message.includes('waiting for: visible'), err.message);
+      assert.ok(!err.message.includes('\u001f'), 'separator must be stripped');
+      return true;
+    },
+  );
+});
+
+test('SelectorNotMatchedError carries a structured diagnosis on element() miss', async () => {
+  await assert.rejects(
+    _makeTestLocator().descendant('button[name="Nope"]').element(),
+    (err) => {
+      assert.ok(err instanceof SelectorNotMatchedError);
+      assert.equal(err.selector, 'application button[name="Nope"]');
+      assert.ok(err.candidates.includes('button "Back"'), `candidates: ${err.candidates}`);
+      assert.ok(err.scope.includes('TestApp'), `scope: ${err.scope}`);
+      assert.equal(err.elapsedMs, null);
+      return true;
+    },
+  );
+});
+
+test('diagnosis fields default to null/[] when a path produces no context', async () => {
+  await assert.rejects(
+    _makeTestLocator().descendant('[[[bad').elements(),
+    (err) => {
+      // Not a diagnosis-carrying class; just confirm the carrying classes
+      // always expose the fields even before population.
+      const t = new TimeoutError('x');
+      assert.equal(t.selector, null);
+      assert.equal(t.condition, null);
+      assert.equal(t.lastObserved, null);
+      assert.deepEqual(t.candidates, []);
+      assert.equal(t.scope, null);
+      assert.equal(t.elapsedMs, null);
+      return true;
+    },
+  );
+});

--- a/xa11y-js/index.d.ts
+++ b/xa11y-js/index.d.ts
@@ -267,14 +267,55 @@ export class PermissionDeniedError extends XA11yError {}
  */
 export class AccessibilityNotEnabledError extends XA11yError {}
 
-/** No element matched the selector (also used for stale elements). */
-export class SelectorNotMatchedError extends XA11yError {}
+/**
+ * No element matched the selector (also used for stale elements).
+ *
+ * Carries a structured diagnosis so the failure is understandable without
+ * re-running it under manual tree dumps. Every field is always present
+ * (`null` / `[]` when not applicable); the same content is rendered into
+ * the message.
+ */
+export class SelectorNotMatchedError extends XA11yError {
+  /** The selector that failed to match. */
+  selector: string | null;
+  /** What the operation was waiting for / trying to find, if known. */
+  condition: string | null;
+  /** What the failing operation last observed. */
+  lastObserved: string | null;
+  /** Bounded near-miss candidates (e.g. same-role elements). */
+  candidates: string[];
+  /** Bounded rendering of the search scope (tree dump or app list). */
+  scope: string | null;
+  /** Always `null` for this class (parity with {@link TimeoutError}). */
+  elapsedMs: number | null;
+}
 
 /** The requested action is not supported on the target element. */
 export class ActionNotSupportedError extends XA11yError {}
 
-/** An operation exceeded its timeout. */
-export class TimeoutError extends XA11yError {}
+/**
+ * An operation exceeded its timeout.
+ *
+ * Carries a structured diagnosis: what the wait was for (`condition` +
+ * `selector`), what it last observed, and — when the selector never
+ * matched — bounded scope context (`candidates` + `scope`). Every field is
+ * always present (`null` / `[]` when not applicable); the same content is
+ * rendered into the message.
+ */
+export class TimeoutError extends XA11yError {
+  /** Wall-clock milliseconds the operation waited before giving up. */
+  elapsedMs: number | null;
+  /** What the wait was for: `'visible'`, `'attached'`, `'press target actionable (visible && enabled)'`, ... */
+  condition: string | null;
+  /** The selector being resolved, when the wait had one. */
+  selector: string | null;
+  /** The last poll's observation (matched-with-states vs never matched). */
+  lastObserved: string | null;
+  /** Bounded near-miss candidates; collected only when the selector never matched. */
+  candidates: string[];
+  /** Bounded rendering of the search scope; collected only when the selector never matched. */
+  scope: string | null;
+}
 
 /** The selector string has invalid syntax. */
 export class InvalidSelectorError extends XA11yError {}

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -53,6 +53,15 @@ class SelectorNotMatchedError extends XA11yError {
   constructor(message) {
     super(message);
     this.name = 'SelectorNotMatchedError';
+    // Structured diagnosis (tenet 6) — populated from the native payload in
+    // `toTypedError`. Defaults keep every field present so consumers never
+    // need existence checks.
+    /** @type {string | null} */ this.selector = null;
+    /** @type {string | null} */ this.condition = null;
+    /** @type {string | null} */ this.lastObserved = null;
+    /** @type {string[]} */ this.candidates = [];
+    /** @type {string | null} */ this.scope = null;
+    /** @type {number | null} */ this.elapsedMs = null;
   }
 }
 
@@ -67,6 +76,15 @@ class TimeoutError extends XA11yError {
   constructor(message) {
     super(message);
     this.name = 'TimeoutError';
+    // Structured diagnosis (tenet 6) — populated from the native payload in
+    // `toTypedError`. Defaults keep every field present so consumers never
+    // need existence checks.
+    /** @type {string | null} */ this.selector = null;
+    /** @type {string | null} */ this.condition = null;
+    /** @type {string | null} */ this.lastObserved = null;
+    /** @type {string[]} */ this.candidates = [];
+    /** @type {string | null} */ this.scope = null;
+    /** @type {number | null} */ this.elapsedMs = null;
   }
 }
 
@@ -106,17 +124,47 @@ const CODE_TO_CLASS = {
   XA11Y_UNSUPPORTED: ActionNotSupportedError,
 };
 
+/**
+ * Separator between the human-readable message and the JSON diagnosis
+ * payload in native error reasons. Mirrors `DIAGNOSIS_SEP` in
+ * `src/errors.rs`.
+ */
+const DIAGNOSIS_SEP = '\u001f';
+
 /** Convert any thrown value into a typed xa11y error if it carries our tag. */
 function toTypedError(err) {
   if (!(err instanceof Error) || typeof err.message !== 'string') return err;
-  const colon = err.message.indexOf(':');
+  // Split off the structured diagnosis payload, if present.
+  let message = err.message;
+  let diagnosis = null;
+  const sep = message.indexOf(DIAGNOSIS_SEP);
+  if (sep >= 0) {
+    try {
+      diagnosis = JSON.parse(message.slice(sep + 1));
+      message = message.slice(0, sep);
+    } catch {
+      // Malformed payload: keep the full original message rather than
+      // silently dropping bytes from the error (the message still renders
+      // the same content in prose).
+      diagnosis = null;
+    }
+  }
+  const colon = message.indexOf(':');
   if (colon < 0) return err;
-  const tag = err.message.slice(0, colon);
+  const tag = message.slice(0, colon);
   const Cls = CODE_TO_CLASS[tag];
   if (!Cls) return err;
-  const detail = err.message.slice(colon + 2);
+  const detail = message.slice(colon + 2);
   const typed = new Cls(detail);
   typed.stack = err.stack;
+  if (diagnosis && typeof diagnosis === 'object') {
+    typed.selector = diagnosis.selector ?? null;
+    typed.condition = diagnosis.condition ?? null;
+    typed.lastObserved = diagnosis.lastObserved ?? null;
+    typed.candidates = Array.isArray(diagnosis.candidates) ? diagnosis.candidates : [];
+    typed.scope = diagnosis.scope ?? null;
+    typed.elapsedMs = diagnosis.elapsedMs ?? null;
+  }
   return typed;
 }
 

--- a/xa11y-js/index.js
+++ b/xa11y-js/index.js
@@ -236,9 +236,18 @@ Object.defineProperty(native.Locator.prototype, 'waitUntil', {
       }
       const remaining = deadline - Date.now();
       if (remaining <= 0) {
-        throw new TimeoutError(
+        const err = new TimeoutError(
           `Timeout after ${timeout}ms waiting for predicate on '${this.selector}'`,
         );
+        // Mirror the structured diagnosis fields native timeouts carry
+        // (tenet 6); `el` is the final poll's observation.
+        err.condition = 'custom predicate';
+        err.selector = this.selector;
+        err.lastObserved = el
+          ? `matched ${el.role}${el.name ? ` "${el.name}"` : ''}`
+          : 'selector never matched';
+        err.elapsedMs = timeout;
+        throw err;
       }
 
       await new Promise((resolve, reject) => {

--- a/xa11y-js/src/errors.rs
+++ b/xa11y-js/src/errors.rs
@@ -2,6 +2,12 @@
 //!
 //! The JS wrapper (in `index.js`) re-throws these as typed `XA11yError`
 //! subclasses so users can `instanceof` them.
+//!
+//! Diagnosis-carrying errors (`SelectorNotMatched`, `Timeout`) additionally
+//! append a JSON payload after a U+001F unit separator; the wrapper parses
+//! it and assigns the structured fields (`selector`, `condition`,
+//! `lastObserved`, `candidates`, `scope`, `elapsedMs`) onto the typed error
+//! (tenet 6: rich context is structured, not just message prose).
 
 use napi::{Error, Status};
 
@@ -22,20 +28,46 @@ pub mod codes {
     pub const UNSUPPORTED: &str = "XA11Y_UNSUPPORTED";
 }
 
+/// Unit separator between the human-readable message and the JSON diagnosis
+/// payload inside the napi error reason. U+001F can't occur in rendered
+/// messages (selector strings and tree dumps never contain control
+/// characters), so a plain `indexOf` split on the JS side is unambiguous.
+pub const DIAGNOSIS_SEP: char = '\u{1f}';
+
+/// Serialize the structured diagnosis for the JS wrapper. `selector` is the
+/// error's primary selector field (SelectorNotMatched) or the diagnosis
+/// selector (Timeout); `elapsed_ms` is set for timeouts only.
+fn diagnosis_json(
+    selector: Option<&str>,
+    elapsed_ms: Option<f64>,
+    diagnosis: Option<&xa11y::Diagnosis>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "selector": selector,
+        "elapsedMs": elapsed_ms,
+        "condition": diagnosis.and_then(|d| d.condition.as_deref()),
+        "lastObserved": diagnosis.and_then(|d| d.last_observed.as_deref()),
+        "candidates": diagnosis.map(|d| d.candidates.clone()).unwrap_or_default(),
+        "scope": diagnosis.and_then(|d| d.scope.as_deref()),
+    })
+}
+
 /// Convert an `xa11y::Error` into a `napi::Error`. The `reason` field doubles
 /// as both the human-readable message (prefixed by the code tag) and a machine
 /// code that the JS wrapper parses out.
 pub fn map_err(e: xa11y::Error) -> Error {
-    let (code, msg) = match e {
-        xa11y::Error::PermissionDenied { instructions } => (codes::PERMISSION_DENIED, instructions),
+    let (code, msg) = match &e {
+        xa11y::Error::PermissionDenied { instructions } => {
+            (codes::PERMISSION_DENIED, instructions.clone())
+        }
         xa11y::Error::AccessibilityNotEnabled { app, instructions } => (
             codes::ACCESSIBILITY_NOT_ENABLED,
             format!("Accessibility not enabled for {app}: {instructions}"),
         ),
-        xa11y::Error::SelectorNotMatched { selector } => (
-            codes::SELECTOR_NOT_MATCHED,
-            format!("No element matched: {selector}"),
-        ),
+        // Core Display renders the diagnosis suffix into the message; the
+        // structured payload below carries the same fields for programmatic
+        // access.
+        xa11y::Error::SelectorNotMatched { .. } => (codes::SELECTOR_NOT_MATCHED, e.to_string()),
         xa11y::Error::ElementStale { selector } => {
             (codes::ELEMENT_STALE, format!("Element stale: {selector}"))
         }
@@ -47,9 +79,7 @@ pub fn map_err(e: xa11y::Error) -> Error {
             codes::TEXT_VALUE_NOT_SUPPORTED,
             "Text value not supported for this element".to_string(),
         ),
-        xa11y::Error::Timeout { elapsed } => {
-            (codes::TIMEOUT, format!("Timeout after {elapsed:.1?}"))
-        }
+        xa11y::Error::Timeout { .. } => (codes::TIMEOUT, e.to_string()),
         xa11y::Error::InvalidSelector { selector, message } => (
             codes::INVALID_SELECTOR,
             format!("Invalid selector '{selector}': {message}"),
@@ -71,7 +101,28 @@ pub fn map_err(e: xa11y::Error) -> Error {
         }
     };
 
+    let payload = match &e {
+        xa11y::Error::SelectorNotMatched { selector, .. } => {
+            Some(diagnosis_json(Some(selector), None, e.diagnosis()))
+        }
+        xa11y::Error::ElementStale { selector } => Some(diagnosis_json(Some(selector), None, None)),
+        xa11y::Error::Timeout { elapsed, .. } => {
+            let d = e.diagnosis();
+            Some(diagnosis_json(
+                d.and_then(|d| d.selector.as_deref()),
+                Some(elapsed.as_secs_f64() * 1000.0),
+                d,
+            ))
+        }
+        _ => None,
+    };
+
     // Encode the tag at the start of the message so the JS wrapper can split
-    // it off: "XA11Y_PERMISSION_DENIED: <details>".
-    Error::new(Status::GenericFailure, format!("{code}: {msg}"))
+    // it off: "XA11Y_PERMISSION_DENIED: <details>". The diagnosis payload,
+    // when present, follows a U+001F separator.
+    let reason = match payload {
+        Some(p) => format!("{code}: {msg}{DIAGNOSIS_SEP}{p}"),
+        None => format!("{code}: {msg}"),
+    };
+    Error::new(Status::GenericFailure, reason)
 }

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -1558,12 +1558,17 @@ impl Provider for LinuxProvider {
                 None => unresolved += 1,
             }
         }
-        Err(Error::SelectorNotMatched {
-            selector: format!(
-                "application with pid={pid} ({total} AT-SPI registry entries examined, \
-                 {unresolved} without a resolvable pid)"
+        Err(
+            Error::selector_not_matched(format!("application[pid={pid}]")).diagnose(
+                xa11y_core::Diagnosis {
+                    last_observed: Some(format!(
+                        "{total} AT-SPI registry entries examined, {unresolved} without a \
+                         resolvable pid"
+                    )),
+                    ..Default::default()
+                },
             ),
-        })
+        )
     }
 
     fn press(&self, element: &ElementData) -> Result<()> {

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -2038,11 +2038,16 @@ impl Provider for MacOSProvider {
     fn app_by_pid(&self, pid: u32) -> Result<ElementData> {
         let app_element = AXElement::from_owned(unsafe { safe_ax_create_application(pid as i32) });
         if app_element.is_null() {
-            return Err(Error::SelectorNotMatched {
-                selector: format!(
-                    "application with pid={pid} (AXUIElementCreateApplication returned NULL)"
+            return Err(
+                Error::selector_not_matched(format!("application[pid={pid}]")).diagnose(
+                    xa11y_core::Diagnosis {
+                        last_observed: Some(
+                            "AXUIElementCreateApplication returned NULL".to_string(),
+                        ),
+                        ..Default::default()
+                    },
                 ),
-            });
+            );
         }
         let attr = CFString::new("AXRole");
         let mut value: CFTypeRef = std::ptr::null();
@@ -2072,12 +2077,16 @@ impl Provider for MacOSProvider {
             AX_ERROR_CANNOT_COMPLETE
             | AX_ERROR_INVALID_UI_ELEMENT
             | AX_ERROR_NOT_IMPLEMENTED
-            | AX_ERROR_NO_VALUE => Err(Error::SelectorNotMatched {
-                selector: format!(
-                    "application with pid={pid} (AX attach probe returned AXError {err}: \
-                     process not yet AX-reachable, exited, or has no accessibility bridge)"
-                ),
-            }),
+            | AX_ERROR_NO_VALUE => Err(Error::selector_not_matched(format!(
+                "application[pid={pid}]"
+            ))
+            .diagnose(xa11y_core::Diagnosis {
+                last_observed: Some(format!(
+                    "AX attach probe returned AXError {err}: process not yet AX-reachable, \
+                     exited, or has no accessibility bridge"
+                )),
+                ..Default::default()
+            })),
             _ => Err(Error::Platform {
                 code: err as i64,
                 message: format!(
@@ -2517,9 +2526,17 @@ impl MacOSProvider {
                 safe_cf_release(observer);
                 drop(Box::from_raw(ctx_ptr as *mut ObserverContext));
             }
-            return Err(Error::SelectorNotMatched {
-                selector: format!("application with pid:{}", pid),
-            });
+            return Err(
+                Error::selector_not_matched(format!("application[pid={pid}]")).diagnose(
+                    xa11y_core::Diagnosis {
+                        last_observed: Some(
+                            "AXUIElementCreateApplication returned NULL while subscribing"
+                                .to_string(),
+                        ),
+                        ..Default::default()
+                    },
+                ),
+            );
         }
 
         let notifications = [

--- a/xa11y-python/Cargo.lock
+++ b/xa11y-python/Cargo.lock
@@ -1433,7 +1433,7 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xa11y"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "xa11y-core",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-core"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "png",
  "serde",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-linux"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "evdev",
  "png",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-macos"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "cc",
  "core-foundation",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-python"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "xa11y-windows"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "windows",

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -23,13 +23,68 @@ class AccessibilityNotEnabledError(XA11yError):
     """
 
 class SelectorNotMatchedError(XA11yError):
-    """No element in the tree matched the given selector."""
+    """No element in the tree matched the given selector.
+
+    Carries a structured diagnosis (tenet 6) so the failure is
+    understandable without re-running it under manual tree dumps. All
+    attributes are always present (``None`` / ``[]`` when not applicable);
+    the same content is rendered into the exception message.
+    """
+
+    selector: str | None
+    """The selector that failed to match."""
+    condition: str | None
+    """What the operation was waiting for / trying to find, if known."""
+    last_observed: str | None
+    """What the failing operation last observed (e.g. ``'selector matched
+    2 element(s); nth(5) requested'``)."""
+    candidates: list[str]
+    """Bounded near-miss candidates, e.g. same-role elements with different
+    names, or the running applications for app lookups."""
+    scope: str | None
+    """Bounded rendering of the search scope: a depth-limited tree dump for
+    scoped locators, or the application list for rootless ones."""
+    elapsed: float | None
+    """Always ``None`` for this class (present for attribute parity with
+    :class:`TimeoutError`)."""
 
 class ActionNotSupportedError(XA11yError):
     """The requested action is not supported on the target element."""
 
 class TimeoutError(XA11yError):
-    """An operation exceeded its timeout."""
+    """An operation exceeded its timeout.
+
+    Carries a structured diagnosis (tenet 6): what the wait was for
+    (``condition`` + ``selector``), what it last observed, and — when the
+    selector never matched — bounded scope context (``candidates`` +
+    ``scope``). All attributes are always present (``None`` / ``[]`` when
+    not applicable); the same content is rendered into the message, e.g.::
+
+        Timeout after 60.0s; waiting for: visible; selector:
+        dialog[name^="Submit"]; last observed: selector never matched;
+        candidates: window "Untitled — MyApp"
+        search scope (bounded):
+        ...
+    """
+
+    elapsed: float | None
+    """Wall-clock seconds the operation waited before giving up."""
+    condition: str | None
+    """What the wait was for: ``'visible'``, ``'attached'``, ``'press
+    target actionable (visible && enabled)'``, ``'event matching
+    predicate'``, ``'custom predicate'``, ..."""
+    selector: str | None
+    """The selector being resolved, when the wait had one."""
+    last_observed: str | None
+    """The last poll's observation: ``'matched button "Export"
+    (visible=false, enabled=true, focused=false)'`` vs ``'selector never
+    matched'``."""
+    candidates: list[str]
+    """Bounded near-miss candidates (same role, different attributes).
+    Collected only when the selector never matched during the wait."""
+    scope: str | None
+    """Bounded rendering of the search scope. Collected only when the
+    selector never matched during the wait."""
 
 class InvalidSelectorError(XA11yError):
     """The selector string has invalid syntax."""
@@ -409,7 +464,12 @@ class Locator:
     def wait_unfocused(self, timeout: float = 5.0) -> Element:
         """Wait until the element does not have keyboard focus."""
     def wait_until(self, predicate: Callable[[Element | None], bool], timeout: float = 5.0) -> None:
-        """Wait until an arbitrary predicate is satisfied."""
+        """Wait until an arbitrary predicate is satisfied.
+
+        A predicate that *raises* aborts the wait immediately and propagates
+        the exception — it is not swallowed as "not yet" (which would
+        resurface later as a misleading timeout). Mirrors ``App.find``.
+        """
     def __repr__(self) -> str: ...
 
 # ── InputSim ─────────────────────────────────────────────────────────────────

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -46,6 +46,38 @@ where
     Ok(())
 }
 
+/// Attach the structured diagnosis fields (tenet 6) as attributes on an
+/// exception instance, so harnesses can read `e.selector`, `e.condition`,
+/// `e.last_observed`, `e.candidates`, `e.scope` (and `e.elapsed` on
+/// timeouts) instead of parsing the message. Every attribute is always set
+/// (`None` / `[]` when absent) so consumers don't need `hasattr` guards.
+fn attach_diagnosis_attrs(
+    err: PyErr,
+    selector: Option<String>,
+    elapsed_secs: Option<f64>,
+    diagnosis: Option<&xa11y::Diagnosis>,
+) -> PyErr {
+    Python::with_gil(|py| {
+        let value = err.value(py);
+        // Best-effort by design: the rendered message already carries the
+        // same content, and replacing the original exception with an
+        // attribute-setting failure would mask the real error.
+        let _ = value.setattr("selector", selector);
+        let _ = value.setattr("elapsed", elapsed_secs);
+        let _ = value.setattr("condition", diagnosis.and_then(|d| d.condition.clone()));
+        let _ = value.setattr(
+            "last_observed",
+            diagnosis.and_then(|d| d.last_observed.clone()),
+        );
+        let _ = value.setattr(
+            "candidates",
+            diagnosis.map(|d| d.candidates.clone()).unwrap_or_default(),
+        );
+        let _ = value.setattr("scope", diagnosis.and_then(|d| d.scope.clone()));
+    });
+    err
+}
+
 fn to_py_err(e: xa11y::Error) -> PyErr {
     match e {
         xa11y::Error::PermissionDenied { instructions } => {
@@ -56,11 +88,22 @@ fn to_py_err(e: xa11y::Error) -> PyErr {
                 "Accessibility not enabled for {app}: {instructions}"
             ))
         }
-        xa11y::Error::SelectorNotMatched { selector } => {
-            SelectorNotMatchedError::new_err(format!("No element matched: {selector}"))
+        xa11y::Error::SelectorNotMatched {
+            selector,
+            diagnosis,
+        } => {
+            // Reassemble so Display renders the diagnosis suffix into the
+            // message; the same fields are exposed as attributes below.
+            let err = xa11y::Error::SelectorNotMatched {
+                selector: selector.clone(),
+                diagnosis,
+            };
+            let py_err = SelectorNotMatchedError::new_err(err.to_string());
+            attach_diagnosis_attrs(py_err, Some(selector), None, err.diagnosis())
         }
         xa11y::Error::ElementStale { selector } => {
-            SelectorNotMatchedError::new_err(format!("Element stale: {selector}"))
+            let py_err = SelectorNotMatchedError::new_err(format!("Element stale: {selector}"));
+            attach_diagnosis_attrs(py_err, Some(selector), None, None)
         }
         xa11y::Error::ActionNotSupported { action, role } => {
             ActionNotSupportedError::new_err(format!("{action} not supported on {role}"))
@@ -68,8 +111,16 @@ fn to_py_err(e: xa11y::Error) -> PyErr {
         xa11y::Error::TextValueNotSupported => {
             ActionNotSupportedError::new_err("Text value not supported for this element")
         }
-        xa11y::Error::Timeout { elapsed } => {
-            TimeoutError::new_err(format!("Timeout after {elapsed:.1?}"))
+        xa11y::Error::Timeout { elapsed, diagnosis } => {
+            let err = xa11y::Error::Timeout { elapsed, diagnosis };
+            let py_err = TimeoutError::new_err(err.to_string());
+            let selector = err.diagnosis().and_then(|d| d.selector.clone());
+            attach_diagnosis_attrs(
+                py_err,
+                selector,
+                Some(elapsed.as_secs_f64()),
+                err.diagnosis(),
+            )
         }
         xa11y::Error::InvalidSelector { selector, message } => {
             InvalidSelectorError::new_err(format!("Invalid selector '{selector}': {message}"))
@@ -381,99 +432,96 @@ impl Element {
     // (contrast with Locator, which re-queries the provider on every call).
 
     /// Press (default activate) this element.
-    fn press(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .press()
-            .map_err(to_py_err)
+    fn press(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.press()).map_err(to_py_err)
     }
     /// Move keyboard focus to this element.
-    fn focus(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .focus()
-            .map_err(to_py_err)
+    fn focus(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.focus()).map_err(to_py_err)
     }
     /// Remove keyboard focus from this element.
-    fn blur(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .blur()
-            .map_err(to_py_err)
+    fn blur(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.blur()).map_err(to_py_err)
     }
     /// Toggle this element's checked state.
-    fn toggle(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .toggle()
+    fn toggle(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.toggle())
             .map_err(to_py_err)
     }
     /// Expand this element (e.g. tree node, combo box).
-    fn expand(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .expand()
+    fn expand(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.expand())
             .map_err(to_py_err)
     }
     /// Collapse this element.
-    fn collapse(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .collapse()
+    fn collapse(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.collapse())
             .map_err(to_py_err)
     }
     /// Select this element (e.g. list item, tab).
-    fn select(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .select()
+    fn select(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.select())
             .map_err(to_py_err)
     }
     /// Show this element's context menu.
-    fn show_menu(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .show_menu()
+    fn show_menu(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.show_menu())
             .map_err(to_py_err)
     }
     /// Scroll this element into view.
-    fn scroll_into_view(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .scroll_into_view()
+    fn scroll_into_view(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.scroll_into_view())
             .map_err(to_py_err)
     }
     /// Increment this element's value (e.g. slider, spinner).
-    fn increment(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .increment()
+    fn increment(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.increment())
             .map_err(to_py_err)
     }
     /// Decrement this element's value.
-    fn decrement(&self) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .decrement()
+    fn decrement(&self, py: Python<'_>) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.decrement())
             .map_err(to_py_err)
     }
     /// Replace this element's text value.
-    fn set_value(&self, value: &str) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .set_value(value)
+    fn set_value(&self, py: Python<'_>, value: &str) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.set_value(value))
             .map_err(to_py_err)
     }
     /// Set this element's numeric value.
-    fn set_numeric_value(&self, value: f64) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .set_numeric_value(value)
+    fn set_numeric_value(&self, py: Python<'_>, value: f64) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.set_numeric_value(value))
             .map_err(to_py_err)
     }
     /// Insert text at the current cursor position.
-    fn type_text(&self, text: &str) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .type_text(text)
+    fn type_text(&self, py: Python<'_>, text: &str) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.type_text(text))
             .map_err(to_py_err)
     }
     /// Select the text range from `start` to `end` (0-based character offsets).
-    fn select_text(&self, start: u32, end: u32) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .select_text(start, end)
+    fn select_text(&self, py: Python<'_>, start: u32, end: u32) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.select_text(start, end))
             .map_err(to_py_err)
     }
     /// Perform an action by its ``snake_case`` name.
-    fn perform_action(&self, action: &str) -> PyResult<()> {
-        xa11y::Element::new(self.inner_data.clone(), self.provider.clone())
-            .perform_action(action)
+    fn perform_action(&self, py: Python<'_>, action: &str) -> PyResult<()> {
+        let element = xa11y::Element::new(self.inner_data.clone(), self.provider.clone());
+        py.allow_threads(move || element.perform_action(action))
             .map_err(to_py_err)
     }
 
@@ -549,21 +597,29 @@ impl Locator {
 
     // ── Queries ──
 
-    fn exists(&self) -> PyResult<bool> {
-        self.inner.exists().map_err(to_py_err)
+    fn exists(&self, py: Python<'_>) -> PyResult<bool> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.exists()).map_err(to_py_err)
     }
 
-    fn count(&self) -> PyResult<usize> {
-        self.inner.count().map_err(to_py_err)
+    fn count(&self, py: Python<'_>) -> PyResult<usize> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.count()).map_err(to_py_err)
     }
 
     fn element(&self, py: Python<'_>) -> PyResult<Py<Element>> {
-        let el = self.inner.element().map_err(to_py_err)?;
+        let inner = self.inner.clone();
+        let el = py
+            .allow_threads(move || inner.element())
+            .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
     fn elements(&self, py: Python<'_>) -> PyResult<Vec<Py<Element>>> {
-        let els = self.inner.elements().map_err(to_py_err)?;
+        let inner = self.inner.clone();
+        let els = py
+            .allow_threads(move || inner.elements())
+            .map_err(to_py_err)?;
         els.iter()
             .map(|el| make_py_element(py, el.data(), el.provider().clone()))
             .collect()
@@ -600,149 +656,206 @@ impl Locator {
 
     // ── Actions ──
 
-    fn press(&self) -> PyResult<()> {
-        self.inner.press().map_err(to_py_err)
+    fn press(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.press()).map_err(to_py_err)
     }
-    fn focus(&self) -> PyResult<()> {
-        self.inner.focus().map_err(to_py_err)
+    fn focus(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.focus()).map_err(to_py_err)
     }
-    fn blur(&self) -> PyResult<()> {
-        self.inner.blur().map_err(to_py_err)
+    fn blur(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.blur()).map_err(to_py_err)
     }
-    fn toggle(&self) -> PyResult<()> {
-        self.inner.toggle().map_err(to_py_err)
+    fn toggle(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.toggle()).map_err(to_py_err)
     }
-    fn expand(&self) -> PyResult<()> {
-        self.inner.expand().map_err(to_py_err)
+    fn expand(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.expand()).map_err(to_py_err)
     }
-    fn collapse(&self) -> PyResult<()> {
-        self.inner.collapse().map_err(to_py_err)
+    fn collapse(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.collapse())
+            .map_err(to_py_err)
     }
-    fn select(&self) -> PyResult<()> {
-        self.inner.select().map_err(to_py_err)
+    fn select(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.select()).map_err(to_py_err)
     }
-    fn show_menu(&self) -> PyResult<()> {
-        self.inner.show_menu().map_err(to_py_err)
+    fn show_menu(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.show_menu())
+            .map_err(to_py_err)
     }
-    fn scroll_into_view(&self) -> PyResult<()> {
-        self.inner.scroll_into_view().map_err(to_py_err)
+    fn scroll_into_view(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.scroll_into_view())
+            .map_err(to_py_err)
     }
-    fn increment(&self) -> PyResult<()> {
-        self.inner.increment().map_err(to_py_err)
+    fn increment(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.increment())
+            .map_err(to_py_err)
     }
-    fn decrement(&self) -> PyResult<()> {
-        self.inner.decrement().map_err(to_py_err)
+    fn decrement(&self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.decrement())
+            .map_err(to_py_err)
     }
-    fn set_value(&self, value: &str) -> PyResult<()> {
-        self.inner.set_value(value).map_err(to_py_err)
+    fn set_value(&self, py: Python<'_>, value: &str) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.set_value(value))
+            .map_err(to_py_err)
     }
-    fn set_numeric_value(&self, value: f64) -> PyResult<()> {
-        self.inner.set_numeric_value(value).map_err(to_py_err)
+    fn set_numeric_value(&self, py: Python<'_>, value: f64) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.set_numeric_value(value))
+            .map_err(to_py_err)
     }
-    fn type_text(&self, text: &str) -> PyResult<()> {
-        self.inner.type_text(text).map_err(to_py_err)
+    fn type_text(&self, py: Python<'_>, text: &str) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.type_text(text))
+            .map_err(to_py_err)
     }
-    fn select_text(&self, start: u32, end: u32) -> PyResult<()> {
-        self.inner.select_text(start, end).map_err(to_py_err)
+    fn select_text(&self, py: Python<'_>, start: u32, end: u32) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.select_text(start, end))
+            .map_err(to_py_err)
     }
-    fn perform_action(&self, action: &str) -> PyResult<()> {
-        self.inner.perform_action(action).map_err(to_py_err)
+    fn perform_action(&self, py: Python<'_>, action: &str) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.perform_action(action))
+            .map_err(to_py_err)
     }
 
     // ── Wait operations ──
 
     #[pyo3(signature = (timeout=5.0))]
     fn wait_visible(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
-        let el = self
-            .inner
-            .wait_visible(Duration::from_secs_f64(timeout))
+        let inner = self.inner.clone();
+        let el = py
+            .allow_threads(move || inner.wait_visible(Duration::from_secs_f64(timeout)))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
     #[pyo3(signature = (timeout=5.0))]
     fn wait_attached(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
-        let el = self
-            .inner
-            .wait_attached(Duration::from_secs_f64(timeout))
+        let inner = self.inner.clone();
+        let el = py
+            .allow_threads(move || inner.wait_attached(Duration::from_secs_f64(timeout)))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
     #[pyo3(signature = (timeout=5.0))]
-    fn wait_detached(&self, timeout: f64) -> PyResult<()> {
-        self.inner
-            .wait_detached(Duration::from_secs_f64(timeout))
+    fn wait_detached(&self, py: Python<'_>, timeout: f64) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.wait_detached(Duration::from_secs_f64(timeout)))
             .map_err(to_py_err)
     }
 
     #[pyo3(signature = (timeout=5.0))]
     fn wait_enabled(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
-        let el = self
-            .inner
-            .wait_enabled(Duration::from_secs_f64(timeout))
+        let inner = self.inner.clone();
+        let el = py
+            .allow_threads(move || inner.wait_enabled(Duration::from_secs_f64(timeout)))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
     #[pyo3(signature = (timeout=5.0))]
-    fn wait_hidden(&self, timeout: f64) -> PyResult<()> {
-        self.inner
-            .wait_hidden(Duration::from_secs_f64(timeout))
+    fn wait_hidden(&self, py: Python<'_>, timeout: f64) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.allow_threads(move || inner.wait_hidden(Duration::from_secs_f64(timeout)))
             .map_err(to_py_err)
     }
 
     #[pyo3(signature = (timeout=5.0))]
     fn wait_disabled(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
-        let el = self
-            .inner
-            .wait_disabled(Duration::from_secs_f64(timeout))
+        let inner = self.inner.clone();
+        let el = py
+            .allow_threads(move || inner.wait_disabled(Duration::from_secs_f64(timeout)))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
     #[pyo3(signature = (timeout=5.0))]
     fn wait_focused(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
-        let el = self
-            .inner
-            .wait_focused(Duration::from_secs_f64(timeout))
+        let inner = self.inner.clone();
+        let el = py
+            .allow_threads(move || inner.wait_focused(Duration::from_secs_f64(timeout)))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
     #[pyo3(signature = (timeout=5.0))]
     fn wait_unfocused(&self, py: Python<'_>, timeout: f64) -> PyResult<Py<Element>> {
-        let el = self
-            .inner
-            .wait_unfocused(Duration::from_secs_f64(timeout))
+        let inner = self.inner.clone();
+        let el = py
+            .allow_threads(move || inner.wait_unfocused(Duration::from_secs_f64(timeout)))
             .map_err(to_py_err)?;
         make_py_element(py, el.data(), el.provider().clone())
     }
 
     /// Wait until an arbitrary Python predicate is satisfied.
+    ///
+    /// A predicate that *raises* aborts the wait immediately and propagates
+    /// the exception — it is not swallowed as "not yet" (which would
+    /// resurface later as a misleading timeout). Mirrors `App.find`.
     #[pyo3(signature = (predicate, timeout=5.0))]
-    fn wait_until(&self, predicate: PyObject, timeout: f64) -> PyResult<()> {
+    fn wait_until(&self, py: Python<'_>, predicate: PyObject, timeout: f64) -> PyResult<()> {
         let provider = self.inner.provider().clone();
-        self.inner
-            .wait_until(
+        let inner = self.inner.clone();
+        // The poll loop runs with the GIL released (tenet 5); the predicate
+        // closure reacquires it per call. A raised predicate exception is
+        // stashed here and re-raised below. The closure reports `true` after
+        // stashing so the core loop terminates on this tick instead of
+        // burning the remaining timeout; the stash check after the loop
+        // takes precedence over the loop's own result.
+        let pred_err: std::sync::Mutex<Option<PyErr>> = std::sync::Mutex::new(None);
+        let result = py.allow_threads(|| {
+            inner.wait_until(
                 |element_data: Option<&xa11y::ElementData>| {
                     Python::with_gil(|py| -> bool {
+                        let mut stash = pred_err.lock().unwrap_or_else(|e| e.into_inner());
+                        if stash.is_some() {
+                            return true;
+                        }
                         let arg: PyObject = match element_data {
                             Some(data) => match make_py_element(py, data, provider.clone()) {
                                 Ok(el) => el.into_any(),
-                                Err(_) => py.None(),
+                                Err(e) => {
+                                    *stash = Some(e);
+                                    return true;
+                                }
                             },
                             None => py.None(),
                         };
-                        predicate
+                        match predicate
                             .call1(py, (arg,))
                             .and_then(|r| r.extract::<bool>(py))
-                            .unwrap_or(false)
+                        {
+                            Ok(matched) => matched,
+                            Err(e) => {
+                                *stash = Some(e);
+                                true
+                            }
+                        }
                     })
                 },
                 Duration::from_secs_f64(timeout),
             )
-            .map_err(to_py_err)?;
+        });
+        // A stashed predicate error takes precedence — re-raise the exact
+        // Python exception the predicate threw rather than a timeout.
+        if let Some(e) = pred_err.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            return Err(e);
+        }
+        result.map_err(to_py_err)?;
         Ok(())
     }
 
@@ -922,13 +1035,18 @@ impl Subscription {
     fn wait_for(&self, py: Python<'_>, predicate: PyObject, timeout: f64) -> PyResult<Event> {
         let dur = Duration::from_secs_f64(timeout);
         let start = std::time::Instant::now();
+        let mut seen: usize = 0;
 
         loop {
             let remaining = dur.saturating_sub(start.elapsed());
             if remaining.is_zero() {
-                return Err(to_py_err(xa11y::Error::Timeout {
-                    elapsed: start.elapsed(),
-                }));
+                return Err(to_py_err(xa11y::Error::timeout(start.elapsed()).diagnose(
+                    xa11y::Diagnosis {
+                        condition: Some("event matching predicate".to_string()),
+                        last_observed: Some(format!("{seen} event(s) received, none matched")),
+                        ..Default::default()
+                    },
+                )));
             }
             let poll = remaining.min(Duration::from_millis(50));
             let provider = self.provider.clone();
@@ -958,6 +1076,7 @@ impl Subscription {
             if matched {
                 return Ok(py_event);
             }
+            seen += 1;
         }
     }
 

--- a/xa11y-python/tests/test_exceptions.py
+++ b/xa11y-python/tests/test_exceptions.py
@@ -198,3 +198,70 @@ def test_no_internal_timeout_alias_leaks():
     callers should only reach the class via `xa11y.TimeoutError`."""
     assert not hasattr(xa11y, "XA11yTimeoutError")
     assert not hasattr(_native, "XA11yTimeoutError")
+
+
+# ── Structured diagnosis (tenet 6) ───────────────────────────────────────────
+#
+# Timeouts and selector misses carry structured fields — `condition`,
+# `selector`, `last_observed`, `candidates`, `scope` (plus `elapsed` on
+# timeouts) — so a test harness never needs to wrap a call in try/except just
+# to print the tree. The same content is rendered into the message.
+
+
+def test_timeout_diagnosis_attributes_never_matched(test_app):
+    with pytest.raises(xa11y.TimeoutError) as exc_info:
+        test_app.descendant('button[name="Nope"]').wait_visible(timeout=0.3)
+    e = exc_info.value
+    assert e.condition == "visible"
+    assert e.selector == 'application button[name="Nope"]'
+    assert e.last_observed == "selector never matched"
+    # Near-miss candidates: same-role elements from the mock tree.
+    assert 'button "Back"' in e.candidates
+    assert 'button "Forward"' in e.candidates
+    # Rootless locator: scope lists the running applications.
+    assert "TestApp" in e.scope
+    assert isinstance(e.elapsed, float) and e.elapsed >= 0.3
+
+
+def test_timeout_diagnosis_attributes_matched_wrong_state(test_app):
+    # static_text "Status" exists but is invisible in the mock tree.
+    with pytest.raises(xa11y.TimeoutError) as exc_info:
+        test_app.descendant('static_text[name="Status"]').wait_visible(timeout=0.3)
+    e = exc_info.value
+    assert 'static_text "Status"' in e.last_observed
+    assert "visible=false" in e.last_observed
+    # A matched element needs no candidate/scope sweep.
+    assert e.candidates == []
+    assert e.scope is None
+
+
+def test_timeout_message_renders_diagnosis(test_app):
+    """The message alone must be enough to understand the failure — no
+    `print(app.dump())` wrapper required."""
+    with pytest.raises(xa11y.TimeoutError) as exc_info:
+        test_app.descendant('button[name="Nope"]').wait_visible(timeout=0.3)
+    msg = str(exc_info.value)
+    assert "waiting for: visible" in msg
+    assert 'button[name="Nope"]' in msg
+    assert "selector never matched" in msg
+    assert 'button "Back"' in msg
+
+
+def test_selector_not_matched_diagnosis_attributes(test_app):
+    with pytest.raises(xa11y.SelectorNotMatchedError) as exc_info:
+        test_app.descendant('button[name="Nope"]').element()
+    e = exc_info.value
+    assert e.selector == 'application button[name="Nope"]'
+    assert 'button "Back"' in e.candidates
+    assert "TestApp" in e.scope
+    assert e.elapsed is None
+
+
+def test_diagnosis_attributes_always_present(test_app):
+    """Attributes exist (as None / []) even on paths that produce no
+    diagnosis content, so consumers never need hasattr guards."""
+    with pytest.raises(xa11y.TimeoutError) as exc_info:
+        test_app.descendant("button").wait_detached(timeout=0.05)
+    e = exc_info.value
+    for attr in ("condition", "selector", "last_observed", "candidates", "scope", "elapsed"):
+        assert hasattr(e, attr), f"missing diagnosis attribute {attr!r}"

--- a/xa11y-python/tests/test_gil_release.py
+++ b/xa11y-python/tests/test_gil_release.py
@@ -1,0 +1,91 @@
+"""Tenet 5 enforcement: native waits must release the GIL.
+
+Each test runs a Python background thread that increments a counter in a
+tight loop while the main thread blocks inside a native xa11y wait. If the
+wait held the GIL, the background thread could not be scheduled and the
+counter would stay near zero for the duration of the wait.
+
+Referenced from AGENTS.md (Design Tenets, tenet 5) — keep the file name
+stable.
+"""
+
+import threading
+import time
+
+import pytest
+import xa11y
+
+# A 1-second native wait. With the GIL released the 1 ms spin loop gets
+# hundreds of iterations; with the GIL held it gets approximately zero
+# (only the iterations before the wait starts and after it returns).
+_WAIT_S = 1.0
+_MIN_TICKS = 50
+
+
+def _ticks_during(blocked_call):
+    """Run `blocked_call` on the main thread while a background thread spins;
+    return how many spin iterations happened in that window."""
+    ticks = {"n": 0}
+    started = threading.Event()
+    stop = threading.Event()
+
+    def spin():
+        started.set()
+        while not stop.is_set():
+            ticks["n"] += 1
+            time.sleep(0.001)
+
+    t = threading.Thread(target=spin, daemon=True)
+    t.start()
+    if not started.wait(timeout=5):
+        raise AssertionError("spin thread failed to start")
+    ticks["n"] = 0  # discount any pre-wait iterations
+    try:
+        blocked_call()
+    finally:
+        stop.set()
+        t.join(timeout=5)
+    return ticks["n"]
+
+
+def test_wait_visible_releases_gil(test_app):
+    missing = test_app.descendant('button[name="Nope"]')
+
+    def blocked():
+        with pytest.raises(xa11y.TimeoutError):
+            missing.wait_visible(timeout=_WAIT_S)
+
+    ticks = _ticks_during(blocked)
+    assert ticks >= _MIN_TICKS, (
+        f"background thread made only {ticks} iterations during a "
+        f"{_WAIT_S}s wait_visible — the wait is holding the GIL (tenet 5)"
+    )
+
+
+def test_wait_detached_releases_gil(test_app):
+    present = test_app.descendant("button")
+
+    def blocked():
+        with pytest.raises(xa11y.TimeoutError):
+            present.wait_detached(timeout=_WAIT_S)
+
+    ticks = _ticks_during(blocked)
+    assert ticks >= _MIN_TICKS, (
+        f"background thread made only {ticks} iterations during a "
+        f"{_WAIT_S}s wait_detached — the wait is holding the GIL (tenet 5)"
+    )
+
+
+def test_wait_until_releases_gil_between_predicate_calls(test_app):
+    """wait_until calls back into Python, so it must hold the GIL only for
+    each predicate call — not across the 100 ms sleeps between polls."""
+
+    def blocked():
+        with pytest.raises(xa11y.TimeoutError):
+            test_app.wait_until(lambda el: False, timeout=_WAIT_S)
+
+    ticks = _ticks_during(blocked)
+    assert ticks >= _MIN_TICKS, (
+        f"background thread made only {ticks} iterations during a "
+        f"{_WAIT_S}s wait_until — the poll loop is holding the GIL (tenet 5)"
+    )

--- a/xa11y-python/tests/test_locator.py
+++ b/xa11y-python/tests/test_locator.py
@@ -182,3 +182,28 @@ def test_wait_enabled_timeout(test_app):
 def test_wait_detached_timeout(test_app):
     with pytest.raises(xa11y.TimeoutError):
         test_app.descendant('button[name="Back"]').wait_detached(timeout=0.3)
+
+
+# ── wait_until predicate error propagation ───────────────────────────────────
+
+
+def test_wait_until_predicate_exception_propagates(test_app):
+    """A raising predicate aborts the wait immediately with the original
+    exception — it must not be swallowed as "not yet" and resurface as a
+    misleading TimeoutError (mirrors App.find)."""
+    import time as _time
+
+    def boom(_el):
+        raise ValueError("boom")
+
+    start = _time.monotonic()
+    with pytest.raises(ValueError, match="boom"):
+        test_app.wait_until(boom, timeout=5.0)
+    assert _time.monotonic() - start < 2.0, "predicate exception should fail fast"
+
+
+def test_wait_until_predicate_false_times_out(test_app):
+    with pytest.raises(xa11y.TimeoutError) as exc_info:
+        test_app.wait_until(lambda _el: False, timeout=0.3)
+    # The custom predicate's timeout still carries a diagnosis.
+    assert exc_info.value.condition == "custom predicate"

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -730,12 +730,16 @@ impl Provider for WindowsProvider {
         } {
             Ok(el) => el,
             Err(e) if e.code().is_ok() => {
-                return Err(Error::SelectorNotMatched {
-                    selector: format!(
-                        "application with pid={pid} (no top-level UIA element owned by the \
-                         process yet)"
+                return Err(
+                    Error::selector_not_matched(format!("application[pid={pid}]")).diagnose(
+                        xa11y_core::Diagnosis {
+                            last_observed: Some(
+                                "no top-level UIA element owned by the process yet".to_string(),
+                            ),
+                            ..Default::default()
+                        },
                     ),
-                });
+                );
             }
             Err(e) => {
                 return Err(Error::Platform {

--- a/xa11y/src/lib.rs
+++ b/xa11y/src/lib.rs
@@ -22,8 +22,9 @@ use std::sync::{Arc, OnceLock};
 
 // Re-export public types.
 pub use xa11y_core::{
-    App, Element, ElementData, ElementState, Error, Event, EventKind, Locator, RawPlatformData,
-    Rect, Result, Role, StateFlag, StateSet, Subscription, SubscriptionIter, Toggled, TreeNode,
+    App, Diagnosis, Element, ElementData, ElementState, Error, Event, EventKind, Locator,
+    RawPlatformData, Rect, Result, Role, StateFlag, StateSet, Subscription, SubscriptionIter,
+    Toggled, TreeNode,
 };
 
 // Re-export input simulation surface.

--- a/xa11y/tests/integ/errors.rs
+++ b/xa11y/tests/integ/errors.rs
@@ -79,10 +79,25 @@ mod tests {
             .locator(NO_MATCH)
             .wait_attached(Duration::from_millis(500))
         {
-            Err(Error::Timeout { elapsed }) => {
+            Err(err @ Error::Timeout { .. }) => {
+                let Error::Timeout { elapsed, .. } = &err else {
+                    unreachable!()
+                };
                 assert!(
-                    elapsed >= Duration::from_millis(500),
+                    *elapsed >= Duration::from_millis(500),
                     "Timeout::elapsed should cover the full wait, got {elapsed:?}"
+                );
+                // Tenet 6: the timeout must say what it was waiting for and
+                // what it observed, on every platform provider.
+                let d = err
+                    .diagnosis()
+                    .expect("wait timeout must carry a diagnosis");
+                assert_eq!(d.condition.as_deref(), Some("attached"));
+                assert_eq!(d.selector.as_deref(), Some(NO_MATCH));
+                assert_eq!(d.last_observed.as_deref(), Some("selector never matched"));
+                assert!(
+                    d.scope.is_some(),
+                    "a never-matched wait should include a bounded scope snapshot"
                 );
             }
             Err(e) => panic!("expected Timeout, got: {e}"),

--- a/xa11y/tests/integ/tree.rs
+++ b/xa11y/tests/integ/tree.rs
@@ -57,7 +57,7 @@ mod tests {
         let result = App::by_pid(999_999_999, std::time::Duration::ZERO);
         match result {
             Ok(_) => panic!("by_pid for a nonexistent process must fail"),
-            Err(Error::SelectorNotMatched { selector }) => {
+            Err(Error::SelectorNotMatched { selector, .. }) => {
                 assert!(
                     selector.contains("pid=999999999"),
                     "diagnostic should name the pid, got: {selector}"

--- a/xa11y/tests/unit_test.rs
+++ b/xa11y/tests/unit_test.rs
@@ -530,9 +530,7 @@ fn error_display() {
     };
     assert!(format!("{}", err).contains("Permission denied"));
 
-    let err = Error::SelectorNotMatched {
-        selector: "button[name=\"Submit\"]".to_string(),
-    };
+    let err = Error::selector_not_matched("button[name=\"Submit\"]");
     assert!(format!("{}", err).contains("Submit"));
 
     let err = Error::ElementStale {
@@ -1544,9 +1542,9 @@ fn by_pid_with_routes_through_provider_app_by_pid() {
             if pid == 100 {
                 Ok(app1.clone())
             } else {
-                Err(Error::SelectorNotMatched {
-                    selector: format!("application with pid={pid}"),
-                })
+                Err(Error::selector_not_matched(format!(
+                    "application with pid={pid}"
+                )))
             }
         }),
     });
@@ -1687,21 +1685,34 @@ fn by_pid_timeout_reports_enumeration_diagnostics() {
         Ok(_) => panic!("lookup for an unknown pid must fail"),
         Err(e) => e,
     };
-    match err {
-        Error::SelectorNotMatched { selector } => {
+    match &err {
+        Error::SelectorNotMatched { selector, .. } => {
             assert!(
                 selector.contains("pid=999"),
                 "diagnostic should name the pid, got: {selector}"
             );
-            assert!(
-                selector.contains("3 running apps"),
-                "diagnostic should report enumeration size, got: {selector}"
-            );
-            assert!(
-                selector.contains("1 without a resolvable pid"),
-                "diagnostic should count unresolved pids, got: {selector}"
-            );
         }
         other => panic!("expected SelectorNotMatched, got {other:?}"),
     }
+    // The enumeration counts are structured diagnosis fields now (tenet 6),
+    // and the rendered message must still carry them so a CI timeout is
+    // diagnosable from the message alone.
+    let diagnosis = err.diagnosis().expect("by_pid miss must carry a diagnosis");
+    let last = diagnosis
+        .last_observed
+        .as_deref()
+        .expect("diagnosis must record what enumeration observed");
+    assert!(
+        last.contains("3 running apps"),
+        "diagnosis should report enumeration size, got: {last}"
+    );
+    assert!(
+        last.contains("1 without a resolvable pid"),
+        "diagnosis should count unresolved pids, got: {last}"
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("3 running apps") && msg.contains("1 without a resolvable pid"),
+        "rendered message should include the diagnosis, got: {msg}"
+    );
 }


### PR DESCRIPTION
Two new design tenets, with full implementations:

Tenet 5 — blocking calls release the host runtime's lock. Every Python
binding path that can block or poll (Locator wait_*/actions/queries,
Element actions, wait_until) now wraps the native call in
py.allow_threads; wait_until reacquires the GIL per predicate call and
propagates predicate exceptions instead of coercing them to "not yet"
(mirrors App.find). Previously a 60s wait_visible froze every other
Python thread, forcing consumers (e.g. the deadline-cloud-for-cinema4d
integ suite) to move in-process mock servers into separate processes.
Enforced by xa11y-python/tests/test_gil_release.py.

Tenet 6 — errors carry their own diagnosis. New structured Diagnosis
(condition, selector, last_observed, candidates, scope) on
Error::Timeout and Error::SelectorNotMatched, with the pattern
documented in xa11y-core/src/error.rs module docs:

- Locator waits/actions report what they waited for and what the last
  poll observed (matched-with-states vs never matched vs nth overflow).
- Terminal misses attach bounded context: same-role near-miss
  candidates and a depth-limited, line-capped scope snapshot — so
  consumers no longer wrap calls in print(app.dump()).
- App lookups list what is running; event waits count non-matching
  events and name disconnects. Platform app_by_pid diagnostics move
  from prose-in-selector to structured fields.
- Poll loops keep using cheap undiagnosed errors as retry signals;
  enrichment happens only where the error reaches the caller.

Bindings expose the fields structurally: Python exception attributes
(selector/condition/last_observed/candidates/scope/elapsed, always
present) and JS error properties parsed from a U+001F-separated JSON
payload on the existing code-tag channel. Messages render the same
content in both.

Docs: new "Errors & Diagnosis" guide, updated .pyi stubs and index.d.ts.
Tests: core diagnosis unit tests, Python attribute + GIL-release tests,
JS diagnosis tests, and end-to-end diagnosis assertions in the integ
suite (125 integ tests pass on Linux/AT-SPI; full cargo xtask check
green; xa11y-windows / xa11y-macos cross-checked).

https://claude.ai/code/session_01P9cVNQ3pGrjw7Po2M14AyY