### PR TITLE
Surface App.find: stub parity tests, multi-app discovery docs, Qt quirks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,14 +679,15 @@ jobs:
       - name: Check doc tables
         run: python docs/check_tables.py
 
-      - name: Check doc links
-        run: python docs/check_links.py
-
       - name: Generate Python API docs
         run: python docs/generate_python_api.py
 
       - name: Generate JavaScript API docs
         run: python docs/generate_js_api.py
+
+      # After generation, so links into the generated API pages resolve.
+      - name: Check doc links
+        run: python docs/check_links.py
 
       - name: Install Starlight npm dependencies
         working-directory: docs/site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,6 +679,9 @@ jobs:
       - name: Check doc tables
         run: python docs/check_tables.py
 
+      - name: Check doc links
+        run: python docs/check_links.py
+
       - name: Generate Python API docs
         run: python docs/generate_python_api.py
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check doc tables
         run: python docs/check_tables.py
 
+      - name: Check doc links
+        run: python docs/check_links.py
+
       - name: Generate Python API docs
         run: python docs/generate_python_api.py
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,14 +86,15 @@ jobs:
       - name: Check doc tables
         run: python docs/check_tables.py
 
-      - name: Check doc links
-        run: python docs/check_links.py
-
       - name: Generate Python API docs
         run: python docs/generate_python_api.py
 
       - name: Generate JavaScript API docs
         run: python docs/generate_js_api.py
+
+      # After generation, so links into the generated API pages resolve.
+      - name: Check doc links
+        run: python docs/check_links.py
 
       - name: Install npm dependencies
         working-directory: docs/site

--- a/docs/check_links.py
+++ b/docs/check_links.py
@@ -21,13 +21,15 @@ ASSET_PATH_PREFIXES = [
 ]
 
 # Regex for markdown links: [text](/path/) and HTML href="/path/"
-MARKDOWN_LINK = re.compile(r'\]\((/[^)]+)\)')
+MARKDOWN_LINK = re.compile(r"\]\((/[^)]+)\)")
 HTML_HREF = re.compile(r'href="(/[^"]+)"')
 
 
 def slug_to_file(slug: str) -> Path:
     """Convert a Starlight content slug like /guides/overview/ to a file path."""
     slug = slug.strip("/")
+    if not slug:
+        return DOCS_DIR / "index.mdx"
     return DOCS_DIR / f"{slug}.mdx"
 
 
@@ -54,6 +56,9 @@ def validate_link(link: str) -> str | None:
     # Allow anchor-only links
     if link.startswith("#"):
         return None
+
+    # Resolve against the page path; in-page fragments aren't validated
+    link = link.split("#", 1)[0]
 
     # Allow known asset paths
     for prefix in ASSET_PATH_PREFIXES:

--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -265,6 +265,67 @@ def _escape_table_pipe(text: str) -> str:
     return text.replace("|", "\\|")
 
 
