### PR TITLE
fix(windows): report logical bounds + honest screenshot scale (#300)

### DIFF
--- a/xa11y-core/src/element.rs
+++ b/xa11y-core/src/element.rs
@@ -43,7 +43,17 @@ pub struct ElementData {
     /// See [`crate::text::strip_bidi`].
     pub description: Option<String>,
 
-    /// Bounding rectangle in screen pixels
+    /// Bounding rectangle in **logical** screen coordinates
+    /// (device-independent points), origin at the top-left of the primary
+    /// display. This is the same coordinate space accepted by
+    /// [`crate::ScreenshotProvider::capture_region`] and by the input layer's
+    /// [`crate::input::Point`], so bounds can be fed directly to
+    /// `screenshot_element` / `click` without conversion.
+    ///
+    /// To map to physical device pixels (e.g. to index into a captured image),
+    /// multiply by the [`crate::Screenshot::scale`] reported for that display:
+    /// `physical = logical × scale`. See [`Rect::to_physical`] /
+    /// [`Rect::to_logical`].
     pub bounds: Option<Rect>,
 
     /// Available actions reported by the platform.
@@ -422,6 +432,183 @@ pub struct Rect {
     pub y: i32,
     pub width: u32,
     pub height: u32,
+}
+
+impl Rect {
+    /// Convert a **logical** rectangle to **physical** device pixels by
+    /// multiplying every component by `scale` (the physical-to-logical ratio,
+    /// e.g. `1.5` at 150% or `2.0` on a typical Retina display).
+    ///
+    /// This is the inverse of [`Rect::to_logical`]. Each field is rounded to
+    /// the nearest integer independently; for a single rectangle the position
+    /// and size therefore round separately, which can differ by 1px from
+    /// scaling the far edge — acceptable for capture/hit-test use where a 1px
+    /// slack is expected on fractional scales.
+    ///
+    /// A non-finite or non-positive `scale` is treated as `1.0` (identity):
+    /// callers on platforms without a known scale factor pass `1.0`, and a
+    /// bogus value must never produce garbage coordinates.
+    #[must_use]
+    pub fn to_physical(self, scale: f64) -> Rect {
+        let s = sane_scale(scale);
+        Rect {
+            x: scale_i32(self.x, s),
+            y: scale_i32(self.y, s),
+            width: scale_u32(self.width, s),
+            height: scale_u32(self.height, s),
+        }
+    }
+
+    /// Convert a **physical** rectangle (device pixels) to **logical**
+    /// coordinates by dividing every component by `scale`. Inverse of
+    /// [`Rect::to_physical`]. See that method for rounding and `scale`
+    /// validity semantics.
+    #[must_use]
+    pub fn to_logical(self, scale: f64) -> Rect {
+        self.to_physical(1.0 / sane_scale(scale))
+    }
+}
+
+/// Clamp a scale factor to a usable positive, finite value. Non-finite or
+/// non-positive inputs collapse to `1.0` so a bad platform reading degrades
+/// to identity rather than producing nonsense coordinates.
+pub(crate) fn sane_scale(scale: f64) -> f64 {
+    if scale.is_finite() && scale > 0.0 {
+        scale
+    } else {
+        1.0
+    }
+}
+
+fn scale_i32(v: i32, scale: f64) -> i32 {
+    (f64::from(v) * scale).round() as i32
+}
+
+fn scale_u32(v: u32, scale: f64) -> u32 {
+    let scaled = (f64::from(v) * scale).round();
+    if scaled < 0.0 {
+        0
+    } else {
+        scaled as u32
+    }
+}
+
+#[cfg(test)]
+mod rect_scale_tests {
+    use super::Rect;
+
+    const R: Rect = Rect {
+        x: 100,
+        y: 200,
+        width: 300,
+        height: 40,
+    };
+
+    #[test]
+    fn scale_one_is_identity() {
+        assert_eq!(R.to_physical(1.0), R);
+        assert_eq!(R.to_logical(1.0), R);
+    }
+
+    #[test]
+    fn to_physical_multiplies_all_fields() {
+        assert_eq!(
+            R.to_physical(2.0),
+            Rect {
+                x: 200,
+                y: 400,
+                width: 600,
+                height: 80
+            }
+        );
+    }
+
+    #[test]
+    fn to_logical_divides_all_fields() {
+        // Physical bounds on a 150% display -> logical points.
+        let physical = Rect {
+            x: 150,
+            y: 300,
+            width: 450,
+            height: 60,
+        };
+        assert_eq!(
+            physical.to_logical(1.5),
+            Rect {
+                x: 100,
+                y: 200,
+                width: 300,
+                height: 40
+            }
+        );
+    }
+
+    #[test]
+    fn round_trip_preserves_within_one_px() {
+        for &scale in &[1.25_f64, 1.5, 1.75, 2.0] {
+            let back = R.to_physical(scale).to_logical(scale);
+            assert!((back.x - R.x).abs() <= 1, "x drift at {scale}");
+            assert!((back.y - R.y).abs() <= 1, "y drift at {scale}");
+            assert!(
+                (back.width as i64 - R.width as i64).abs() <= 1,
+                "w drift at {scale}"
+            );
+            assert!(
+                (back.height as i64 - R.height as i64).abs() <= 1,
+                "h drift at {scale}"
+            );
+        }
+    }
+
+    #[test]
+    fn negative_origin_scales_correctly() {
+        // Multi-monitor: a window on a display left of the primary.
+        let r = Rect {
+            x: -1920,
+            y: -100,
+            width: 200,
+            height: 100,
+        };
+        assert_eq!(
+            r.to_physical(2.0),
+            Rect {
+                x: -3840,
+                y: -200,
+                width: 400,
+                height: 200
+            }
+        );
+    }
+
+    #[test]
+    fn fractional_scale_rounds_to_nearest() {
+        let r = Rect {
+            x: 3,
+            y: 3,
+            width: 5,
+            height: 5,
+        };
+        // 3 * 1.5 = 4.5 -> 5 (round half away from zero via f64::round);
+        // 5 * 1.5 = 7.5 -> 8.
+        assert_eq!(
+            r.to_physical(1.5),
+            Rect {
+                x: 5,
+                y: 5,
+                width: 8,
+                height: 8
+            }
+        );
+    }
+
+    #[test]
+    fn bad_scale_degrades_to_identity() {
+        assert_eq!(R.to_physical(0.0), R);
+        assert_eq!(R.to_physical(-2.0), R);
+        assert_eq!(R.to_physical(f64::NAN), R);
+        assert_eq!(R.to_physical(f64::INFINITY), R);
+        assert_eq!(R.to_logical(0.0), R);
+    }
 }
 
 /// Platform-specific raw data attached to every element.

--- a/xa11y-core/src/input.rs
+++ b/xa11y-core/src/input.rs
@@ -43,12 +43,19 @@ use crate::error::{Error, Result};
 
 // ── Geometry ────────────────────────────────────────────────────────
 
-/// A 2D point in screen coordinates.
+/// A 2D point in **logical** screen coordinates (device-independent points).
 ///
-/// Coordinates are integer screen pixels in the platform's native coordinate
-/// space. On macOS this is points (the OS handles HiDPI scaling for input
-/// events); on Windows and Linux this is physical pixels. Origin is top-left
-/// of the primary display; negative values are valid on multi-monitor setups.
+/// This is the same coordinate space as [`crate::element::Rect`] in
+/// `Element::bounds`, so anchor points computed from an element's bounds are
+/// already in the right space. Origin is top-left of the primary display;
+/// negative values are valid on multi-monitor setups.
+///
+/// Each [`InputProvider`] converts logical points to whatever its OS input API
+/// requires at the FFI boundary: macOS uses points natively (identity), while
+/// Windows and Linux multiply by the target display's scale factor to reach
+/// physical device pixels before dispatching the event. Consumers never see
+/// physical pixels here — a point that lands on an element's centre is
+/// `anchor_point(&element.bounds, Anchor::Center)`, unscaled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Point {
     pub x: i32,
@@ -58,6 +65,26 @@ pub struct Point {
 impl Point {
     pub const fn new(x: i32, y: i32) -> Self {
         Self { x, y }
+    }
+
+    /// Convert this **logical** point to **physical** device pixels by
+    /// multiplying by `scale` (the physical-to-logical ratio). Used by input
+    /// backends at the OS boundary. A non-finite or non-positive `scale`
+    /// collapses to `1.0` (identity) — see [`crate::element::Rect::to_physical`].
+    #[must_use]
+    pub fn to_physical(self, scale: f64) -> Point {
+        let s = crate::element::sane_scale(scale);
+        Point {
+            x: (f64::from(self.x) * s).round() as i32,
+            y: (f64::from(self.y) * s).round() as i32,
+        }
+    }
+
+    /// Convert this **physical** point to **logical** coordinates by dividing
+    /// by `scale`. Inverse of [`Point::to_physical`].
+    #[must_use]
+    pub fn to_logical(self, scale: f64) -> Point {
+        self.to_physical(1.0 / crate::element::sane_scale(scale))
     }
 }
 
@@ -671,5 +698,52 @@ where
         (Err(e), _) => Err(e),
         (Ok(()), Some(e)) => Err(e),
         (Ok(()), None) => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod point_scale_tests {
+    use super::{anchor_point, Anchor, Point};
+    use crate::element::Rect;
+
+    #[test]
+    fn scale_one_is_identity() {
+        let p = Point::new(100, -50);
+        assert_eq!(p.to_physical(1.0), p);
+        assert_eq!(p.to_logical(1.0), p);
+    }
+
+    #[test]
+    fn logical_to_physical_scales() {
+        assert_eq!(Point::new(100, 200).to_physical(1.5), Point::new(150, 300));
+        assert_eq!(Point::new(-40, 10).to_physical(2.0), Point::new(-80, 20));
+    }
+
+    #[test]
+    fn physical_to_logical_is_inverse() {
+        assert_eq!(Point::new(150, 300).to_logical(1.5), Point::new(100, 200));
+    }
+
+    #[test]
+    fn bad_scale_degrades_to_identity() {
+        let p = Point::new(7, 9);
+        assert_eq!(p.to_physical(0.0), p);
+        assert_eq!(p.to_physical(f64::NAN), p);
+    }
+
+    #[test]
+    fn anchor_center_of_logical_bounds_scales_to_physical() {
+        // A button whose logical bounds are 200x40 at (100, 100). Its centre
+        // is (200, 120) logically; on a 2x display the physical pixel is
+        // (400, 240) — what an input backend would feed to the OS.
+        let bounds = Rect {
+            x: 100,
+            y: 100,
+            width: 200,
+            height: 40,
+        };
+        let center = anchor_point(&bounds, Anchor::Center);
+        assert_eq!(center, Point::new(200, 120));
+        assert_eq!(center.to_physical(2.0), Point::new(400, 240));
     }
 }

--- a/xa11y-js/src/input.rs
+++ b/xa11y-js/src/input.rs
@@ -14,8 +14,10 @@ use crate::map_err;
 /// Synthesises OS-level pointer and keyboard events.
 ///
 /// Constructed via the module-level `inputSim()` function. Targets are
-/// either an `[x, y]` tuple in screen pixels, or an `Element` (centred on
-/// its bounds). Key values are strings: printable characters are literal
+/// either an `[x, y]` tuple in logical screen coordinates (same space as
+/// `Element.bounds`), or an `Element` (centred on its bounds). Each backend
+/// converts to physical device pixels at the OS boundary. Key values are
+/// strings: printable characters are literal
 /// (`"a"`, `"7"`, `";"`); named keys use their Pascal name (`"Enter"`,
 /// `"ArrowUp"`, `"F5"`); modifiers are `"Shift"`, `"Ctrl"`, `"Alt"`,
 /// `"Meta"`.

--- a/xa11y-js/src/types.rs
+++ b/xa11y-js/src/types.rs
@@ -25,11 +25,13 @@ impl From<xa11y::TreeNode> for TreeNode {
     }
 }
 
-/// A bounding rectangle in screen coordinates.
+/// A bounding rectangle in **logical** screen coordinates
+/// (device-independent points) on every platform. Origin is the top-left of
+/// the primary display; negative `x` / `y` are valid on multi-monitor setups.
 ///
-/// Coordinates use the platform's native coordinate space: points on macOS,
-/// physical pixels on Windows and Linux. Origin is the top-left of the
-/// primary display; negative `x` / `y` are valid on multi-monitor setups.
+/// This is the same space accepted by `screenshotRegion` and the input layer,
+/// so bounds can be passed straight through. To map onto captured pixels,
+/// multiply by the screenshot's `scale` (`physical = logical × scale`).
 #[napi(object)]
 #[derive(Clone)]
 pub struct Rect {

--- a/xa11y-python/python/xa11y/_native.pyi
+++ b/xa11y-python/python/xa11y/_native.pyi
@@ -99,7 +99,12 @@ class PlatformError(XA11yError):
 # ── Data Classes ─────────────────────────────────────────────────────────────
 
 class Rect:
-    """A bounding rectangle in screen coordinates (pixels)."""
+    """A bounding rectangle in logical screen coordinates (device-independent
+    points) on every platform, origin at the top-left of the primary display.
+
+    Same coordinate space as ``screenshot(region=...)`` and input targets, so
+    bounds pass straight through. To index into a captured image multiply by
+    the screenshot's ``scale`` (``physical = logical * scale``)."""
 
     @property
     def x(self) -> int: ...
@@ -548,8 +553,10 @@ class Locator:
 class InputSim:
     """Input-simulation façade for synthesised pointer and keyboard events.
 
-    Targets are either a ``(x, y)`` tuple in screen pixels, or an ``Element``
-    (uses its bounds centre). Key values are strings: printable characters
+    Targets are either a ``(x, y)`` tuple in logical screen coordinates (same
+    space as ``Element.bounds``), or an ``Element`` (uses its bounds centre);
+    each backend converts to physical device pixels at the OS boundary. Key
+    values are strings: printable characters
     are literal (``"a"``, ``"7"``, ``";"``); named keys use their Pascal name
     (``"Enter"``, ``"ArrowUp"``, ``"F5"``); modifiers are ``"Shift"``,
     ``"Ctrl"``, ``"Alt"``, ``"Meta"``.

--- a/xa11y-windows/src/dpi.rs
+++ b/xa11y-windows/src/dpi.rs
@@ -1,0 +1,113 @@
+//! Shared Windows DPI handling.
+//!
+//! # Why this exists
+//!
+//! UI Automation reports element bounds, `GetSystemMetrics(SM_*VIRTUALSCREEN)`
+//! reports the virtual desktop, and GDI `BitBlt` reads pixels — all in a
+//! coordinate space that depends on the **process DPI awareness**. A
+//! DPI-unaware process sees system-virtualized (logical) coordinates; a
+//! Per-Monitor-V2 process sees true physical pixels. That awareness is a
+//! process-wide, set-once flag.
+//!
+//! Previously it was set lazily on the first screenshot, which meant any UIA
+//! bounds read *before* the first screenshot came back in a different
+//! coordinate space than the screenshot itself (issue #300). We now:
+//!
+//! 1. Set Per-Monitor-V2 awareness **eagerly and exactly once**
+//!    ([`ensure_process_dpi_aware`]), called from both `WindowsProvider::new`
+//!    and `WindowsScreenshot::new`, so it is established before the first
+//!    UIA bounds read regardless of which subsystem the consumer touches
+//!    first.
+//! 2. With awareness pinned to Per-Monitor-V2, UIA bounds and `BitBlt` are
+//!    both in **physical** pixels. The provider then converts bounds down to
+//!    **logical** coordinates (`xa11y_core::Rect::to_logical`) so that
+//!    `Element::bounds` matches the cross-platform contract (logical points,
+//!    same as macOS), and the screenshot/input backends convert back up to
+//!    physical at the OS boundary using [`scale_for_logical_point`].
+//!
+//! # Multi-monitor
+//!
+//! The per-monitor effective DPI is queried for the monitor containing the
+//! point of interest. For a uniform-DPI desktop this is exact everywhere. For
+//! a **mixed-DPI** multi-monitor desktop the conversion is only exact within a
+//! single monitor; a rectangle that straddles a DPI boundary is scaled by the
+//! DPI of the monitor under its origin, which can be off by the DPI ratio near
+//! the seam. Mixed-DPI straddling windows are rare and this is documented
+//! rather than silently "corrected".
+
+#![cfg(target_os = "windows")]
+
+use std::sync::Once;
+
+use windows::Win32::Foundation::POINT;
+use windows::Win32::Graphics::Gdi::{MonitorFromPoint, HMONITOR, MONITOR_DEFAULTTONEAREST};
+use windows::Win32::UI::HiDpi::{
+    GetDpiForMonitor, SetProcessDpiAwarenessContext, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+    MDT_EFFECTIVE_DPI,
+};
+
+/// The DPI value Windows treats as "100%": one logical unit == one physical
+/// pixel. `scale = effective_dpi / USER_DEFAULT_SCREEN_DPI`.
+const USER_DEFAULT_SCREEN_DPI: f64 = 96.0;
+
+static DPI_AWARENESS: Once = Once::new();
+
+/// Set the process to Per-Monitor-V2 DPI awareness, at most once per process.
+///
+/// Idempotent and safe to call from any entry point. The first call sets the
+/// awareness; later calls are cheap no-ops (the `Once` short-circuits, and the
+/// underlying `SetProcessDpiAwarenessContext` would return `ERROR_ACCESS_DENIED`
+/// anyway once awareness is pinned). If a host application already selected an
+/// equal or higher awareness, this is a no-op and we keep theirs — we never
+/// downgrade.
+pub fn ensure_process_dpi_aware() {
+    DPI_AWARENESS.call_once(|| {
+        // Best-effort: the result is intentionally ignored. Success sets
+        // Per-Monitor-V2; failure means awareness was already pinned (by an
+        // earlier call or a manifest) to something at least as high, which is
+        // exactly what we want. There is no coordinate correctness we could
+        // recover by propagating this error — the only requirement is that
+        // awareness is >= Per-Monitor-V2 before the first bounds read.
+        unsafe {
+            let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+        }
+    });
+}
+
+/// Effective DPI scale (physical/logical) of the monitor containing the given
+/// **physical** pixel. Used to convert UIA's physical bounds to logical.
+///
+/// Returns `1.0` if the monitor or its DPI can't be resolved — a best-effort
+/// degradation to identity, matching the "no known scale" convention the
+/// other backends use, rather than failing a tree read over a DPI query.
+pub fn scale_for_physical_point(x: i32, y: i32) -> f64 {
+    scale_for_point(x, y)
+}
+
+/// Effective DPI scale (physical/logical) of the monitor containing the given
+/// **logical** point. Used to convert logical bounds/points up to physical for
+/// `BitBlt` and `SendInput`.
+///
+/// On a uniform-DPI desktop the logical and physical coordinates identify the
+/// same monitor, so this is exact. See the module docs for the mixed-DPI
+/// caveat.
+pub fn scale_for_logical_point(x: i32, y: i32) -> f64 {
+    scale_for_point(x, y)
+}
+
+fn scale_for_point(x: i32, y: i32) -> f64 {
+    // SAFETY: MonitorFromPoint takes a POINT by value and a flag; it always
+    // returns a monitor handle (DEFAULTTONEAREST never returns null for a
+    // real desktop). GetDpiForMonitor writes two u32s we own.
+    let monitor: HMONITOR = unsafe { MonitorFromPoint(POINT { x, y }, MONITOR_DEFAULTTONEAREST) };
+    if monitor.is_invalid() {
+        return 1.0;
+    }
+    let mut dpi_x: u32 = 0;
+    let mut dpi_y: u32 = 0;
+    let hr = unsafe { GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) };
+    if hr.is_err() || dpi_x == 0 {
+        return 1.0;
+    }
+    f64::from(dpi_x) / USER_DEFAULT_SCREEN_DPI
+}

--- a/xa11y-windows/src/input.rs
+++ b/xa11y-windows/src/input.rs
@@ -46,6 +46,11 @@ pub struct WindowsInputProvider {
 
 impl WindowsInputProvider {
     pub fn new() -> Result<Self> {
+        // Match the provider/screenshot backends' DPI awareness so the
+        // logical->physical conversion in `pointer_move` and the virtual-screen
+        // metrics in `to_absolute` agree, even if input is the first subsystem
+        // constructed. Shared once-only init — see `crate::dpi`.
+        crate::dpi::ensure_process_dpi_aware();
         Ok(Self::default())
     }
 
@@ -271,7 +276,14 @@ fn button_down_up(button: MouseButton) -> (u32, u32) {
 
 impl InputProvider for WindowsInputProvider {
     fn pointer_move(&self, to: Point) -> Result<()> {
-        let (ax, ay) = to_absolute(to.x, to.y);
+        // `to` is in logical coordinates (the cross-platform contract, same
+        // space as `Element::bounds`). SendInput's absolute normalization runs
+        // against the physical virtual-desktop metrics (we are Per-Monitor-V2
+        // aware), so convert logical -> physical first using the DPI of the
+        // monitor under the point.
+        let scale = crate::dpi::scale_for_logical_point(to.x, to.y);
+        let phys = to.to_physical(scale);
+        let (ax, ay) = to_absolute(phys.x, phys.y);
         let input = mouse_input(
             MOUSEEVENTF_MOVE.0 | MOUSEEVENTF_ABSOLUTE.0 | MOUSEEVENTF_VIRTUALDESK.0,
             ax,

--- a/xa11y-windows/src/lib.rs
+++ b/xa11y-windows/src/lib.rs
@@ -6,6 +6,8 @@
 mod splice;
 
 #[cfg(target_os = "windows")]
+mod dpi;
+#[cfg(target_os = "windows")]
 mod input;
 #[cfg(target_os = "windows")]
 mod uia;

--- a/xa11y-windows/src/screenshot.rs
+++ b/xa11y-windows/src/screenshot.rs
@@ -9,17 +9,20 @@
 //!
 //! # DPI
 //!
-//! The process is switched to Per-Monitor-V2 DPI awareness on first
-//! [`WindowsScreenshot::new`] so the captured coordinates match the physical
-//! pixels UIA reports for element bounds. If a higher awareness has already
+//! Per-Monitor-V2 DPI awareness is set once, eagerly, via
+//! [`crate::dpi::ensure_process_dpi_aware`] — the same shared init the UIA
+//! provider calls — so it is established before the first UIA bounds read
+//! regardless of call order (issue #300). If a higher awareness has already
 //! been set (for example by a host application), the call is a no-op and we
 //! keep the existing awareness — we never downgrade.
 //!
-//! `Screenshot::scale` is reported as 1.0 because with Per-Monitor-V2
-//! awareness the bounds we take in are already physical pixels, so no
-//! further upscaling is needed. Multi-monitor setups with mixed DPI still
-//! work: the virtual desktop spans all monitors, and `BitBlt` composites
-//! through DWM at each monitor's native DPI.
+//! Regions are captured in **physical** pixels. `capture_region` receives a
+//! rectangle in **logical** coordinates (the cross-platform contract, matching
+//! `Element::bounds`) and converts it to physical using the DPI of the monitor
+//! under its origin; the resulting [`Screenshot::scale`] carries the
+//! physical-to-logical ratio so callers can map logical bounds onto captured
+//! pixels. Multi-monitor setups with mixed DPI are handled per-monitor; see
+//! [`crate::dpi`] for the boundary-straddling caveat.
 //!
 //! # Active session required
 //!
@@ -62,10 +65,6 @@ use windows::Win32::Graphics::Gdi::{
     HGDIOBJ, SRCCOPY,
 };
 #[cfg(target_os = "windows")]
-use windows::Win32::UI::HiDpi::{
-    SetProcessDpiAwarenessContext, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
-};
-#[cfg(target_os = "windows")]
 use windows::Win32::UI::WindowsAndMessaging::{
     GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
 };
@@ -73,13 +72,11 @@ use windows::Win32::UI::WindowsAndMessaging::{
 #[cfg(target_os = "windows")]
 impl WindowsScreenshot {
     pub fn new() -> Result<Self> {
-        // Best-effort: succeeds on first call, returns ERROR_ACCESS_DENIED on
-        // subsequent calls (or if the awareness is pinned by manifest). Either
-        // outcome is fine — we only care that awareness is at least
-        // Per-Monitor-V2 before we read pixels.
-        unsafe {
-            let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        }
+        // Ensure Per-Monitor-V2 awareness is set before we read pixels. This
+        // is the same shared, once-only init the UIA provider calls, so
+        // awareness is established regardless of whether the consumer touches
+        // the a11y tree or a screenshot first (issue #300).
+        crate::dpi::ensure_process_dpi_aware();
         Ok(Self)
     }
 }
@@ -87,6 +84,8 @@ impl WindowsScreenshot {
 #[cfg(target_os = "windows")]
 impl ScreenshotProvider for WindowsScreenshot {
     fn capture_full(&self) -> Result<Screenshot> {
+        // With Per-Monitor-V2 awareness the virtual-screen metrics are already
+        // physical pixels, so no logical->physical conversion is needed here.
         let vx = unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) };
         let vy = unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) };
         let vw = unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) };
@@ -97,34 +96,45 @@ impl ScreenshotProvider for WindowsScreenshot {
                 message: format!("virtual screen has non-positive size: {vw}x{vh}"),
             });
         }
-        capture_rect(vx, vy, vw, vh)
+        // Report the scale of the monitor at the virtual-desktop origin. The
+        // full capture may span mixed-DPI monitors; `scale` is a single scalar
+        // by contract, so we report the origin monitor's factor.
+        let scale = crate::dpi::scale_for_physical_point(vx, vy) as f32;
+        capture_rect(vx, vy, vw, vh, scale)
     }
 
     fn capture_region(&self, rect: Rect) -> Result<Screenshot> {
-        if rect.width == 0 || rect.height == 0 {
+        // `rect` arrives in logical coordinates (the cross-platform contract,
+        // matching `Element::bounds`). Convert to the physical pixels BitBlt
+        // works in, using the DPI of the monitor under the rect's origin.
+        let scale = crate::dpi::scale_for_logical_point(rect.x, rect.y);
+        let phys = rect.to_physical(scale);
+        if phys.width == 0 || phys.height == 0 {
             return Err(Error::Platform {
                 code: -1,
                 message: "zero-sized capture rect".into(),
             });
         }
-        let w = i32::try_from(rect.width).map_err(|_| Error::Platform {
+        let w = i32::try_from(phys.width).map_err(|_| Error::Platform {
             code: -1,
             message: "rect width out of i32 range".into(),
         })?;
-        let h = i32::try_from(rect.height).map_err(|_| Error::Platform {
+        let h = i32::try_from(phys.height).map_err(|_| Error::Platform {
             code: -1,
             message: "rect height out of i32 range".into(),
         })?;
-        capture_rect(rect.x, rect.y, w, h)
+        capture_rect(phys.x, phys.y, w, h, scale as f32)
     }
 }
 
 /// BitBlt a rectangle of the virtual desktop into an RGBA8 `Screenshot`.
 ///
-/// `x`/`y` are virtual-screen coordinates (may be negative on multi-monitor
-/// setups); `w`/`h` are positive pixel dimensions.
+/// `x`/`y` are **physical** virtual-screen coordinates (may be negative on
+/// multi-monitor setups); `w`/`h` are positive physical pixel dimensions.
+/// `scale` is the physical-to-logical ratio recorded on the returned
+/// `Screenshot` so callers can map logical bounds to captured pixels.
 #[cfg(target_os = "windows")]
-fn capture_rect(x: i32, y: i32, w: i32, h: i32) -> Result<Screenshot> {
+fn capture_rect(x: i32, y: i32, w: i32, h: i32, scale: f32) -> Result<Screenshot> {
     let width = w as u32;
     let height = h as u32;
 
@@ -224,7 +234,7 @@ fn capture_rect(x: i32, y: i32, w: i32, h: i32) -> Result<Screenshot> {
         width,
         height,
         pixels,
-        scale: 1.0,
+        scale,
     })
 }
 

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -62,6 +62,11 @@ unsafe impl Sync for WindowsProvider {}
 
 impl WindowsProvider {
     pub fn new() -> Result<Self> {
+        // Establish Per-Monitor-V2 DPI awareness before the first bounds read
+        // so UIA reports coordinates in a stable (physical) space that we can
+        // convert to logical. Shared once-only init with the screenshot
+        // backend — see `crate::dpi` and issue #300.
+        crate::dpi::ensure_process_dpi_aware();
         ensure_com_initialized().map_err(|e| Error::Platform {
             code: e.code().0 as i64,
             message: format!("COM initialization failed: {}", e),
@@ -390,12 +395,21 @@ fn build_snapshot_data(
             if width == 0 && height == 0 {
                 None
             } else {
-                Some(Rect {
-                    x: r.left,
-                    y: r.top,
-                    width,
-                    height,
-                })
+                // Under Per-Monitor-V2 awareness UIA reports physical pixels.
+                // Convert to logical coordinates so `Element::bounds` matches
+                // the cross-platform contract (logical points, same space as
+                // the screenshot/input layers). Scale is the DPI of the
+                // monitor the element sits on.
+                let scale = crate::dpi::scale_for_physical_point(r.left, r.top);
+                Some(
+                    Rect {
+                        x: r.left,
+                        y: r.top,
+                        width,
+                        height,
+                    }
+                    .to_logical(scale),
+                )
             }
         });
 

--- a/xa11y/tests/integ/screenshot.rs
+++ b/xa11y/tests/integ/screenshot.rs
@@ -82,4 +82,66 @@ mod tests {
         let bytes = shot.to_png().expect("PNG encode");
         assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
     }
+
+    /// Contract guard for issue #300: `Element::bounds` are **logical**
+    /// coordinates and `Screenshot::scale` is the honest physical-to-logical
+    /// ratio, so a region captured from those logical bounds must contain
+    /// `bounds × scale` physical pixels.
+    ///
+    /// Under the old Windows model (physical bounds, `scale` hard-coded to
+    /// 1.0) this invariant only held by accident at 100% DPI; on a scaled
+    /// display the reported scale disagreed with the bounds. This test encodes
+    /// the relationship directly. On 100%-DPI CI runners `scale == 1.0`, but
+    /// the equation is still exercised end-to-end through every backend.
+    #[test]
+    #[ignore]
+    fn region_from_logical_bounds_matches_scale() {
+        let app = h::app_root();
+        let button = h::named(&app, "Submit");
+
+        let Some(bounds) = button.bounds else {
+            eprintln!("skipping: element has no bounds (likely headless)");
+            return;
+        };
+        if bounds.width == 0 || bounds.height == 0 {
+            eprintln!("skipping: element bounds are zero-sized");
+            return;
+        }
+
+        // Capture the exact logical rect (not via screenshot_element) to prove
+        // that a caller passing logical bounds straight to screenshot_region
+        // gets pixels back at the reported scale.
+        let shot = match xa11y::screenshot_region(bounds) {
+            Ok(s) => s,
+            Err(xa11y::Error::Unsupported { feature }) => {
+                eprintln!("skipping: {feature}");
+                return;
+            }
+            Err(e) => panic!("region capture: {e}"),
+        };
+
+        assert!(
+            shot.scale.is_finite() && shot.scale > 0.0,
+            "scale must be a positive, finite ratio, got {}",
+            shot.scale
+        );
+        let expected_w = (bounds.width as f32 * shot.scale).round() as i64;
+        let expected_h = (bounds.height as f32 * shot.scale).round() as i64;
+        assert!(
+            (shot.width as i64 - expected_w).abs() <= 1,
+            "region width {} != logical {} × scale {} (= {})",
+            shot.width,
+            bounds.width,
+            shot.scale,
+            expected_w
+        );
+        assert!(
+            (shot.height as i64 - expected_h).abs() <= 1,
+            "region height {} != logical {} × scale {} (= {})",
+            shot.height,
+            bounds.height,
+            shot.scale,
+            expected_h
+        );
+    }
 }


### PR DESCRIPTION
Windows previously forced the process to Per-Monitor-V2 DPI awareness
lazily, on the first screenshot, and reported everything in physical
pixels with Screenshot.scale hard-coded to 1.0. Two problems:

1. Race (#300): if any UIA bounds were read before the first screenshot,
   they came back in a different coordinate space (logical/virtualized)
   than the screenshot taken afterward (physical), so the two disagreed
   on scale on HiDPI displays.
2. Contract violation: the core ScreenshotProvider docs say bounds are
   *logical* and Screenshot.scale bridges to physical (as macOS does),
   but Windows exposed physical bounds + scale=1.0.

Make Windows honor the documented, macOS-parity contract:

- Set Per-Monitor-V2 awareness eagerly and exactly once via a shared
  crate::dpi::ensure_process_dpi_aware(), called from WindowsProvider,
  WindowsScreenshot, and WindowsInputProvider construction — so it is
  established before the first bounds read regardless of call order.
- Convert UIA's physical bounds to logical in the provider using the
  element's monitor DPI, so Element::bounds are logical points.
- capture_region now takes logical coordinates, converts to physical
  for BitBlt, and reports the honest physical-to-logical scale.
- Input converts logical points to physical before SendInput.

Coordinate math lives in xa11y-core as pure, unit-tested helpers
(Rect::to_physical/to_logical, Point::to_physical/to_logical) that
degrade to identity on a bad scale. Element::bounds and input Point are
now documented as logical on all platforms; macOS already behaved this
way (AXPosition/AXSize are points) and needs no code change.

Docs in the Python (.pyi) and JS bindings updated to match. Adds an
integration guard asserting a region captured from logical bounds
contains bounds*scale physical pixels.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CgWcR4fVPHRvzvyDtT4MpJ