### PR TITLE
Close table gaps across providers: AccessKit cells on Windows, macOS cell selection, cross-framework coverage

### DIFF
--- a/docs/site/src/content/docs/guides/platform-details.mdx
+++ b/docs/site/src/content/docs/guides/platform-details.mdx
@@ -26,8 +26,8 @@ xa11y normalizes platform-specific APIs into a unified interface. This page docu
 | `Tab` | *(subrole AXTabButton)* | page tab | TabItemControlType |
 | `TabGroup` | AXTabGroup | page tab list | TabControlType |
 | `Table` | AXTable | table, tree table | TableControlType, DataGridControlType |
-| `TableRow` | *(via AXRow)* | table row | DataItemControlType |
-| `TableCell` | AXCell | table cell, column/row header | HeaderItemControlType |
+| `TableRow` | *(via AXRow)* | table row | DataItemControlType *(no cell signal)* |
+| `TableCell` | AXCell | table cell, column/row header | HeaderItemControlType, DataItemControlType *(with TableItem pattern, or parent DataItem)* |
 | `Toolbar` | AXToolbar | tool bar | ToolBarControlType |
 | `ScrollBar` | AXScrollBar | scroll bar | ScrollBarControlType |
 | `Slider` | AXSlider | slider | SliderControlType |
@@ -118,6 +118,18 @@ The tri-state checked value (`Off` / `On` / `Mixed`) is derived differently:
 - **macOS:** Parses the `AXValue` attribute — `"0"` = Off, `"1"` = On, `"2"` = Mixed.
 - **Linux:** Uses AT-SPI state bits — `Checked` (0x10) and `Mixed` (0x2000).
 - **Windows:** Reads `TogglePattern.CurrentToggleState` — 0 = Off, 1 = On, 2 = Indeterminate.
+
+### Selected state
+
+Per-item selection (`selected` on rows, cells, list items) is read differently:
+
+- **macOS:** The per-element `AXSelected` attribute when present. Some bridges — notably Qt's — implement no per-element `AXSelected` and expose selection only through the container's `AXSelectedChildren`; for `table_cell` / `table_row` / `list_item` elements whose `AXSelected` attribute is absent, xa11y resolves `selected` by membership in the nearest ancestor's `AXSelectedChildren` (at most two hops: cell → row → table). Derived values appear in `states.selected` only — `raw` never gains a synthetic `AXSelected` key.
+- **Linux:** The AT-SPI `Selected` state bit.
+- **Windows:** `SelectionItemPattern.CurrentIsSelected`.
+
+### Table headers
+
+Header exposure varies by toolkit as well as platform. Windows surfaces header cells as `HeaderItem` elements and per-cell header relationships via the `TableItem` pattern; AT-SPI exposes `column header` / `row header` roles; AppKit tables expose a header group whose sort buttons carry the column titles. One known toolkit gap: **Qt tables on macOS expose no header objects at all** — Qt's Cocoa bridge synthesizes `AXRow`/`AXColumn` children only and implements no `AXHeader` attribute, so column titles are absent from the AX tree and xa11y cannot surface them. This is an upstream Qt limitation; use the platform-consistent `table table_cell` selectors for data, and avoid depending on header names for Qt apps on macOS.
 
 ### Linux: X11 vs Wayland
 

--- a/test-apps/cocoa/main.swift
+++ b/test-apps/cocoa/main.swift
@@ -49,11 +49,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         scroll.hasVerticalScroller = true
         scroll.autoresizingMask = [.width, .height]
 
-        let docView = NSView(frame: NSRect(x: 0, y: 0, width: 680, height: 1320))
+        let docView = NSView(frame: NSRect(x: 0, y: 0, width: 680, height: 1480))
         scroll.documentView = docView
         window.contentView = scroll
 
-        var y: CGFloat = 1160
+        var y: CGFloat = 1320
         func addSection(_ title: String) -> NSView {
             let box = NSBox(frame: NSRect(x: 12, y: y - 180, width: 656, height: 180))
             box.title = title
@@ -234,6 +234,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         tableScroll.documentView = listTable
         listBox.addSubview(tableScroll)
 
+        // ── Table (multi-column NSTableView → AXTable/AXRow/AXCell) ──────
+        // Distinct from the single-column "Items" list above: two columns
+        // with headers, so macOS exposes real AXCell children under each
+        // AXRow — the cross-platform table/table_row/table_cell shape.
+        let usersBox = NSBox(frame: NSRect(x: 12, y: y - 150, width: 656, height: 150))
+        usersBox.title = "Table"
+        docView.addSubview(usersBox)
+        y -= 160
+
+        let usersScroll = NSScrollView(frame: NSRect(x: 16, y: 10, width: 400, height: 120))
+        usersTable = NSTableView(frame: usersScroll.bounds)
+        usersTable.setAccessibilityLabel("Users Table")
+        let nameCol = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("name"))
+        nameCol.title = "Name"
+        usersTable.addTableColumn(nameCol)
+        let roleCol = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("role"))
+        roleCol.title = "Role"
+        usersTable.addTableColumn(roleCol)
+        usersTable.dataSource = self
+        usersScroll.documentView = usersTable
+        usersBox.addSubview(usersScroll)
+
         // ── Grid (NSGridView → AXGrid → table role) ──────────────────────
         let gridBox = NSBox(frame: NSRect(x: 12, y: y - 120, width: 656, height: 120))
         gridBox.title = "Grid"
@@ -335,17 +357,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var radioA: NSButton!
     var slider: NSSlider!
     var listTable: NSTableView!
+    var usersTable: NSTableView!
     var statusLabel: NSTextField!
     var rowCount: Int = 5
+    let users = [["Alice", "Admin"], ["Bob", "User"]]
 }
 
 // ── NSTableViewDataSource ─────────────────────────────────────────────────────
 
 extension AppDelegate: NSTableViewDataSource {
-    func numberOfRows(in _: NSTableView) -> Int { rowCount }
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        tableView === usersTable ? users.count : rowCount
+    }
 
     func tableView(_ tableView: NSTableView, objectValueFor column: NSTableColumn?, row: Int) -> Any? {
-        "Item \(row + 1)"
+        if tableView === usersTable {
+            let colIndex = column?.identifier.rawValue == "role" ? 1 : 0
+            return users[row][colIndex]
+        }
+        return "Item \(row + 1)"
     }
 }
 

--- a/test-apps/cocoa/main.swift
+++ b/test-apps/cocoa/main.swift
@@ -236,8 +236,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // ── Table (multi-column NSTableView → AXTable/AXRow/AXCell) ──────
         // Distinct from the single-column "Items" list above: two columns
-        // with headers, so macOS exposes real AXCell children under each
-        // AXRow — the cross-platform table/table_row/table_cell shape.
+        // with headers, and view-based (delegate returns NSTableCellView) —
+        // only view-based tables expose an AXCell layer under each AXRow;
+        // legacy cell-based (NSCell) tables put text straight under the row,
+        // which breaks the cross-platform table/table_row/table_cell shape.
         let usersBox = NSBox(frame: NSRect(x: 12, y: y - 150, width: 656, height: 150))
         usersBox.title = "Table"
         docView.addSubview(usersBox)
@@ -253,6 +255,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         roleCol.title = "Role"
         usersTable.addTableColumn(roleCol)
         usersTable.dataSource = self