+def _collect_class_attributes(
+    cls: ast.ClassDef,
+) -> list[tuple[str, str, str | None, str]]:
+    """Collect class-body attribute declarations as (name, annotation,
+    literal value or None, doc).
+
+    Supports the stub's attribute-docstring convention: a string literal
+    expression immediately following the declaration documents it.
+    """
+    attrs: list[tuple[str, str, str | None, str]] = []
+    body = cls.body
+    for i, item in enumerate(body):
+        name: str | None = None
+        annotation = ""
+        value: str | None = None
+        if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+            name = item.target.id
+            annotation = _unparse_annotation(item.annotation)
+            if item.value is not None:
+                value = ast.unparse(item.value)
+        elif isinstance(item, ast.Assign) and len(item.targets) == 1:
+            target = item.targets[0]
+            if isinstance(target, ast.Name):
+                name = target.id
+                value = ast.unparse(item.value)
+        if name is None or not _should_include(name):
+            continue
+        doc = ""
+        if i + 1 < len(body):
+            nxt = body[i + 1]
+            if (
+                isinstance(nxt, ast.Expr)
+                and isinstance(nxt.value, ast.Constant)
+                and isinstance(nxt.value.value, str)
+            ):
+                doc = textwrap.dedent(nxt.value.value).strip().split("\n")[0]
+        attrs.append((name, annotation, value, doc))
+    return attrs
+
+
+def _render_attributes_table(attrs: list[tuple[str, str, str | None, str]]) -> str:
+    """Render class attributes. Constants (all carry literal values) get a
+    Value column; plain attribute declarations get a Type column."""
+    all_constants = all(value is not None for _, _, value, _ in attrs)
+    if all_constants:
+        lines = [
+            "| Constant | Value | Description |",
+            "| -------- | ----- | ----------- |",
+        ]
+        for name, _, value, doc in attrs:
+            lines.append(f"| `{name}` | `{_escape_table_pipe(value or '')}` | {doc} |")
+    else:
+        lines = [
+            "| Attribute | Type | Description |",
+            "| --------- | ---- | ----------- |",
+        ]
+        for name, annotation, _, doc in attrs:
+            lines.append(f"| `{name}` | `{_escape_table_pipe(annotation)}` | {doc} |")
+    return "\n".join(lines)
+
+
 def _render_properties_table(members: list[ast.FunctionDef]) -> str:
     lines = [
         "| Property | Type | Description |",
@@ -387,6 +448,14 @@ def _render_class(cls: ast.ClassDef) -> str:
             else:
                 methods.append(item)
 
+    attributes = _collect_class_attributes(cls)
+    if attributes:
+        all_constants = all(value is not None for _, _, value, _ in attributes)
+        lines.append("#### Constants" if all_constants else "#### Attributes")
+        lines.append("")
+        lines.append(_render_attributes_table(attributes))
+        lines.append("")
+
     if properties:
         lines.append("#### Properties")
         lines.append("")
@@ -405,23 +474,17 @@ def _render_class(cls: ast.ClassDef) -> str:
                         "These methods accept a selector string or a `Node` as *target*:"
                     )
                     lines.append("")
-                    lines.append(
-                        _render_methods_table(group_methods)
-                    )
+                    lines.append(_render_methods_table(group_methods))
                 else:
                     lines.append(
-                        _render_methods_table(
-                            group_methods, category_label=label
-                        )
+                        _render_methods_table(group_methods, category_label=label)
                     )
                 lines.append("")
     elif cls.name == "Locator" and methods:
         groups = _categorize_locator_methods(methods)
         for label, group_methods in groups.items():
             if group_methods:
-                lines.append(
-                    _render_methods_table(group_methods, category_label=label)
-                )
+                lines.append(_render_methods_table(group_methods, category_label=label))
                 lines.append("")
     elif cls.name == "Provider" and methods:
         lines.append("#### Methods")
@@ -482,7 +545,8 @@ def generate() -> str:
     # Main classes (Provider, Tree, Node, Locator)
     class_order = ["Provider", "Tree", "Node", "Locator"]
     ordered_main = sorted(
-        main_classes, key=lambda c: class_order.index(c.name) if c.name in class_order else 99
+        main_classes,
+        key=lambda c: class_order.index(c.name) if c.name in class_order else 99,
     )
 
     if ordered_main:

--- a/docs/site/src/content/docs/guides/accessibility-quirks.mdx
+++ b/docs/site/src/content/docs/guides/accessibility-quirks.mdx
@@ -167,6 +167,17 @@ deterministic.
 States are a separate 64-bit bitfield (`AtspiStateType`), not properties —
 `ENABLED` (8), `FOCUSED` (12), `VISIBLE` (30), `EDITABLE` (7), `CHECKED` (4).
 
+### Qt tabs: `tab` on Windows, `radio_button` on macOS
+
+Qt's accessibility bridges map a `QTabBar` tab to different roles per
+platform: Windows UIA reports `tab` (inside a `tab_group`), while the macOS
+AX bridge reports `radio_button`. A selector that should work on both
+platforms has to match either:
+
+```python
+dialog.descendant("tab[name='Settings'], radio_button[name='Settings']").press()
+```
+
 ### WebKitGTK changed the role it reports for `<textarea>` between releases
 
 WebKitGTK **2.52** changed which AT-SPI role it reports for an HTML `<textarea>`,
