### PR TITLE
docs: logical bounds + honest HiDPI scale on Windows and Linux

### DIFF
--- a/docs/site/src/content/docs/guides/accessibility-quirks.mdx
+++ b/docs/site/src/content/docs/guides/accessibility-quirks.mdx
@@ -510,7 +510,7 @@ In containers, Docker's `/dev` tmpfs isolation hides host-created
   `Screenshot.scale` bridging to physical pixels. On Linux the scale is exact
   where reliably detectable and falls back to `1.0` (coordinates then physical)
   otherwise — see [platform details](/guides/platform-details/#coordinates-and-hidpi).
-  Multi-monitor setups produce **negative coordinates** for displays positioned
+  Multi-monitor setups produce negative coordinates for displays positioned
   left of or above the primary.
 
 ## Further reading

--- a/docs/site/src/content/docs/guides/accessibility-quirks.mdx
+++ b/docs/site/src/content/docs/guides/accessibility-quirks.mdx
@@ -506,8 +506,12 @@ In containers, Docker's `/dev` tmpfs isolation hides host-created
 - **macOS reports points, not pixels.** On a Retina display 1 point = 2 physical
   pixels — hit-testing against a screenshot taken in pixels will be off by the
   scale factor.
-- **Windows / Linux report physical pixels**, and multi-monitor setups produce
-  **negative coordinates** for displays positioned left of or above the primary.
+- **Windows and Linux report logical (device-independent) coordinates**, with
+  `Screenshot.scale` bridging to physical pixels. On Linux the scale is exact
+  where reliably detectable and falls back to `1.0` (coordinates then physical)
+  otherwise — see [platform details](/guides/platform-details/#coordinates-and-hidpi).
+  Multi-monitor setups produce **negative coordinates** for displays positioned
+  left of or above the primary.
 
 ## Further reading
 

--- a/docs/site/src/content/docs/guides/input.mdx
+++ b/docs/site/src/content/docs/guides/input.mdx
@@ -114,7 +114,7 @@ xa11y picks the Linux backend at runtime: if `DISPLAY` is set we drive XTest; ot
 
 Every pointer method accepts either a screen-space point or an `Element`:
 
-- **Point** — absolute screen coordinates in the platform's native coordinate space (points on macOS, physical pixels on Windows and Linux). Origin is the top-left of the primary display; negative values are valid on multi-monitor setups.
+- **Point** — absolute screen coordinates in **logical** (device-independent) units: points on macOS, DIPs on Windows, and logical pixels on Linux (physical where the HiDPI scale can't be read reliably — see [platform details](/guides/platform-details/#coordinates-and-hidpi)). Origin is the top-left of the primary display; negative values are valid on multi-monitor setups.
 - **Element** — uses the centre of the element's `bounds` at the time of the call. `InputSim` does not re-read the accessibility tree for you — re-fetch via a locator first if the UI may have moved.
 
 In Rust, additional anchors are available via `ClickOptions.anchor` (`Anchor::TopLeft`, `Anchor::Offset { dx, dy }`, etc.).

--- a/docs/site/src/content/docs/guides/input.mdx
+++ b/docs/site/src/content/docs/guides/input.mdx
@@ -114,7 +114,7 @@ xa11y picks the Linux backend at runtime: if `DISPLAY` is set we drive XTest; ot
 
 Every pointer method accepts either a screen-space point or an `Element`:
 
-- **Point** — absolute screen coordinates in **logical** (device-independent) units: points on macOS, DIPs on Windows, and logical pixels on Linux (physical where the HiDPI scale can't be read reliably — see [platform details](/guides/platform-details/#coordinates-and-hidpi)). Origin is the top-left of the primary display; negative values are valid on multi-monitor setups.
+- **Point** — absolute screen coordinates in logical (device-independent) units: points on macOS, DIPs on Windows, and logical pixels on Linux (physical where the HiDPI scale can't be read reliably — see [platform details](/guides/platform-details/#coordinates-and-hidpi)). Origin is the top-left of the primary display; negative values are valid on multi-monitor setups.
 - **Element** — uses the centre of the element's `bounds` at the time of the call. `InputSim` does not re-read the accessibility tree for you — re-fetch via a locator first if the UI may have moved.
 
 In Rust, additional anchors are available via `ClickOptions.anchor` (`Anchor::TopLeft`, `Anchor::Offset { dx, dy }`, etc.).

--- a/docs/site/src/content/docs/guides/platform-details.mdx
+++ b/docs/site/src/content/docs/guides/platform-details.mdx
@@ -96,10 +96,12 @@ Inserts text via the accessibility API — never simulates keyboard events.
 
 ### Coordinates
 
-All platforms report bounds as screen coordinates with origin at the top-left of the primary display. Note:
+All platforms report bounds as **logical** (device-independent) screen coordinates with origin at the top-left of the primary display, and `Screenshot.scale` carries the physical-to-logical ratio for mapping bounds onto captured pixels. Note:
 
-- **macOS** reports in **points**, not pixels. On Retina displays, 1 point = 2 physical pixels.
-- **Windows / Linux** report in physical pixels. Multi-monitor setups can produce negative coordinates for displays to the left or above the primary.
+- **macOS** reports in **points** — its native logical unit. On Retina displays, 1 point = 2 physical pixels.
+- **Windows** reports device-independent pixels (DIPs); `scale` is the display's DPI scaling (e.g. `1.5` at 150%).
+- **Linux** reports logical pixels where the HiDPI scale is reliably detectable, and falls back to physical at scale `1.0` otherwise — see [Coordinates and HiDPI](/guides/platform-details/#coordinates-and-hidpi) for exactly when.
+- Multi-monitor setups can produce **negative coordinates** for displays positioned left of or above the primary.
 
 ### Name resolution
 
@@ -145,7 +147,18 @@ The Screenshot portal usually auto-approves for non-interactive callers (`intera
 
 #### Coordinates and HiDPI
 
-X11 and Wayland coordinates are accepted in physical pixels at scale 1.0 today. HiDPI scale is not surfaced through the existing `Screenshot.scale` field on Linux — it stays 1.0. `Point` arguments to input simulation are taken at face value, then mapped onto the uinput virtual coordinate range. Override the assumed screen size (default 1920×1080) with `XA11Y_SCREEN_WIDTH` / `XA11Y_SCREEN_HEIGHT` env vars if your setup differs.
+`Element.bounds` and input `Point`s are **logical** (device-independent) coordinates, matching the cross-platform contract, and `Screenshot.scale` reports the physical-to-logical ratio. The scale is detected best-effort and is **exact** where it can be read reliably:
+
+- **Pure X11, integer scaling** — read from `Xft.dpi` in the X `RESOURCE_MANAGER` (the same signal GTK/Qt use). AT-SPI extents and `XTest` are physical, so bounds are divided and input points multiplied by it.
+- **Single-output Wayland, integer *or* fractional** — the exact ratio `physical_mode / logical_size` from `xdg-output` (e.g. `1920 / 1280 = 1.5`), not the rounded `wl_output.scale`.
+
+Every other configuration **fails closed to `1.0`** — never wrong data. There, bounds stay physical and the scale is not upscaled, but capture and input round-trips remain correct because bounds and pixels stay in the same space:
+
+- **Fractional X11** — GTK's X11 window scale is integer-only, so a fractional `Xft.dpi` scales fonts, not the coordinate space.
+- **Multi-monitor mixed-DPI Wayland** — a single scalar can't represent per-monitor scales, so it falls back to the largest integer `wl_output.scale` (the Windows backend has the same limitation).
+- **XWayland** (both `DISPLAY` and `WAYLAND_DISPLAY` set) — capture runs through the X11 backend, so the reported scale follows the X11 source and stays `1.0`, consistent with that backend.
+
+`Point` arguments to input simulation, after the logical→physical conversion, are mapped onto the uinput virtual coordinate range. Override the assumed screen size (default 1920×1080) with `XA11Y_SCREEN_WIDTH` / `XA11Y_SCREEN_HEIGHT` env vars if your setup differs.
 
 ### GTK press fallback (Linux)
 

--- a/docs/site/src/content/docs/guides/platform-details.mdx
+++ b/docs/site/src/content/docs/guides/platform-details.mdx
@@ -96,12 +96,12 @@ Inserts text via the accessibility API — never simulates keyboard events.
 
 ### Coordinates
 
-All platforms report bounds as **logical** (device-independent) screen coordinates with origin at the top-left of the primary display, and `Screenshot.scale` carries the physical-to-logical ratio for mapping bounds onto captured pixels. Note:
+All platforms report bounds as logical (device-independent) screen coordinates with origin at the top-left of the primary display, and `Screenshot.scale` carries the physical-to-logical ratio for mapping bounds onto captured pixels. Note:
 
-- **macOS** reports in **points** — its native logical unit. On Retina displays, 1 point = 2 physical pixels.
+- **macOS** reports in points — its native logical unit. On Retina displays, 1 point = 2 physical pixels.
 - **Windows** reports device-independent pixels (DIPs); `scale` is the display's DPI scaling (e.g. `1.5` at 150%).
 - **Linux** reports logical pixels where the HiDPI scale is reliably detectable, and falls back to physical at scale `1.0` otherwise — see [Coordinates and HiDPI](/guides/platform-details/#coordinates-and-hidpi) for exactly when.
-- Multi-monitor setups can produce **negative coordinates** for displays positioned left of or above the primary.
+- Multi-monitor setups can produce negative coordinates for displays positioned left of or above the primary.
 
 ### Name resolution
 
@@ -147,12 +147,12 @@ The Screenshot portal usually auto-approves for non-interactive callers (`intera
 
 #### Coordinates and HiDPI
 
-`Element.bounds` and input `Point`s are **logical** (device-independent) coordinates, matching the cross-platform contract, and `Screenshot.scale` reports the physical-to-logical ratio. The scale is detected best-effort and is **exact** where it can be read reliably:
+`Element.bounds` and input `Point`s are logical (device-independent) coordinates, matching the cross-platform contract, and `Screenshot.scale` reports the physical-to-logical ratio. The scale is detected best-effort and is exact where it can be read reliably:
 
 - **Pure X11, integer scaling** — read from `Xft.dpi` in the X `RESOURCE_MANAGER` (the same signal GTK/Qt use). AT-SPI extents and `XTest` are physical, so bounds are divided and input points multiplied by it.
-- **Single-output Wayland, integer *or* fractional** — the exact ratio `physical_mode / logical_size` from `xdg-output` (e.g. `1920 / 1280 = 1.5`), not the rounded `wl_output.scale`.
+- **Single-output Wayland, integer or fractional** — the exact ratio `physical_mode / logical_size` from `xdg-output` (e.g. `1920 / 1280 = 1.5`), not the rounded `wl_output.scale`.
 
-Every other configuration **fails closed to `1.0`** — never wrong data. There, bounds stay physical and the scale is not upscaled, but capture and input round-trips remain correct because bounds and pixels stay in the same space:
+Every other configuration fails closed to `1.0` — never wrong data. There, bounds stay physical and the scale is not upscaled, but capture and input round-trips remain correct because bounds and pixels stay in the same space:
 
 - **Fractional X11** — GTK's X11 window scale is integer-only, so a fractional `Xft.dpi` scales fonts, not the coordinate space.
 - **Multi-monitor mixed-DPI Wayland** — a single scalar can't represent per-monitor scales, so it falls back to the largest integer `wl_output.scale` (the Windows backend has the same limitation).


### PR DESCRIPTION
Documentation follow-up to #301 (Windows) and #302 (Linux). Those PRs changed `Element::bounds`, input `Point`s, and `Screenshot::scale` from "physical pixels at scale 1.0" to **logical** (device-independent) coordinates with an honest physical-to-logical scale — but both landed without touching the guides, so several pages still described the old behavior.

## Changes

- **`platform-details.mdx` → Coordinates** — bounds are logical on all platforms; spell out Windows DIPs and Linux "logical where reliably detectable", and note `Screenshot.scale` bridges to physical.
- **`platform-details.mdx` → Coordinates and HiDPI (Linux)** — rewritten to describe the behavior #302 actually ships: exact scale via `Xft.dpi` (pure-X11 integer) and `xdg-output` (single-output Wayland, including fractional), and **fail-closed to `1.0`** on fractional X11, multi-monitor mixed-DPI Wayland, and XWayland. The old text ("accepted in physical pixels at scale 1.0 today … scale stays 1.0") described the pre-#302 code exactly.
- **`accessibility-quirks.mdx` → Coordinate systems** and **`input.mdx` → Targets** — Windows/Linux report logical, not physical, coordinates; both now link to the HiDPI details.

`screenshots.mdx` needed no change — it already described logical region coordinates and the `1.5 / 1.75 / 2.0` Windows/Linux HiDPI scales, so it is now accurate rather than stale.

## Testing

- `docs/check_tables.py` passes.
- `docs/check_links.py` reports only one broken link — `/api/python/` in `guides/quick-start.mdx`, which is pre-existing on `main` and untouched here. The three edited files introduce no broken links, and the new anchor links (`/guides/platform-details/#coordinates-and-hidpi`) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UU6WVaHkUEEpZ7dvqvuhf7)_