+        usersTable.delegate = self
         usersScroll.documentView = usersTable
         usersBox.addSubview(usersScroll)
 
@@ -372,10 +375,28 @@ extension AppDelegate: NSTableViewDataSource {
 
     func tableView(_ tableView: NSTableView, objectValueFor column: NSTableColumn?, row: Int) -> Any? {
         if tableView === usersTable {
+            // Unused (the users table is view-based via the delegate below),
+            // but harmless to answer correctly.
             let colIndex = column?.identifier.rawValue == "role" ? 1 : 0
             return users[row][colIndex]
         }
         return "Item \(row + 1)"
+    }
+}
+
+// ── NSTableViewDelegate (view-based users table) ──────────────────────────────
+
+extension AppDelegate: NSTableViewDelegate {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard tableView === usersTable, let column = tableColumn else { return nil }
+        let colIndex = column.identifier.rawValue == "role" ? 1 : 0
+        let text = NSTextField(labelWithString: users[row][colIndex])
+        let cell = NSTableCellView()
+        cell.addSubview(text)
+        cell.textField = text
+        text.frame = cell.bounds
+        text.autoresizingMask = [.width, .height]
+        return cell
     }
 }
 

--- a/test-apps/electron/index.html
+++ b/test-apps/electron/index.html
@@ -48,6 +48,20 @@ Line 2
 Line 3</textarea>
   </div>
 
+  <!-- Table (markup mirrors test-apps/tauri/frontend/index.html; Chromium
+       exposes <table> as "table" with "table cell" children on AT-SPI) -->
+  <div>
+    <table id="users-table" aria-label="Users Table">
+      <thead>
+        <tr><th>Name</th><th>Role</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Alice</td><td>Admin</td></tr>
+        <tr><td>Bob</td><td>User</td></tr>
+      </tbody>
+    </table>
+  </div>
+
   <script>
     // Keep aria-valuenow in sync so AT-SPI value reads track user changes.
     const slider = document.getElementById('volume-slider');

--- a/test-apps/gtk/app.py
+++ b/test-apps/gtk/app.py
@@ -16,7 +16,17 @@ import sys
 import gi
 
 gi.require_version("Gtk", "4.0")
-from gi.repository import GLib, Gtk  # noqa: E402
+from gi.repository import Gio, GLib, GObject, Gtk  # noqa: E402
+
+
+class UserItem(GObject.Object):
+    """Row model for the Users table (Gtk.ColumnView)."""
+
+    name = GObject.Property(type=str, default="")
+    role = GObject.Property(type=str, default="")
+
+    def __init__(self, name: str, role: str) -> None:
+        super().__init__(name=name, role=role)
 
 
 class TestWindow(Gtk.ApplicationWindow):
@@ -167,6 +177,22 @@ class TestWindow(Gtk.ApplicationWindow):
             self.list_box.append(row)
         list_group.append(self.list_box)
 
+        # ── Table ────────────────────────────────────────────────────
+        table_group = self._make_group("Table")
+        box.append(table_group)
+
+        # Only one table in the app — identified by role in tests.
+        # Gtk.ColumnView exposes AT-SPI role "tree table" (66) → xa11y
+        # table; its rows are "table row" and its cells "table cell",
+        # each cell named from its child Gtk.Label's text.
+        store = Gio.ListStore(item_type=UserItem)
+        store.append(UserItem("Alice", "Admin"))
+        store.append(UserItem("Bob", "User"))
+        self.users_table = Gtk.ColumnView(model=Gtk.NoSelection(model=store))
+        self.users_table.append_column(self._make_users_column("Name", "name"))
+        self.users_table.append_column(self._make_users_column("Role", "role"))
+        table_group.append(self.users_table)
+
         # ── Dynamic widgets (event tests) ────────────────────────────
         # These mutate on click so the event suite can observe:
         #   - NameChanged  (Submit → status label text change)
@@ -197,6 +223,19 @@ class TestWindow(Gtk.ApplicationWindow):
         self.open_dialog_button.connect("clicked", self._on_open_dialog_clicked)
         dlg_group.append(self.open_dialog_button)
         self._sample_dialog: Gtk.Window | None = None
+
+    def _make_users_column(self, title: str, attr: str) -> Gtk.ColumnViewColumn:
+        factory = Gtk.SignalListItemFactory()
+        factory.connect(
+            "setup", lambda _f, item: item.set_child(Gtk.Label(xalign=0))
+        )
+        factory.connect(
+            "bind",
+            lambda _f, item: item.get_child().set_label(
+                item.get_item().get_property(attr)
+            ),
+        )
+        return Gtk.ColumnViewColumn(title=title, factory=factory)
 
     def _make_group(self, name: str) -> Gtk.Box:
         inner = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)

--- a/test-apps/qt/app.py
+++ b/test-apps/qt/app.py
@@ -280,6 +280,12 @@ class TestWindow(QMainWindow):
         for row, values in enumerate((("Alice", "Admin"), ("Bob", "User"))):
             for column, value in enumerate(values):
                 self.users_table.setItem(row, column, QTableWidgetItem(value))
+        # Select a single cell so the suites can assert that per-cell
+        # selection state survives every platform bridge (UIA SelectionItem,
+        # AT-SPI selected state, AX container selection on macOS).
+        self.users_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectItems)
+        self.users_table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
+        self.users_table.setCurrentCell(0, 0)
         self.users_table.setMaximumHeight(120)
         lay.addWidget(self.users_table)
 

--- a/test-apps/tauri/frontend/index.html
+++ b/test-apps/tauri/frontend/index.html
@@ -160,13 +160,26 @@ Line 3</textarea>
 
   <!-- Table: WebKit exposes <table> as AT-SPI "table" (AXTable on macOS)
        with "table cell" (AXCell) children, matching the cross-platform
-       table/table_cell contract. -->
+       table/table_cell contract.
+
+       Deliberately NO <th> header cells: under WebKitGTK 2.52 with a
+       window manager present (the CI setup), a table containing <th>
+       sends the web process's accessibility tree into a continuous
+       invalidation churn — every content accessible goes defunct
+       moments after being exposed, which takes the whole page out of
+       the AT-SPI tree and fails every suite test. Verified by bisecting
+       this file against a live harness run; <td>-only tables are
+       stable. The Electron page keeps its <th> row (Chromium is
+       unaffected), so header coverage for webviews lives there.
+
+       The <caption> is load-bearing: without headers, WebKit's layout-
+       table heuristic judges the table decorative and drops it from the
+       accessibility tree entirely; a caption marks it as a data table
+       (and names it on macOS). -->
   <fieldset>
     <legend>Table</legend>
     <table id="users-table" aria-label="Users Table">
-      <thead>
-        <tr><th>Name</th><th>Role</th></tr>
-      </thead>
+      <caption>Users Table</caption>
       <tbody>
         <tr><td>Alice</td><td>Admin</td></tr>
         <tr><td>Bob</td><td>User</td></tr>

--- a/test-apps/tauri/frontend/index.html
+++ b/test-apps/tauri/frontend/index.html
@@ -158,6 +158,22 @@ Line 3</textarea>
     </ul>
   </fieldset>
 
