### PR TITLE
ci: bump apt-cache-version to evict poisoned setup-a11y package cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
         uses: xa11y/setup-a11y@v1
         with:
           package-groups: base gtk
+          # Bumped 2->3 to evict a poisoned apt-package cache: a partial
+          # save left the `base gtk` entry with a manifest but no .deb
+          # payload, so warm restores installed 0 packages and the build
+          # failed to link libxkbcommon (rust-lld: unable to find
+          # -lxkbcommon). A new version mints a fresh cache key. Kept in
+          # sync across every setup-a11y call below.
+          apt-cache-version: "3"
           setup-display: "false"
           setup-atspi: "false"
 
@@ -255,6 +262,7 @@ jobs:
         uses: xa11y/setup-a11y@v1
         with:
           package-groups: base gtk electron
+          apt-cache-version: "3"
           setup-window-manager: ${{ matrix.app == 'egui' }}
 
       # ── Build Rust workspace (all workspace test-app binaries) ─────
@@ -467,6 +475,7 @@ jobs:
         uses: xa11y/setup-a11y@v1
         with:
           package-groups: base
+          apt-cache-version: "3"
 
       # ── Build everything the examples need ───────────────────────────
       - name: Build workspace (test app, CLI, Rust example)
@@ -601,6 +610,7 @@ jobs:
         uses: xa11y/setup-a11y@v1
         with:
           package-groups: link
+          apt-cache-version: "3"
           setup-display: "false"
           setup-atspi: "false"
 
@@ -729,6 +739,7 @@ jobs:
         uses: xa11y/setup-a11y@v1
         with:
           package-groups: link
+          apt-cache-version: "3"
           setup-display: "false"
           setup-atspi: "false"
 
@@ -800,6 +811,7 @@ jobs:
         uses: xa11y/setup-a11y@v1
         with:
           package-groups: link
+          apt-cache-version: "3"
           setup-display: "false"
           setup-atspi: "false"
 


### PR DESCRIPTION
The Linux job's setup-a11y step hit a poisoned apt-package cache: the
awalsh128/cache-apt-pkgs-action "base gtk" entry had been saved with a
manifest but no .deb payload (a known partial-save race), so warm
restores reported a cache hit yet installed 0 packages ("Restoring 0
packages from cache...", manifest_all.log missing). With libxkbcommon-dev
never installed, cargo test --workspace failed to link xa11y-linux:

    rust-lld: error: unable to find library -lxkbcommon

Bump apt-cache-version 2 -> 3 on every Linux setup-a11y invocation to
mint fresh cache keys, evicting the poisoned entry and any others the
same race could have corrupted. A single explicit libxkbcommon-dev
install would not suffice: a poisoned cache drops the whole package set,
so the later run_integ_tests.sh step would still lack xvfb/at-spi2/gtk.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VfmXCk9PjdZv1p553cZskY