@@ -175,6 +186,49 @@ upgrade (`2.50.4` → `2.52.3`). The portable fix is to never trust the toolkit'
 text role directly — derive single-line vs multi-line from the `MULTI_LINE`
 state bit, which is consistent across GTK (`GtkEntry`/`GtkTextView`),
 Qt (`QLineEdit`/`QPlainTextEdit`), and every WebKit version.
+
+## One process, several "applications"
+
+### Windows: Qt registers dialogs as separate UIA apps
+
+A `QDialog` opened inside a host process (e.g. a Qt submitter dialog inside
+a C++ DCC application) can register with UIA as its **own top-level
+"application"**, sharing the host's PID but living outside the host app's
+element tree. Searching the host app for the dialog finds nothing — you
+must attach to the dialog's own app. Predicate-based discovery handles this
+without hand-rolling an enumeration loop:
+
+```python
+dialog_app = xa11y.App.find(
+    lambda a: a.pid == proc.pid and a.name.startswith("My Submitter"),
+    timeout=60.0,
+)
+```
+
+On macOS AX the same dialog is an ordinary child window of the host app —
+so dialog discovery is one of the few places where platform-specific code
+is legitimately required.
+
+Two corollaries, both confirmed against live trees:
+
+- **The dialog's accessible name is the `QApplication` display name, not
+  `windowTitle()`.** Both the UIA "app" and the dialog window inside it
+  surface `QGuiApplication::applicationDisplayName()` (typically the app
+  name + version), so match on a name *prefix* rather than the window
+  title you see in the title bar.
+- **Child popups may be hosted elsewhere.** A `QMessageBox` shown from such
+  a dialog can land in the *host* application's tree, not the dialog's UIA
+  app. When the owner is unpredictable, search from the system root
+  (module-level `xa11y.locator(...)`) and wait for the popup's body text.
+
+### Qt forms don't label their fields
+
+`QFormLayout` does not propagate a row's label to the field's accessible
+name. In practice sibling widgets surface with the enclosing group's name
+(e.g. three spin boxes all named `"Job Properties"`) or with an empty name.
+Selectors can't disambiguate by name alone — pin the widget with
+`.nth(n)` (1-based, tree order) or scope to a parent `group` first, and
+re-verify the indices when the form's layout changes.
 
 ## Action names and mechanisms are not standardized
 
@@ -235,6 +289,28 @@ it is a genuine no-op.
 - **Windows:** numeric goes through `RangeValuePattern`, text through
   `ValuePattern` — and `type_text` is a non-atomic read-modify-write splice via
   `TextPattern.GetSelection()` + `ValuePattern.SetValue()`.