+  <!-- Table: WebKit exposes <table> as AT-SPI "table" (AXTable on macOS)
+       with "table cell" (AXCell) children, matching the cross-platform
+       table/table_cell contract. -->
+  <fieldset>
+    <legend>Table</legend>
+    <table id="users-table" aria-label="Users Table">
+      <thead>
+        <tr><th>Name</th><th>Role</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Alice</td><td>Admin</td></tr>
+        <tr><td>Bob</td><td>User</td></tr>
+      </tbody>
+    </table>
+  </fieldset>
+
   <!--
     Dynamic widgets used by the event test suite. These mutate on click so
     NameChanged (Submit → status label) and StructureChanged (Add/Remove Item

--- a/tests/suites/python/conftest.py
+++ b/tests/suites/python/conftest.py
@@ -232,17 +232,26 @@ APP_CONFIGS: dict[str, dict] = {
         "textfield_selector": 'text_field[name="Search"]',
         "textfield_initial_value": "hello world",
         "textarea_selector": 'text_area[name="Notes"]',
-        # Table — HTML <table aria-label="Users Table">. Whether the webview
-        # names the cell accessible itself or only the text leaf inside it
-        # varies by engine/platform, so content is asserted via descendants.
+        # Table — HTML <table aria-label="Users Table">. Cell role
+        # normalization holds everywhere; content naming differs by engine:
+        # WebKitGTK names the text leaves (asserted via descendants), but
+        # WebKit on macOS exposes cell text only through its text-marker
+        # API — neither the AXCell nor a descendant carries the text as a
+        # name — so the content assertion is Linux-only.
         "table_selector": 'table[name="Users Table"]',
         "table_min_cells": 4,
         "table_cell_names": None,
-        "table_content_names": ["Alice", "Admin", "Bob", "User"],
+        "table_content_names": (
+            None if sys.platform == "darwin" else ["Alice", "Admin", "Bob", "User"]
+        ),
         # Plain HTML tables have no selection.
         "table_selected_cell_name": None,
-        # <th> header cells are named from their text content.
-        "table_header_names": ["Name", "Role"],
+        # <th> header cells are named from their text content on AT-SPI;
+        # on macOS WebKit header text is text-marker-only, like cell text
+        # above, so the assertion is Linux-only.
+        "table_header_names": (
+            None if sys.platform == "darwin" else ["Name", "Role"]
+        ),
         "window_name_contains": None,  # not asserted for Tauri
         "submit_button_name": "Submit",
         "add_item_button_name": "Add Item",

--- a/tests/suites/python/conftest.py
+++ b/tests/suites/python/conftest.py
@@ -91,6 +91,25 @@ APP_CONFIGS: dict[str, dict] = {
         "textfield_initial_value": None,  # Qt does not guarantee specific text
         # Text area
         "textarea_selector": '[name="Notes"]',
+        # Table — QTableWidget. Qt names each cell accessible from its item
+        # text on every platform (UIA DataItem+TableItem, AT-SPI table cell,
+        # AXCell), so cell names are asserted directly.
+        "table_selector": 'table[name="Users Table"]',
+        "table_min_cells": 4,
+        "table_cell_names": ["Alice", "Admin", "Bob", "User"],
+        "table_content_names": None,
+        # The app selects cell (0, 0); the "Alice" cell must report
+        # selected=true on every platform. On macOS Qt's bridge implements
+        # no per-element AXSelected — selection is derived from the table's
+        # AXSelectedChildren (see xa11y-macos container-selection probe).
+        "table_selected_cell_name": "Alice",
+        # Header cells are named on Windows (UIA HeaderItem), Linux (AT-SPI
+        # column header), and in webviews — but Qt's Cocoa bridge exposes no
+        # header objects at all (synthesized AXRows/AXColumns only, no
+        # AXHeader attribute), so header names are absent from the macOS AX
+        # tree entirely. Upstream Qt limitation, not an xa11y one — see
+        # https://github.com/mrexodia/xa11y-table-repro captures.
+        "table_header_names": (None if sys.platform == "darwin" else ["Name", "Role"]),
         # Window
         "window_name_contains": "xa11y-qt-test-app",
         # Dynamic buttons for event tests
@@ -124,6 +143,18 @@ APP_CONFIGS: dict[str, dict] = {
         "textfield_selector": "text_field",
         "textfield_initial_value": "hello world",
         "textarea_selector": "text_area",
+        # Table — Gtk.ColumnView (AT-SPI "tree table"); only one table in the
+        # app so a role selector suffices. GTK 4.14 names each "table cell"
+        # accessible from its child Gtk.Label (verified against a live
+        # AT-SPI session), so cell names are asserted directly.
+        "table_selector": "table",
+        "table_min_cells": 4,
+        "table_cell_names": ["Alice", "Admin", "Bob", "User"],
+        "table_content_names": None,
+        # The GTK table uses a NoSelection model — nothing is selected.
+        "table_selected_cell_name": None,
+        # ColumnView's header row is named from its column titles.
+        "table_header_names": ["Name", "Role"],
         "window_name_contains": None,  # not asserted for GTK
         # Dynamic buttons for event tests (Dynamic group in app.py).
         "submit_button_name": "Submit",
@@ -154,6 +185,20 @@ APP_CONFIGS: dict[str, dict] = {
         "textfield_selector": 'text_field[name="Search"]',
         "textfield_initial_value": "hello world",
         "textarea_selector": 'text_area[name="Notes"]',
+        # Table — multi-column cell-based NSTableView ("Users Table").
+        # AppKit exposes AXCell elements without a title; the text is the
+        # AXValue of the AXStaticText inside each cell, so content is
+        # asserted via descendants, not cell names.
+        "table_selector": 'table[name="Users Table"]',
+        "table_min_cells": 4,
+        "table_cell_names": None,
+        "table_content_names": ["Alice", "Admin", "Bob", "User"],
+        # Not instrumented yet: NSTableView selects rows, not cells; a
+        # row-selection assertion needs named rows to target.
+        "table_selected_cell_name": None,
+        # AppKit exposes the header as sort-button children under the
+        # table's header group, named from the column titles.
+        "table_header_names": ["Name", "Role"],
         "window_name_contains": None,  # not asserted for Cocoa
         "submit_button_name": "Submit",
         "add_item_button_name": "Add Item",
@@ -187,6 +232,17 @@ APP_CONFIGS: dict[str, dict] = {
         "textfield_selector": 'text_field[name="Search"]',
         "textfield_initial_value": "hello world",
         "textarea_selector": 'text_area[name="Notes"]',
+        # Table — HTML <table aria-label="Users Table">. Whether the webview
+        # names the cell accessible itself or only the text leaf inside it
+        # varies by engine/platform, so content is asserted via descendants.
+        "table_selector": 'table[name="Users Table"]',
+        "table_min_cells": 4,
+        "table_cell_names": None,
+        "table_content_names": ["Alice", "Admin", "Bob", "User"],
+        # Plain HTML tables have no selection.
+        "table_selected_cell_name": None,
+        # <th> header cells are named from their text content.
+        "table_header_names": ["Name", "Role"],
         "window_name_contains": None,  # not asserted for Tauri
         "submit_button_name": "Submit",
         "add_item_button_name": "Add Item",
@@ -219,6 +275,16 @@ APP_CONFIGS: dict[str, dict] = {
         "textfield_selector": 'text_field[name="Search"]',
         "textfield_initial_value": "hello world",
         "textarea_selector": 'text_area[name="Notes"]',
+        # Table — markup mirrors the Tauri test app; same descendant-based
+        # content assertion (Chromium's cell naming varies by platform).
+        "table_selector": 'table[name="Users Table"]',
+        "table_min_cells": 4,
+        "table_cell_names": None,
+        "table_content_names": ["Alice", "Admin", "Bob", "User"],
+        # Plain HTML tables have no selection.
+        "table_selected_cell_name": None,
+        # <th> header cells are named from their text content.
+        "table_header_names": ["Name", "Role"],
         "window_name_contains": None,  # not asserted for Electron
         # Not instrumented yet: no Dynamic (Submit / Add Item / Remove Item)
         # group in the Electron test app, so event tests skip.
@@ -280,6 +346,26 @@ APP_CONFIGS: dict[str, dict] = {
         "textfield_settable": False,
         # The AccessKit app has no multiline text area.
         "textarea_selector": None,
+        # Table — Role::Table "Users" with Role::Row / Role::Cell children.
+        # AccessKit sets each cell's name from its label on every adapter
+        # (on Windows via the structural DataItem disambiguation in
+        # xa11y-windows — AccessKit exposes cells as pattern-less DataItems).
+        "table_selector": 'table[name="Users"]',
+        "table_min_cells": 6,
+        "table_cell_names": [
+            "Alice",
+            "alice@test.com",
+            "Admin",
+            "Bob",
+            "bob@test.com",
+            "User",
+        ],
+        "table_content_names": None,
+        # Not instrumented yet: the AccessKit app sets no selection on its
+        # table cells.
+        "table_selected_cell_name": None,
+        # Not instrumented yet: the AccessKit app's table has no header row.
+        "table_header_names": None,
         # Window name comes from the winit window title but AT-SPI reports the
         # binary name; leave unchecked.
         "window_name_contains": None,
@@ -334,6 +420,17 @@ APP_CONFIGS: dict[str, dict] = {
         # Windows collapses to UIA_EditControlTypeId (xa11y `text_field`,
         # no distinct multiline role exists in UIA). Skip on Windows.
         "textarea_selector": None if sys.platform == "win32" else "text_area",
+        # Table — egui has no table widget with table accessibility
+        # semantics (egui::Grid and egui_extras' TableBuilder are layout
+        # only; they emit no AccessKit Table/Row/Cell roles).
+        "table_selector": unsupported(
+            "egui has no table widget that exposes AccessKit table semantics"
+        ),
+        "table_min_cells": 0,
+        "table_cell_names": None,
+        "table_content_names": None,
+        "table_selected_cell_name": None,
+        "table_header_names": None,
         # Window name comes from `ViewportBuilder::with_title` but the
         # AT-SPI/UIA/AX layer reports the binary name; leave unchecked.
         "window_name_contains": None,

--- a/tests/suites/python/conftest.py
+++ b/tests/suites/python/conftest.py
@@ -232,26 +232,29 @@ APP_CONFIGS: dict[str, dict] = {
         "textfield_selector": 'text_field[name="Search"]',
         "textfield_initial_value": "hello world",
         "textarea_selector": 'text_area[name="Notes"]',
-        # Table — HTML <table aria-label="Users Table">. Cell role
-        # normalization holds everywhere; content naming differs by engine:
-        # WebKitGTK names the text leaves (asserted via descendants), but
-        # WebKit on macOS exposes cell text only through its text-marker
-        # API — neither the AXCell nor a descendant carries the text as a
-        # name — so the content assertion is Linux-only.
-        "table_selector": 'table[name="Users Table"]',
+        # Table — HTML <table> with a <caption> (WebKit's data-table
+        # heuristic needs a caption/headers to expose the table at all, and
+        # <th> is out — see the page comment). Only one table in the app,
+        # found by role: WebKitGTK doesn't surface aria-label as the
+        # table's AT-SPI name (macOS WebKit does). The cross-platform role
+        # contract (table + table_cell) is asserted; cell text is NOT
+        # name-addressable in either WebKit port — WebKitGTK exposes it
+        # via the AT-SPI Text interface, macOS WebKit via text markers —
+        # so content assertions for webviews live in the Electron config,
+        # where Chromium names the text leaves.
+        "table_selector": "table",
         "table_min_cells": 4,
         "table_cell_names": None,
-        "table_content_names": (
-            None if sys.platform == "darwin" else ["Alice", "Admin", "Bob", "User"]
-        ),
+        "table_content_names": None,
         # Plain HTML tables have no selection.
         "table_selected_cell_name": None,
-        # <th> header cells are named from their text content on AT-SPI;
-        # on macOS WebKit header text is text-marker-only, like cell text
-        # above, so the assertion is Linux-only.
-        "table_header_names": (
-            None if sys.platform == "darwin" else ["Name", "Role"]
-        ),
+        # No header assertions: the Tauri page carries no <th> cells at all —
+        # under WebKitGTK with a window manager present, <th> triggers a
+        # continuous accessibility-tree invalidation churn that detaches the
+        # whole page from AT-SPI (see the comment in
+        # test-apps/tauri/frontend/index.html). Webview header coverage
+        # lives in the Electron config instead.
+        "table_header_names": None,
         "window_name_contains": None,  # not asserted for Tauri
         "submit_button_name": "Submit",
         "add_item_button_name": "Add Item",

--- a/tests/suites/python/test_compat.py
+++ b/tests/suites/python/test_compat.py
@@ -316,18 +316,89 @@ def test_textarea_found(app, app_config):
 # ---------------------------------------------------------------------------
 
 
-def test_qt_table_data_items_are_cells(app, app_name):
-    """Qt's UIA DataItems implement TableItem and must normalize as cells."""
-    if app_name != "qt":
-        pytest.skip("native Qt table regression")
+def test_table_cells_normalize(app, app_config):
+    """Table contents must normalize to table_cell on every toolkit and OS.
 
-    table = app.locator('table[name="Users Table"]').element()
+    This is the cross-platform contract behind ``table table_cell``
+    selectors: Qt's UIA DataItem+TableItem cells, AccessKit's pattern-less
+    DataItem cells (disambiguated structurally on Windows), AT-SPI
+    "table cell", and AXCell must all surface as ``table_cell``.
+    """
+    selector = app_config.get("table_selector")
+    if not selector:
+        # unsupported() markers are falsy strings carrying the reason.
+        reason = str(selector) if isinstance(selector, str) else ""
+        pytest.skip(reason or "test app has no table widget")
+
+    table = app.locator(selector).element()
     assert table.role == "table"
-    for name in ("Alice", "Admin", "Bob", "User"):
-        cell = app.locator(
-            f'table[name="Users Table"] table_cell[name="{name}"]'
-        ).element()
+
+    cells = app.locator(f"{selector} table_cell").elements()
+    min_cells = app_config["table_min_cells"]
+    assert len(cells) >= min_cells, (
+        f"expected at least {min_cells} table_cell elements under "
+        f"{selector!r}, found {len(cells)}"
+    )
+
+    # Toolkits that name the cell accessible itself (Qt, AccessKit): the
+    # named element must be the cell, not a descendant.
+    for name in app_config.get("table_cell_names") or []:
+        cell = app.locator(f'{selector} table_cell[name*="{name}"]').element()
         assert cell.role == "table_cell"
+
+    # Toolkits where the text lives on a child accessible (GTK Labels,
+    # AppKit static text, webview text leaves): the content must at least be
+    # reachable somewhere under the table.
+    for name in app_config.get("table_content_names") or []:
+        assert app.locator(f'{selector} [name*="{name}"]').exists(), (
+            f"no element named {name!r} found under {selector!r}"
+        )
+
+
+def test_table_selected_cell_state(app, app_config):
+    """Per-cell selection state must survive every platform bridge.
+
+    The test app selects one cell programmatically; that cell must report
+    ``selected`` on Windows (UIA SelectionItem.IsSelected), Linux (AT-SPI
+    selected state), and macOS. On macOS, Qt exposes selection only through
+    the table's ``AXSelectedChildren`` (no per-element ``AXSelected``), so
+    this exercises xa11y-macos's container-selection derivation.
+    Regression for https://github.com/mrexodia/xa11y-table-repro.
+    """
+    selector = app_config.get("table_selector")
+    selected_name = app_config.get("table_selected_cell_name")
+    if not selector or not selected_name:
+        pytest.skip("test app has no table with a programmatic cell selection")
+
+    cell = app.locator(f'{selector} table_cell[name*="{selected_name}"]').element()
+    assert cell.selected, (
+        f"cell {selected_name!r} is programmatically selected in the app "
+        f"but reports selected={cell.selected}"
+    )
+    # A sibling cell must NOT leak the selected state.
+    for other in app.locator(f"{selector} table_cell").elements():
+        if other.name and selected_name not in other.name:
+            assert not other.selected, (
+                f"unselected cell {other.name!r} reports selected=True"
+            )
+
+
+def test_table_headers_exposed(app, app_config):
+    """Column header names must be reachable under the table.
+
+    Skipped where the toolkit genuinely exposes no header objects (e.g.
+    Qt's Cocoa bridge synthesizes AXRows/AXColumns only and implements no
+    AXHeader, so header names do not exist in the macOS AX tree at all).
+    """
+    selector = app_config.get("table_selector")
+    headers = app_config.get("table_header_names")
+    if not selector or not headers:
+        pytest.skip("test app exposes no named table headers on this platform")
+
+    for header in headers:
+        assert app.locator(f'{selector} [name*="{header}"]').exists(), (
+            f"header {header!r} not found under {selector!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -2065,13 +2065,20 @@ pub(crate) fn map_atspi_role(role_name: &str) -> Role {
         "page tab list" => Role::TabGroup,
         "table" | "tree table" => Role::Table,
         "table row" => Role::TableRow,
-        "table cell" | "table column header" | "table row header" => Role::TableCell,
+        // Bare "column header"/"row header" are WebKit's <th> and GTK
+        // column-view headers; the "table …" pair is the classic toolkit one.
+        "table cell"
+        | "table column header"
+        | "table row header"
+        | "column header"
+        | "row header" => Role::TableCell,
         "tool bar" => Role::Toolbar,
         "scroll bar" => Role::ScrollBar,
         "slider" => Role::Slider,
         "image" | "icon" | "desktop icon" => Role::Image,
         "link" => Role::Link,
-        "panel" | "section" | "form" | "filler" | "viewport" | "scroll pane" => Role::Group,
+        "panel" | "section" | "form" | "filler" | "viewport" | "scroll pane" | "paragraph"
+        | "header" | "footer" | "grouping" | "block quote" => Role::Group,
         "progress bar" => Role::ProgressBar,
         "tree item" => Role::TreeItem,
         "document web" | "document frame" => Role::WebArea,
@@ -2089,9 +2096,13 @@ pub(crate) fn map_atspi_role(role_name: &str) -> Role {
 /// Values from atspi-common Role enum (repr(u32)).
 pub(crate) fn map_atspi_role_number(role: u32) -> Role {
     match role {
-        2 => Role::Alert,        // Alert
-        7 => Role::CheckBox,     // CheckBox
-        8 => Role::CheckBox,     // CheckMenuItem
+        2 => Role::Alert,    // Alert
+        7 => Role::CheckBox, // CheckBox
+        8 => Role::CheckBox, // CheckMenuItem
+        // Bare ColumnHeader/RowHeader (10/47): WebKit and GTK emit these for
+        // <th> / column-view header cells, distinct from the
+        // TableColumnHeader/TableRowHeader pair (57/58) below.
+        10 => Role::TableCell,   // ColumnHeader
         11 => Role::ComboBox,    // ComboBox
         16 => Role::Dialog,      // Dialog
         19 => Role::Dialog,      // FileChooser
@@ -2113,6 +2124,7 @@ pub(crate) fn map_atspi_role_number(role: u32) -> Role {
         43 => Role::Button,      // Button (push button)
         44 => Role::RadioButton, // RadioButton
         45 => Role::RadioButton, // RadioMenuItem
+        47 => Role::TableCell,   // RowHeader
         48 => Role::ScrollBar,   // ScrollBar
         49 => Role::Group,       // ScrollPane
         50 => Role::Separator,   // Separator
@@ -2131,10 +2143,18 @@ pub(crate) fn map_atspi_role_number(role: u32) -> Role {
         67 => Role::Unknown,     // Unknown
         68 => Role::Group,       // Viewport
         69 => Role::Window,      // Window
+        // Text-document containers WebKit emits for plain markup: a bare
+        // <p> (no ARIA naming) is Paragraph; header/footer/caption/block
+        // quote come from the matching HTML elements. Containers normalize
+        // to Group, caption to StaticText, mirroring the by-name map.
+        71 => Role::Group,       // Header
+        72 => Role::Group,       // Footer
+        73 => Role::Group,       // Paragraph
         75 => Role::Application, // Application
         78 => Role::TextArea, // Embedded — WebKit2GTK uses this for <input type="text"> and <textarea>;
         // multi-line refinement below downgrades single-line ones to TextField
         79 => Role::TextField,   // Entry
+        81 => Role::StaticText,  // Caption
         82 => Role::WebArea,     // DocumentFrame
         83 => Role::Heading,     // Heading
         85 => Role::Group,       // Section
@@ -2146,6 +2166,8 @@ pub(crate) fn map_atspi_role_number(role: u32) -> Role {
         95 => Role::WebArea,     // DocumentWeb
         97 => Role::List,        // WebKit2GTK uses this for <ul role="listbox">
         98 => Role::List,        // ListBox
+        99 => Role::Group,       // Grouping
+        105 => Role::Group,      // BlockQuote
         93 => Role::Tooltip,     // Tooltip
         101 => Role::Alert,      // Notification
         116 => Role::StaticText, // Static

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -122,6 +122,7 @@ extern "C" {
     fn safe_cf_array_get_count(arr: CFArrayRef) -> CFIndex;
     fn safe_cf_array_get_value(arr: CFArrayRef, idx: CFIndex) -> CFTypeRef;
     fn safe_cf_boolean_get_value(b: CFTypeRef) -> bool;
+    fn safe_cf_equal(a: CFTypeRef, b: CFTypeRef) -> bool;
     fn safe_cf_number_get_value(num: CFTypeRef, the_type: i32, value_ptr: *mut c_void) -> bool;
     fn safe_cf_dict_get_value(dict: CFTypeRef, key: CFTypeRef) -> CFTypeRef;
     fn safe_cf_array_create(values: *const CFTypeRef, num_values: CFIndex) -> CFArrayRef;
@@ -398,6 +399,56 @@ fn ax_parent(element: AXUIElementRef) -> Option<AXElement> {
     let value = ax_attr(element, "AXParent")?;
     // AXParent returns an AXUIElement, which we own via copy attribute
     Some(AXElement::from_owned(value as AXUIElementRef))
+}
+
+/// Roles whose selection state may live on the container rather than on the
+/// element itself. Kept narrow so the container probe never fires for
+/// elements that simply have no selection concept.
+fn selection_can_come_from_container(role: Role) -> bool {
+    matches!(role, Role::TableCell | Role::TableRow | Role::ListItem)
+}
+
+/// Resolve selection for an element with no `AXSelected` attribute by
+/// membership in the nearest ancestor's `AXSelectedChildren`.
+///
+/// AppKit sets `AXSelected` directly on rows/cells, but some bridges expose
+/// selection only container-side: Qt's Cocoa bridge implements no
+/// per-element `AXSelected` at all and surfaces `QAccessibleSelectionInterface`
+/// as `AXSelectedChildren` on the table — two hops above a cell
+/// (cell → row → table). Membership is the platform's canonical reading of
+/// per-item selection in that case, not a substitute for it.
+///
+/// Walks at most `max_hops` ancestors and stops at the first that exposes
+/// `AXSelectedChildren`; an empty list there is a definitive "not selected".
+/// A chain with no such container yields `false`, matching how the other
+/// state attributes degrade when absent.
+fn container_selection_contains(element: AXUIElementRef, max_hops: usize) -> bool {
+    let mut current = match ax_parent(element) {
+        Some(p) => p,
+        None => return false,
+    };
+    for _ in 0..max_hops {
+        if let Some(list) = ax_attr(current.as_ptr(), "AXSelectedChildren") {
+            let contained = unsafe {
+                if safe_cf_get_type_id(list) == safe_cf_array_get_type_id() {
+                    let count = safe_cf_array_get_count(list);
+                    (0..count).any(|i| {
+                        let item = safe_cf_array_get_value(list, i);
+                        safe_cf_equal(item, element as CFTypeRef)
+                    })
+                } else {
+                    false
+                }
+            };
+            unsafe { safe_cf_release(list) };
+            return contained;
+        }
+        current = match ax_parent(current.as_ptr()) {
+            Some(p) => p,
+            None => return false,
+        };
+    }
+    false
 }
 
 fn ax_action_names(element: AXUIElementRef) -> Vec<String> {
@@ -1554,7 +1605,20 @@ fn build_snapshot_data(element: AXUIElementRef, pid: Option<u32>, handle: u64) -
         states.focusable = focusable;
         states.modal = attrs.modal.unwrap_or(false);
         states.checked = checked;
-        states.selected = attrs.selected.unwrap_or(false);
+        // `AXSelected` is the per-element attribute, but bridges like Qt's
+        // implement selection only container-side (AXSelectedChildren on the
+        // table). Probe the container only when the attribute is entirely
+        // absent AND the role is a selectable item — AppKit elements carry
+        // AXSelected directly, so they never pay for the probe. `raw` keeps
+        // only genuinely present platform attributes, so a derived value
+        // shows up in `states.selected` but adds no fake "AXSelected" key.
+        states.selected = match attrs.selected {
+            Some(s) => s,
+            None if selection_can_come_from_container(role) => {
+                container_selection_contains(element, 2)
+            }
+            None => false,
+        };
         states.expanded = attrs.expanded;
         states.editable = matches!(role, Role::TextField | Role::TextArea);
         states.required = false;
@@ -2788,6 +2852,31 @@ mod tests {
     fn ax_action_names_returns_empty_for_null_element() {
         let result = ax_action_names(std::ptr::null());
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn container_selection_probe_gated_to_selectable_item_roles() {
+        // Only roles that live inside AXSelectedChildren-style containers
+        // may trigger the (IPC-costly) ancestor probe.
+        for role in [Role::TableCell, Role::TableRow, Role::ListItem] {
+            assert!(selection_can_come_from_container(role), "{role:?}");
+        }
+        for role in [
+            Role::Button,
+            Role::Table,
+            Role::StaticText,
+            Role::Window,
+            Role::CheckBox,
+        ] {
+            assert!(!selection_can_come_from_container(role), "{role:?}");
+        }
+    }
+
+    #[test]
+    fn container_selection_contains_is_false_for_null_element() {
+        // A null element has no parent chain; the probe must degrade to
+        // "not selected" without touching AX APIs.
+        assert!(!container_selection_contains(std::ptr::null(), 2));
     }
 
     #[test]

--- a/xa11y-macos/src/exception_safe.m
+++ b/xa11y-macos/src/exception_safe.m
@@ -251,6 +251,19 @@ Boolean safe_cf_boolean_get_value(CFTypeRef b) {
     }
 }
 
+// Safe CFEqual. AXUIElementRefs compare by underlying accessibility object,
+// which is what the container-selection membership check in ax.rs relies on.
+Boolean safe_cf_equal(CFTypeRef a, CFTypeRef b) {
+    @try {
+        if (a != NULL && b != NULL) {
+            return CFEqual(a, b);
+        }
+        return false;
+    } @catch (NSException *e) {
+        return false;
+    }
+}
+
 // Safe CFNumberGetValue.
 Boolean safe_cf_number_get_value(CFNumberRef num, CFNumberType type, void *valuePtr) {
     @try {

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -52,6 +52,11 @@ pub struct WindowsProvider {
     /// Describes which properties and patterns to pre-fetch in bulk queries.
     /// Not a cache — each FindAllBuildCache call takes a fresh snapshot.
     batch_request: IUIAutomationCacheRequest,
+    /// Raw-view tree walker, created once. Snapshot builds use it to probe a
+    /// pattern-less `DataItem`'s parent (the cell-vs-row disambiguation in
+    /// `map_uia_role`); raw view matches `batch_request`'s TrueCondition so
+    /// the probe sees the same tree the traversal does.
+    raw_walker: IUIAutomationTreeWalker,
     /// UIA elements retained for action dispatch (keyed by handle ID).
     handle_cache: Mutex<HashMap<u64, IUIAutomationElement>>,
 }
@@ -83,10 +88,15 @@ impl WindowsProvider {
             message: format!("Failed to create IUIAutomation: {}", e),
         })?;
         let batch_request = create_batch_request(&automation)?;
+        let raw_walker = unsafe { automation.RawViewWalker() }.map_err(|e| Error::Platform {
+            code: e.code().0 as i64,
+            message: format!("Failed to get RawViewWalker: {}", e),
+        })?;
 
         Ok(Self {
             automation,
             batch_request,
+            raw_walker,
             handle_cache: Mutex::new(HashMap::new()),
         })
     }
@@ -197,7 +207,7 @@ impl WindowsProvider {
     /// Every query takes a fresh snapshot — callers never see stale data.
     fn build_element_data(&self, element: &IUIAutomationElement, pid: Option<u32>) -> ElementData {
         let handle = self.cache_element(element.clone());
-        build_snapshot_data(element, pid, handle)
+        build_snapshot_data(element, pid, handle, Some(&self.raw_walker))
     }
 
     /// Populate a UIA element's snapshot so Cached* accessors work.
@@ -342,11 +352,18 @@ fn build_snapshot_data(
     element: &IUIAutomationElement,
     pid: Option<u32>,
     handle: u64,
+    walker: Option<&IUIAutomationTreeWalker>,
 ) -> ElementData {
     let control_type = unsafe { element.CachedControlType() }.unwrap_or(UIA_CONTROLTYPE_ID(0));
     let is_table_item = control_type == UIA_DataItemControlTypeId
         && uia_cached_bool(element, UIA_IsTableItemPatternAvailablePropertyId).unwrap_or(false);
-    let mut role = map_uia_role(control_type, is_table_item);
+    // The parent probe costs two live COM calls, so it only runs for the one
+    // ambiguous case: a DataItem that doesn't implement TableItem. All other
+    // control types resolve from the cached snapshot alone.
+    let parent_is_data_item = control_type == UIA_DataItemControlTypeId
+        && !is_table_item
+        && walker.and_then(|w| parent_control_type(w, element)) == Some(UIA_DataItemControlTypeId);
+    let mut role = map_uia_role(control_type, is_table_item, parent_is_data_item);
 
     // Refine role using AriaRole property for elements that UIA maps ambiguously
     // (e.g., Alert/Heading both become ControlType.Text, Dialog becomes Window)
@@ -1700,17 +1717,58 @@ fn parse_states(
     states
 }
 
-/// Map a UIA control type and its cell-specific pattern to an xa11y role.
+/// Map a UIA control type and its cell signals to an xa11y role.
 ///
-/// UIA uses `DataItem` for both row containers and individual cells. A
-/// `DataItem` that implements `TableItem` is a cell: the pattern supplies its
-/// row/column header relationships. Keep pattern-less DataItems as rows.
-fn map_uia_role(control_type: UIA_CONTROLTYPE_ID, is_table_item: bool) -> Role {
-    if control_type == UIA_DataItemControlTypeId && is_table_item {
+/// UIA uses `DataItem` for both row containers and individual cells. Two
+/// independent signals mark a `DataItem` as a cell:
+///
+/// - `is_table_item` — the element implements the `TableItem` pattern, which
+///   exists to supply a cell's row/column header relationships (Qt, WPF, and
+///   web grids expose cells this way). Read from the cached property batch.
+/// - `parent_is_data_item` — the element's raw-view parent is itself a
+///   `DataItem`. AccessKit's UIA adapter exposes `Cell`, `Row`, and both
+///   header roles as `DataItem` with no table patterns at all, so its cells
+///   are recognizable only structurally: rows sit under tables, cells under
+///   rows. No mainstream framework nests row `DataItem`s inside row
+///   `DataItem`s, so a `DataItem` under a `DataItem` is a cell. (A tree-grid
+///   that nested child-row DataItems directly under parent rows would
+///   misreport child rows as cells; no framework we cover does this — tree
+///   rows use `TreeItem`.)
+///
+/// The `GridItem` pattern is deliberately NOT a cell signal: UIA's DataItem
+/// spec allows list-style grid items (e.g. a file row in an Explorer details
+/// view) to implement `GridItem` while being rows, so its presence cannot
+/// distinguish cell from row. A pattern-less `DataItem` whose parent is not a
+/// row keeps mapping to `TableRow`.
+fn map_uia_role(
+    control_type: UIA_CONTROLTYPE_ID,
+    is_table_item: bool,
+    parent_is_data_item: bool,
+) -> Role {
+    if control_type == UIA_DataItemControlTypeId && (is_table_item || parent_is_data_item) {
         Role::TableCell
     } else {
         map_uia_control_type(control_type)
     }
+}
+
+/// Live (uncached) control type of `element`'s raw-view parent.
+///
+/// Deliberately not part of the cached batch: UIA cache requests cannot
+/// reach upward in the tree, so parent identity is only available via a
+/// walker round trip. Called only for pattern-less `DataItem`s (see
+/// `build_snapshot_data`).
+///
+/// Returns `None` when the element has no parent (desktop root) or the
+/// element vanished mid-walk; both leave the `DataItem` mapped as a row,
+/// identical to "parent is not a row" — this is a refinement probe, not a
+/// fallible operation whose error a caller could act on.
+fn parent_control_type(
+    walker: &IUIAutomationTreeWalker,
+    element: &IUIAutomationElement,
+) -> Option<UIA_CONTROLTYPE_ID> {
+    let parent = unsafe { walker.GetParentElement(element) }.ok()?;
+    unsafe { parent.CurrentControlType() }.ok()
 }
 
 /// Map UIA ControlTypeId to its coarse xa11y Role.
@@ -1800,7 +1858,19 @@ struct EventContext {
     sender: Mutex<std::sync::mpsc::Sender<Event>>,
     app_name: String,
     app_pid: u32,
+    /// Clone of the provider's raw-view walker, so event-target snapshots
+    /// resolve DataItem cells the same way tree traversal does. COM in MTA
+    /// serializes access via proxies (see `ComCallbackWrapper`), so sharing
+    /// the interface pointer with UIA callback threads is safe.
+    walker: IUIAutomationTreeWalker,
 }
+
+// The COM walker pointer keeps EventContext from auto-deriving Send/Sync
+// (it's shared via Arc with UIA's MTA callback threads). The same MTA proxy
+// guarantee behind `unsafe impl Send for WindowsProvider` covers it: every
+// dereference happens under MTA.
+unsafe impl Send for EventContext {}
+unsafe impl Sync for EventContext {}
 
 impl EventContext {
     fn emit(&self, kind: EventKind, target: Option<ElementData>) {
@@ -1843,7 +1913,7 @@ impl EventContext {
         } else {
             unsafe { sender.BuildUpdatedCache(cache) }.unwrap_or_else(|_| sender.clone())
         };
-        build_snapshot_data(&cached_element, Some(self.app_pid), 0)
+        build_snapshot_data(&cached_element, Some(self.app_pid), 0, Some(&self.walker))
     }
 }
 
@@ -2060,6 +2130,7 @@ impl WindowsProvider {
             sender: Mutex::new(tx),
             app_name,
             app_pid: pid,
+            walker: self.raw_walker.clone(),
         });
 
         // Dedicated cache request: ensures event handlers receive elements
@@ -2495,15 +2566,36 @@ mod tests {
 
     #[test]
     fn data_item_role_uses_table_item_pattern() {
+        // TableItem pattern marks a cell regardless of parent (Qt, WPF).
         assert_eq!(
-            map_uia_role(UIA_DataItemControlTypeId, true),
+            map_uia_role(UIA_DataItemControlTypeId, true, false),
             Role::TableCell
         );
+        // Neither signal: a row container.
         assert_eq!(
-            map_uia_role(UIA_DataItemControlTypeId, false),
+            map_uia_role(UIA_DataItemControlTypeId, false, false),
             Role::TableRow
         );
-        assert_eq!(map_uia_role(UIA_ButtonControlTypeId, true), Role::Button);
+        // Cell signals never leak onto other control types.
+        assert_eq!(
+            map_uia_role(UIA_ButtonControlTypeId, true, true),
+            Role::Button
+        );
+    }
+
+    #[test]
+    fn pattern_less_data_item_under_row_is_cell() {
+        // AccessKit exposes cells as pattern-less DataItems under a row
+        // DataItem — the structural signal alone must classify them.
+        assert_eq!(
+            map_uia_role(UIA_DataItemControlTypeId, false, true),
+            Role::TableCell
+        );
+        // Both signals agreeing is still a cell.
+        assert_eq!(
+            map_uia_role(UIA_DataItemControlTypeId, true, true),
+            Role::TableCell
+        );
     }
 
     #[test]

--- a/xa11y/tests/integ/actions.rs
+++ b/xa11y/tests/integ/actions.rs
@@ -321,23 +321,35 @@ mod tests {
     #[ignore]
     fn nesting_subtree_of_table() {
         let app = h::app_root();
-        let tables = app.locator("table").elements().unwrap();
-        if !tables.is_empty() {
-            // Table should contain rows and cells — use descendant combinator.
-            // On Windows, AccessKit exposes Cell as a DataItem without the
-            // TableItem pattern, so it remains a table_row. Providers such as
-            // Qt that expose TableItem on cell DataItems normalize as table_cell.
-            let cells = app.locator("table table_cell").elements().unwrap();
-            if cells.len() >= 2 {
-                return;
-            }
-            // Fall back to table_row children (Windows: cells appear as table_row)
-            let rows = app.locator("table table_row").elements().unwrap();
+        h::one(&app, "table");
+
+        // Rows and cells must normalize on every platform: AXRow/AXCell on
+        // macOS, "table row"/"table cell" on AT-SPI, and on Windows the
+        // DataItem disambiguation in xa11y-windows (AccessKit cells are
+        // pattern-less DataItems under a row DataItem, resolved by the
+        // structural parent probe).
+        let rows = app.locator("table table_row").elements().unwrap();
+        assert!(
+            rows.len() >= 2,
+            "Table should have at least 2 rows, found {}. App: {}",
+            rows.len(),
+            app
+        );
+        let cells = app.locator("table table_cell").elements().unwrap();
+        assert!(
+            cells.len() >= 6,
+            "Table should have at least 6 cells (2 rows x 3 columns), found {}. App: {}",
+            cells.len(),
+            app
+        );
+        for name in ["Alice", "Admin", "Bob", "User"] {
+            let matched = app
+                .locator(&format!(r#"table table_cell[name*="{name}"]"#))
+                .elements()
+                .unwrap();
             assert!(
-                rows.len() >= 2,
-                "Table should have at least 2 rows/cells, found {}. App: {}",
-                rows.len(),
-                app
+                !matched.is_empty(),
+                "No table_cell named {name:?}. App: {app}"
             );
         }
     }

--- a/xa11y/tests/integ/tree.rs
+++ b/xa11y/tests/integ/tree.rs
@@ -389,11 +389,11 @@ mod tests {
         let app = h::app_root();
         let tables = app.locator("table").elements().unwrap();
         let cells = app.locator("table_cell").elements().unwrap();
-        assert!(
-            !tables.is_empty() || !cells.is_empty(),
-            "Neither Table nor TableCell found. App: {}",
-            app
-        );
+        // Both must be present — cells misreported as rows (the pre-#321
+        // Windows DataItem mapping) made this silently degrade to
+        // tables-only.
+        assert!(!tables.is_empty(), "No Table found. App: {}", app);
+        assert!(!cells.is_empty(), "No TableCell found. App: {}", app);
     }
 
     // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Follow-up to #321, which fixed Qt table cells on Windows via the `TableItem` pattern but left the remaining `DataItem` ambiguity cases open — plus two macOS inconsistencies surfaced by the [xa11y-table-repro](https://github.com/mrexodia/xa11y-table-repro) captures.

## Windows: AccessKit cells (and any pattern-less DataItem cell)

AccessKit's UIA adapter exposes `Cell`, `Row`, `RowHeader`, and `ColumnHeader` **all** as `DataItem` with no `GridItem`/`TableItem` patterns at all (verified against accesskit_windows 0.27 source), so #321's pattern check can't reach them. Its cells are recognizable only structurally: rows sit under tables, cells under rows.

- `map_uia_role` gains a second cell signal: a pattern-less `DataItem` whose raw-view parent is itself a `DataItem` is a cell.
- The parent probe (2 live COM calls) runs **only** for the ambiguous case — a `DataItem` without `TableItem`. Everything else resolves from the cached snapshot as before, and `query_patterns` already makes ~6 live calls per element, so this stays inside the existing cost profile.
- `GridItem` is deliberately **not** a cell signal: UIA's DataItem spec lets list-style grid items (e.g. Explorer details rows) implement `GridItem` while being rows.
- Event-target snapshots share the same walker (via `EventContext`), so roles stay consistent across the query, traversal, and event paths.

## macOS: per-cell selection state (repro finding 1)

The repro app selects cell `W0C0`; Windows and Linux report `selected: true`, macOS reported `false`. Root cause: Qt's Cocoa bridge implements no per-element `AXSelected` — it exposes selection only through the container's `AXSelectedChildren` (confirmed in `qcocoaaccessibilityelement.mm`; there is no `isAccessibilitySelected` implementation).

- For `table_cell` / `table_row` / `list_item` elements whose `AXSelected` attribute is **absent** (not `false`), `states.selected` is now resolved by membership in the nearest ancestor's `AXSelectedChildren` (≤2 hops: cell → row → table), using CFEqual identity via a new exception-safe `safe_cf_equal` wrapper.
- AppKit elements carry `AXSelected` directly and never pay for the probe. `raw` never gains a synthetic `AXSelected` key — derived values appear in `states.selected` only.

## macOS: Qt table headers (repro finding 2 — documented, not fixable here)

Qt's Cocoa bridge synthesizes `AXRow`/`AXColumn` children only, drops the header cells, and implements no `AXHeader` attribute — the header names do not exist anywhere in the macOS AX tree. That's an upstream Qt limitation; per the "only expose what accessibility APIs support" tenet this PR documents it (platform-details docs + an executable skip in the shared header test) rather than fabricating headers.

## Test coverage (patterns × frameworks × platforms)

- **Test apps**: "Users" tables added to gtk (`Gtk.ColumnView`), cocoa (multi-column `NSTableView`), tauri, and electron; the qt table now programmatically selects cell (0, 0); egui documented as having no table a11y semantics.
- **Python suite**: the qt-only table test is replaced by three config-driven tests — cell role normalization, per-cell selected state, and header exposure — parameterized across all seven app configs via new `table_*` keys in `APP_CONFIGS`. These run in the existing integ matrix (qt on Linux/macOS/Windows, gtk/tauri/electron on Linux, cocoa/tauri on macOS).
- **Rust integ** (AccessKit app, Linux + macOS + Windows CI): `nesting_subtree_of_table` and `tree_has_table_with_cells` now require named `table_cell` elements on every platform — the pre-#321 tolerant fallbacks are gone.
- **Unit tests**: Windows mapping matrix for both cell signals; macOS gating + null-safety tests for the selection probe.

## Verification

- GTK ColumnView roles verified against a live AT-SPI session (tree table / table row / named table cells — cells turn out to be named, so the config asserts them directly).
- Linux AccessKit integration suite: **133/133 pass** with the tightened assertions.
- `cargo xtask check` fully green; `xa11y-windows` and `xa11y-macos` clippy-clean under `-Dwarnings` for their native targets (cross-compiled checks).
- The macOS selection fix's end-to-end red→green runs in CI (`macos-latest × qt`): red on current main per the repro's darwin capture of 0.11.0, green with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aGqnGwX7BxGBSDo3Rt1rG

---
_Generated by [Claude Code](https://claude.ai/code/session_014aGqnGwX7BxGBSDo3Rt1rG)_