+
+### Qt spin boxes step — they don't set
+
+Setting a Qt `QSpinBox` / `QDoubleSpinBox` value through the accessibility
+API does not work on either Windows or macOS: depending on the platform and
+call, the set either raises or **reports success without changing the
+value**. The reliable cross-platform pattern is to *step* with
+`increment()` / `decrement()` and read the value back after each step —
+and don't trust a fixed step count, because a single `increment()` can
+occasionally advance the value by more than one:
+
+```python
+spin = dialog.descendant("spin_button[name='Priority']")
+current = int(spin.element().value)
+while current != target:
+    spin.increment() if current < target else spin.decrement()
+    current = int(spin.element().value)
+```
+
+(Bound the loop in real code so an out-of-range target can't spin forever.)
+Text fields and checkboxes are unaffected — `set_value()` and `toggle()`
+work on Qt as expected.
 
 ## Element references go stale — constantly
 

--- a/docs/site/src/content/docs/guides/desktop-testing.mdx
+++ b/docs/site/src/content/docs/guides/desktop-testing.mdx
@@ -41,6 +41,41 @@ xa11y::set_default_timeout(Duration::from_secs(30));   // Rust
 
 Or set the `XA11Y_DEFAULT_TIMEOUT` environment variable (seconds, read once at startup). Resolution order: an explicit per-call `timeout=` always wins, then the programmatic `set_default_timeout()` value, then the environment variable, then the built-in 5 seconds. A timeout of `0` means a single attempt with no polling.
 
+Because Locator *actions* (`press()`, `set_value()`, `toggle()`, …) already auto-wait for the target to be visible and enabled, a short `wait_visible()` immediately before an action is redundant — pass a per-call `timeout=` when one step needs a longer window, or raise the default once when the whole suite does.
+
+The same rule applies to *finding* things: every entry point that can race app startup has a polling form built in, so a hand-rolled `while`/`sleep` loop is never needed. Built-in polling also releases the host language's runtime lock while it waits (Python threads keep running during a 60s `wait_visible`) and produces a structured diagnosis on timeout — what it waited for, what it last observed, and near-miss candidates (see [Errors & Diagnosis](/guides/errors/)). A manual loop gets none of that.
+
+## Attaching to the app under test
+
+The usual test flow is: launch the app as a subprocess, then attach by PID — `App.by_pid` polls until the OS registers the process with the accessibility API:
+
+```python
+proc = subprocess.Popen([app_path])
+app = xa11y.App.by_pid(proc.pid, timeout=60.0)
+```
+
+Two situations need more than a PID:
+
+- **The UI registers as more than one accessibility app.** Some toolkits register top-level windows as *separate* accessibility applications sharing the host PID — on Windows UIA, a Qt dialog can appear as its own app rather than under the main window's tree (see [Accessibility API Quirks](/guides/accessibility-quirks/)). Match it with a predicate instead of polling `App.list()` by hand:
+
+  ```python
+  dialog_app = xa11y.App.find(
+      lambda a: a.pid == proc.pid and a.name.startswith("My Dialog"),
+      timeout=60.0,
+  )
+  ```
+
+- **The element belongs to an app you can't predict.** Message boxes and system popups are sometimes hosted by a different app than the one showing them. A locator created with the module-level `xa11y.locator()` searches from the system root — every running app — so you can wait for the popup without knowing its owner:
+
+  ```python
+  popup_text = xa11y.locator("static_text[name^='Saved the submission']")
+  popup = popup_text.wait_visible(timeout=10.0)
+  # scope follow-up actions to whichever app the popup landed in
+  xa11y.App.by_pid(popup.pid).locator("button[name='OK']").press()
+  ```
+
+  System-root searches visit every app's tree, so keep the selector specific and prefer app-scoped locators everywhere else.
+
 ## Example: testing a calculator
 
 This test opens Calculator, performs `7 × 8`, and asserts the result is `56`.

--- a/docs/site/src/content/docs/guides/overview.mdx
+++ b/docs/site/src/content/docs/guides/overview.mdx
@@ -75,7 +75,7 @@ xa11y supports subscribing to these event streams per-app via `app.subscribe()`.
 
 xa11y is built around three core types:
 
-- **App** — entry point for interacting with an application. Construct via `App::by_name()`, `App::by_pid()`, or `App::list()`. An App provides three paths: `app.children()` for navigating the tree, `app.locator(selector)` for actions and waits, and `app.subscribe()` for event streams.
+- **App** — entry point for interacting with an application. Construct via `App::by_name()`, `App::by_pid()`, `App::find()` (predicate-based discovery), or `App::list()`. An App provides three paths: `app.children()` for navigating the tree, `app.locator(selector)` for actions and waits, and `app.subscribe()` for event streams.
 - **Element** — a live handle to a node in the accessibility tree. Navigate with `children()` and `parent()` — each call queries the platform lazily. Read properties like `role`, `name`, `value`, `states`, `bounds`. Capture the subtree as a structured snapshot with `tree(max_depth)` or as an indented string with `dump(max_depth)`. Actions (`press()`, `set_value()`, etc.) are available too, acting on the captured handle without re-resolution or auto-wait.
 - **Locator** — a lazy selector that re-resolves on every operation. Use for actions (`press()`, `set_value()`, and others), waits (`wait_visible()`, and others), and querying (`element()`, `elements()`). Auto-waits for visible+enabled before acting and is the recommended path for most code. Inspired by [Playwright's Locator pattern](https://playwright.dev/docs/locators).
 - **Subscription** — live event stream from an app. Created via `app.subscribe()`. Pull events with `try_recv()`, `recv(timeout)`, `wait_for(predicate, timeout)`, or iterate with `iter()`. Drop to unsubscribe.
@@ -98,7 +98,13 @@ xa11y is built around three core types:
     // Connect by PID
     let app = App::by_pid(1234, Duration::from_secs(5))?;
 
-    // List all running apps
+    // Connect by predicate — polls until some running app matches.
+    // Use when neither name nor PID alone identifies the target.
+    let app = App::find(Duration::from_secs(5), |a| {
+        a.pid == Some(1234) && a.name.as_deref().unwrap_or("").starts_with("My App")
+    })?;
+
+    // List all running apps (single enumeration, no polling)
     let all = App::list()?;
     ```
   </TabItem>
@@ -112,7 +118,11 @@ xa11y is built around three core types:
     # Connect by PID
     app = xa11y.App.by_pid(1234)
 
-    # List all running apps
+    # Connect by predicate — polls until some running app matches.
+    # Use when neither name nor PID alone identifies the target.
+    app = xa11y.App.find(lambda a: a.pid == 1234 and a.name.startswith("My App"))
+
+    # List all running apps (single enumeration, no polling)
     all_apps = xa11y.App.list()
     ```
   </TabItem>
@@ -126,7 +136,14 @@ xa11y is built around three core types:
     // Connect by PID
     const app = await App.byPid(1234);
 
-    // List all running apps
+    // Connect by predicate — polls until some running app matches.
+    // Use when neither name nor PID alone identifies the target.
+    const app2 = await App.find(
+      (a) => a.pid === 1234 && a.name.startsWith('My App'),
+      { timeout: 5000 },
+    );
+
+    // List all running apps (single enumeration, no polling)
     const all = await App.list();
     ```
   </TabItem>

--- a/xa11y-js/scripts/patch-native-dts.mjs
+++ b/xa11y-js/scripts/patch-native-dts.mjs
@@ -44,8 +44,8 @@ export type EventTypeName =
   | 'selectionChanged'
   | 'menuOpened'
   | 'menuClosed'
-  | 'alert'
-  | 'textChanged';
+  | 'textChanged'
+  | 'announcement';
 
 `;
 

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -131,6 +131,7 @@ class EventType:
     MENU_CLOSED: str
     ALERT: str
     TEXT_CHANGED: str
+    ANNOUNCEMENT: str
 
 # ── Event ────────────────────────────────────────────────────────────────────
 
@@ -145,6 +146,18 @@ class Event:
     def app_pid(self) -> int: ...
     @property
     def target(self) -> Element | None: ...
+    @property
+    def state_flag(self) -> str | None:
+        """For ``state_changed`` events: the flag that changed (e.g. ``'checked'``).
+
+        ``None`` for other event types.
+        """
+    @property
+    def state_value(self) -> bool | None:
+        """For ``state_changed`` events: the new boolean value of the flag.
+
+        ``None`` for other event types.
+        """
     def __repr__(self) -> str: ...
 
 # ── Subscription ─────────────────────────────────────────────────────────────
@@ -215,7 +228,17 @@ class App:
         application on every poll; the first for which it returns truthy is
         returned. A falsy return means "not this one, keep polling"; if the
         predicate *raises*, the search aborts immediately and that exception
-        propagates. See ``by_name`` for ``timeout`` semantics.
+        propagates. See ``by_name`` for ``timeout`` semantics. There is no
+        need to hand-roll a poll over ``App.list()``.
+
+        Use this when neither a name nor a PID alone identifies the target
+        — e.g. a Qt dialog that registers as its own accessibility
+        application sharing the host process's PID::
+
+            app = xa11y.App.find(
+                lambda a: a.pid == pid and a.name.startswith("My Dialog"),
+                timeout=30.0,
+            )
         """
     @staticmethod
     def list() -> list[App]:
@@ -304,7 +327,16 @@ class Element:
     @property
     def focused(self) -> bool: ...
     @property
-    def checked(self) -> str | None: ...
+    def checked(self) -> str | None:
+        """Tri-state toggle value: ``'on'``, ``'off'``, ``'mixed'``, or ``None``.
+
+        ``None`` means the element has no checked state (it is not a
+        checkbox / radio button / toggle). These four are the only possible
+        values. Compare against them explicitly — ``bool(element.checked)``
+        is ``True`` for *every* non-``None`` value, including ``'off'``::
+
+            is_checked = element.checked == "on"
+        """
     @property
     def selected(self) -> bool: ...
     @property

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -115,23 +115,27 @@ class Rect:
 # ── EventType ────────────────────────────────────────────────────────────────
 
 class EventType:
-    """Accessibility event type constants."""
+    """Accessibility event type constants.
 
-    FOCUS_CHANGED: str
-    VALUE_CHANGED: str
-    NAME_CHANGED: str
-    STATE_CHANGED: str
-    STRUCTURE_CHANGED: str
-    WINDOW_OPENED: str
-    WINDOW_CLOSED: str
-    WINDOW_ACTIVATED: str
-    WINDOW_DEACTIVATED: str
-    SELECTION_CHANGED: str
-    MENU_OPENED: str
-    MENU_CLOSED: str
-    ALERT: str
-    TEXT_CHANGED: str
-    ANNOUNCEMENT: str
+    Each constant's value is the string carried in :attr:`Event.event_type`,
+    so handlers can compare against the constant or the literal string
+    interchangeably.
+    """
+
+    FOCUS_CHANGED: str = "focus_changed"
+    VALUE_CHANGED: str = "value_changed"
+    NAME_CHANGED: str = "name_changed"
+    STATE_CHANGED: str = "state_changed"
+    STRUCTURE_CHANGED: str = "structure_changed"
+    WINDOW_OPENED: str = "window_opened"
+    WINDOW_CLOSED: str = "window_closed"
+    WINDOW_ACTIVATED: str = "window_activated"
+    WINDOW_DEACTIVATED: str = "window_deactivated"
+    SELECTION_CHANGED: str = "selection_changed"
+    MENU_OPENED: str = "menu_opened"
+    MENU_CLOSED: str = "menu_closed"
+    TEXT_CHANGED: str = "text_changed"
+    ANNOUNCEMENT: str = "announcement"
 
 # ── Event ────────────────────────────────────────────────────────────────────
 

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -1669,8 +1669,10 @@ fn screenshot(
 // ── Module-level functions ──────────────────────────────────────────────────
 
 /// Create a top-level Locator.
+// The Rust fn is named locator_fn to avoid clashing with the Locator type;
+// pyo3 registers it under the public name "locator".
 #[pyfunction]
-#[pyo3(signature = (selector))]
+#[pyo3(name = "locator", signature = (selector))]
 fn locator_fn(selector: &str) -> PyResult<Locator> {
     let provider = get_provider()?;
     Ok(Locator {
@@ -1733,11 +1735,8 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_exception::<InvalidActionDataError>(m, "InvalidActionDataError")?;
     register_exception::<PlatformError>(m, "PlatformError")?;
 
-    // Module-level locator function (renamed from "locator" to avoid Rust naming conflict)
+    // Module-level locator function (registered as "locator" via #[pyo3(name)])
     m.add_function(wrap_pyfunction!(locator_fn, m)?)?;
-    // Re-export as "locator" in Python
-    let locator_fn_obj = m.getattr("locator_fn")?;
-    m.setattr("locator", &locator_fn_obj)?;
 
     // Process-wide default timeout knobs
     m.add_function(wrap_pyfunction!(set_default_timeout, m)?)?;

--- a/xa11y-python/tests/test_typing.py
+++ b/xa11y-python/tests/test_typing.py
@@ -1,6 +1,117 @@
 """Smoke test that type stubs are loadable and basic annotations work."""
 
+import ast
+import importlib.resources as resources
+
 import xa11y
+from xa11y import _native
+
+
+def _load_stub_tree() -> ast.Module:
+    stub = resources.files("xa11y") / "_native.pyi"
+    return ast.parse(stub.read_text(encoding="utf-8"))
+
+
+def _stub_class_members(tree: ast.Module) -> dict[str, set[str]]:
+    """Map each stub class name to the names declared in its body.
+
+    Collects methods (``def``), and class-body assignments (constants on
+    ``EventType``, documented exception attributes). Instance attributes
+    declared via ``AnnAssign`` don't exist on the runtime *class*, so the
+    stub→runtime direction below only checks methods.
+    """
+    members: dict[str, set[str]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        names: set[str] = set()
+        for item in node.body:
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                names.add(item.name)
+            elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                names.add(item.target.id)
+            elif isinstance(item, ast.Assign):
+                for target in item.targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+        members[node.name] = names
+    return members
+
+
+def _stub_class_methods(tree: ast.Module) -> dict[str, set[str]]:
+    """Map each stub class name to just its method names."""
+    methods: dict[str, set[str]] = {}
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            methods[node.name] = {
+                item.name
+                for item in node.body
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+    return methods
+
+
+def _public(names) -> set[str]:
+    return {n for n in names if not n.startswith("_")}
+
+
+def test_stub_covers_every_native_class_member():
+    """Every public member of a native class must appear in the stub.
+
+    The Python API reference on xa11y.dev is generated from _native.pyi, so
+    a binding method missing from the stub is invisible to type checkers,
+    IDEs, *and* the docs site — exactly how App.find shipped in 0.8.2
+    without ever appearing in the documentation.
+    """
+    stub_members = _stub_class_members(_load_stub_tree())
+    missing: list[str] = []
+    for cls_name, declared in stub_members.items():
+        runtime_cls = getattr(_native, cls_name, None)
+        if runtime_cls is None:
+            continue
+        for member in _public(vars(runtime_cls)):
+            if member not in declared:
+                missing.append(f"{cls_name}.{member}")
+    assert not missing, (
+        "native members missing from _native.pyi (they will not appear in "
+        f"the generated API docs): {sorted(missing)}"
+    )
+
+
+def test_stub_methods_all_exist_at_runtime():
+    """Every method the stub declares must exist on the native class —
+    catches stubs going stale after a binding rename/removal."""
+    stub_methods = _stub_class_methods(_load_stub_tree())
+    stale: list[str] = []
+    for cls_name, declared in stub_methods.items():
+        if cls_name.startswith("_"):
+            # Typing-only fictions (e.g. _TestActionProbe) describe objects
+            # that are reachable but not module attributes.
+            continue
+        runtime_cls = getattr(_native, cls_name, None)
+        if runtime_cls is None:
+            stale.append(cls_name)
+            continue
+        for method in _public(declared):
+            if not hasattr(runtime_cls, method):
+                stale.append(f"{cls_name}.{method}")
+    assert not stale, f"stub declares members the native module lacks: {sorted(stale)}"
+
+
+def test_stub_covers_module_level_names():
+    """Public module-level classes/functions must match between the native
+    module and the stub, in both directions."""
+    tree = _load_stub_tree()
+    stub_names = {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    runtime_names = _public(vars(_native))
+    missing_from_stub = sorted(runtime_names - stub_names)
+    stale_in_stub = sorted(_public(stub_names) - runtime_names)
+    assert not missing_from_stub, f"module names missing from _native.pyi: {missing_from_stub}"
+    assert not stale_in_stub, f"stub declares module names the native module lacks: {stale_in_stub}"
 
 
 def test_stub_types_are_accessible():

--- a/xa11y-python/tests/test_typing.py
+++ b/xa11y-python/tests/test_typing.py
@@ -98,6 +98,58 @@ def test_stub_methods_all_exist_at_runtime():
     assert not stale, f"stub declares members the native module lacks: {sorted(stale)}"
 
 
+def _stub_class_constants(tree: ast.Module) -> dict[str, dict[str, object]]:
+    """Map each stub class name to its constants: class-body assignments
+    that carry a literal value (e.g. ``FOCUS_CHANGED: str = "focus_changed"``).
+
+    Annotation-only declarations (``selector: str | None``) describe
+    *instance* attributes set at runtime and are excluded — they have no
+    class-level counterpart to compare against.
+    """
+    constants: dict[str, dict[str, object]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        values: dict[str, object] = {}
+        for item in node.body:
+            if (
+                isinstance(item, ast.AnnAssign)
+                and isinstance(item.target, ast.Name)
+                and isinstance(item.value, ast.Constant)
+            ):
+                values[item.target.id] = item.value.value
+            elif isinstance(item, ast.Assign) and isinstance(item.value, ast.Constant):
+                for target in item.targets:
+                    if isinstance(target, ast.Name):
+                        values[target.id] = item.value.value
+        if values:
+            constants[node.name] = values
+    return constants
+
+
+def test_stub_constants_match_runtime_values():
+    """Every constant the stub declares with a value (e.g. the EventType
+    strings) must exist on the native class with that exact value — catches
+    both stale constants (EventType.ALERT once outlived its runtime
+    counterpart) and value drift."""
+    constants = _stub_class_constants(_load_stub_tree())
+    problems: list[str] = []
+    for cls_name, values in constants.items():
+        runtime_cls = getattr(_native, cls_name, None)
+        if runtime_cls is None:
+            problems.append(f"{cls_name}: class missing from native module")
+            continue
+        for name, expected in values.items():
+            if not hasattr(runtime_cls, name):
+                problems.append(f"{cls_name}.{name}: missing from native module")
+            elif getattr(runtime_cls, name) != expected:
+                problems.append(
+                    f"{cls_name}.{name}: stub says {expected!r}, "
+                    f"native has {getattr(runtime_cls, name)!r}"
+                )
+    assert not problems, f"stub constants out of sync with native module: {problems}"
+
+
 def test_stub_covers_module_level_names():
     """Public module-level classes/functions must match between the native
     module and the stub, in both directions."""

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -488,14 +488,8 @@ fn do_test_matrix_check() -> bool {
 }
 
 fn do_docs() -> bool {
-    heading("Check doc links");
-    let root = project_root();
-    let links_ok = run_in("python", &["docs/check_links.py"], &root);
-    if !links_ok {
-        return false;
-    }
-
     heading("Check doc tables");
+    let root = project_root();
     let tables_ok = run_in("python", &["docs/check_tables.py"], &root);
     if !tables_ok {
         return false;
@@ -510,6 +504,14 @@ fn do_docs() -> bool {
     heading("Generate JavaScript API docs");
     let gen_js_ok = run_in("python", &["docs/generate_js_api.py"], &root);
     if !gen_js_ok {
+        return false;
+    }
+
+    // After generation, so links into the generated API pages resolve on a
+    // fresh checkout (e.g. /api/python/ from quick-start.mdx).
+    heading("Check doc links");
+    let links_ok = run_in("python", &["docs/check_links.py"], &root);
+    if !links_ok {
         return false;
     }
 


### PR DESCRIPTION
The deadline-cloud-for-cinema-4d integ suite (its PR #465) hand-rolled
several patterns this library already provides, mostly rooted in one gap:
App.find was added to the Python binding in #235 but never to _native.pyi,
and the Python API reference on xa11y.dev is generated from the stub — so
the method was invisible to the docs site, type checkers, and IDEs, and
consumers reimplemented it as a manual App.list() poll loop.

- stubs: add App.find; document Element.checked's exact values
  ('on'/'off'/'mixed'/None) and the bool() footgun; add the also-missing
  Event.state_flag, Event.state_value, EventType.ANNOUNCEMENT.
- tests: stub<->binding parity tests (both directions, classes and module
  level) so a binding method can never again ship without appearing in the
  stub and the generated API docs. They caught the three Event/EventType
  gaps above on first run.
- binding: register the module-level locator function as "locator" via
  #[pyo3(name)] instead of a post-hoc alias, removing the accidental
  public locator_fn duplicate the parity test flagged.
- guides: desktop-testing gains "Attaching to the app under test"
  (by_pid for launched subprocesses, App.find for toolkits that register
  dialogs as separate accessibility apps, system-root xa11y.locator() for
  popups with unpredictable owners) plus a note that Locator actions
  auto-wait; overview shows App.find alongside by_name/by_pid/list in all
  three language tabs.
- quirks: four Qt entries harvested from that suite — dialogs registering
  as separate UIA apps sharing the host PID (accessible name is the
  QApplication display name, not windowTitle; child popups can be hosted
  by the main app), QFormLayout not labeling fields, spin boxes that step
  but don't set, and tab roles differing per platform (tab vs
  radio_button).
- docs CI: check_links.py now resolves links carrying #fragments (and the
  root link) instead of misreporting them broken, and ci.yml/docs.yml run
  it — previously it was only wired into cargo xtask docs, where the
  fragment bug made it fail on three valid anchor links.

https://claude.ai/code/session_01Tdxccrr6J7ARrqGsEB6e43