### PR TITLE
Close the post-#322 audit gaps: role-map drift on all three platforms, WPF Custom cells, defunct diagnostics, unknown-role guard

### DIFF
--- a/docs/site/src/content/docs/guides/platform-details.mdx
+++ b/docs/site/src/content/docs/guides/platform-details.mdx
@@ -176,6 +176,13 @@ Every other configuration fails closed to `1.0` — never wrong data. There, bou
 
 GTK 4 menu-button widgets (`GtkMenuButton`, `AdwMenuButton`, `AdwSplitButton`) present as an outer `push button` accessible that advertises `NActions = 0` wrapping an inner `toggle button` that carries the real `click` action. Calling `press()` on the outer would normally raise `ActionNotSupported`. When the owning application identifies itself as GTK via `Application.ToolkitName == "GTK"`, xa11y-linux instead walks a bounded slice of the outer's subtree (BFS, depth 3, actionable roles only, name must match) and invokes the single actionable descendant it finds. The fallback is strictly scoped: it only runs inside GTK apps, only when the widget's own Action interface is empty, and only when exactly one candidate matches — ambiguous subtrees still surface the original error.
 
+### WebKitGTK tables
+
+Two WebKitGTK behaviors affect `<table>` content (verified against WebKitGTK 2.52; both are engine behaviors, not xa11y ones):
+
+- **`<th>` cells can destabilize the whole page's tree.** With a window manager present, a table containing `<th>` header cells can send WebKit's accessibility tree into continuous invalidation churn — every content accessible goes defunct moments after being exposed, and the page effectively vanishes from AT-SPI. If a WebKitGTK-based app's tree keeps coming back empty or `unknown`, check for this (xa11y marks dead objects with `raw["atspi_defunct"]`).
+- **Layout-table heuristic.** A `<table>` without headers or a `<caption>` is judged decorative and dropped from the accessibility tree entirely. Cell text is exposed through the AT-SPI Text interface (surfaced as the cell's `value`), not as the accessible name — use `table_cell[value*="..."]` selectors for WebKitGTK content.
+
 ### Linux Electron and Chromium apps
 
 On Linux, Electron and Chromium-based apps ship with their AT-SPI2 bridge disabled by default for performance. xa11y will connect to the app but its tree will contain only the top-level window — `App.by_name("…").locator("button").count()` returns 0 even though buttons are visible on screen.

--- a/test-apps/cocoa/main.swift
+++ b/test-apps/cocoa/main.swift
@@ -225,6 +225,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         y -= 160
 
         let tableScroll = NSScrollView(frame: NSRect(x: 16, y: 10, width: 400, height: 120))
+        // Deliberately cell-based (legacy NSCell, no delegate): this list
+        // covers the AX path where text hangs directly off AXRows with no
+        // AXCell layer. The view-based "Users Table" below covers the modern
+        // AXCell shape — keep both.
         listTable = NSTableView(frame: tableScroll.bounds)
         listTable.setAccessibilityLabel("Items")
         let col = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("item"))

--- a/tests/suites/python/conftest.py
+++ b/tests/suites/python/conftest.py
@@ -111,6 +111,8 @@ APP_CONFIGS: dict[str, dict] = {
         # https://github.com/mrexodia/xa11y-table-repro captures.
         "table_header_names": (None if sys.platform == "darwin" else ["Name", "Role"]),
         # Window
+        # Not yet verified unknown-free on all three OSes.
+        "expect_no_unknown_roles": False,
         "window_name_contains": "xa11y-qt-test-app",
         # Dynamic buttons for event tests
         "submit_button_name": "Submit",
@@ -155,6 +157,8 @@ APP_CONFIGS: dict[str, dict] = {
         "table_selected_cell_name": None,
         # ColumnView's header row is named from its column titles.
         "table_header_names": ["Name", "Role"],
+        # Verified clean against a live AT-SPI session.
+        "expect_no_unknown_roles": True,
         "window_name_contains": None,  # not asserted for GTK
         # Dynamic buttons for event tests (Dynamic group in app.py).
         "submit_button_name": "Submit",
@@ -199,6 +203,8 @@ APP_CONFIGS: dict[str, dict] = {
         # AppKit exposes the header as sort-button children under the
         # table's header group, named from the column titles.
         "table_header_names": ["Name", "Role"],
+        # Not yet verified unknown-free.
+        "expect_no_unknown_roles": False,
         "window_name_contains": None,  # not asserted for Cocoa
         "submit_button_name": "Submit",
         "add_item_button_name": "Add Item",
@@ -246,6 +252,12 @@ APP_CONFIGS: dict[str, dict] = {
         "table_min_cells": 4,
         "table_cell_names": None,
         "table_content_names": None,
+        # WebKitGTK exposes cell text through the AT-SPI Text interface,
+        # which xa11y surfaces as the cell's value; macOS WebKit has no
+        # equivalent (text markers only).
+        "table_cell_values": (
+            None if sys.platform == "darwin" else ["Alice", "Admin", "Bob", "User"]
+        ),
         # Plain HTML tables have no selection.
         "table_selected_cell_name": None,
         # No header assertions: the Tauri page carries no <th> cells at all —
@@ -255,6 +267,10 @@ APP_CONFIGS: dict[str, dict] = {
         # test-apps/tauri/frontend/index.html). Webview header coverage
         # lives in the Electron config instead.
         "table_header_names": None,
+        # WebKitGTK exposes two hidden spin-button arrow internals with the
+        # (deliberately unmapped) AT-SPI "arrow" role, so the tree is not
+        # unknown-free.
+        "expect_no_unknown_roles": False,
         "window_name_contains": None,  # not asserted for Tauri
         "submit_button_name": "Submit",
         "add_item_button_name": "Add Item",
@@ -297,6 +313,8 @@ APP_CONFIGS: dict[str, dict] = {
         "table_selected_cell_name": None,
         # <th> header cells are named from their text content.
         "table_header_names": ["Name", "Role"],
+        # Not yet verified unknown-free.
+        "expect_no_unknown_roles": False,
         "window_name_contains": None,  # not asserted for Electron
         # Not instrumented yet: no Dynamic (Submit / Add Item / Remove Item)
         # group in the Electron test app, so event tests skip.
@@ -378,6 +396,8 @@ APP_CONFIGS: dict[str, dict] = {
         "table_selected_cell_name": None,
         # Not instrumented yet: the AccessKit app's table has no header row.
         "table_header_names": None,
+        # Verified clean against a live AT-SPI session.
+        "expect_no_unknown_roles": True,
         # Window name comes from the winit window title but AT-SPI reports the
         # binary name; leave unchecked.
         "window_name_contains": None,
@@ -443,6 +463,8 @@ APP_CONFIGS: dict[str, dict] = {
         "table_content_names": None,
         "table_selected_cell_name": None,
         "table_header_names": None,
+        # Not yet verified unknown-free.
+        "expect_no_unknown_roles": False,
         # Window name comes from `ViewportBuilder::with_title` but the
         # AT-SPI/UIA/AX layer reports the binary name; leave unchecked.
         "window_name_contains": None,

--- a/tests/suites/python/test_compat.py
+++ b/tests/suites/python/test_compat.py
@@ -354,6 +354,13 @@ def test_table_cells_normalize(app, app_config):
             f"no element named {name!r} found under {selector!r}"
         )
 
+    # Engines that expose cell text via the platform text interface rather
+    # than the accessible name (WebKitGTK): it must surface as the cell's
+    # value, so `table_cell[value*=...]` selectors stay usable.
+    for text in app_config.get("table_cell_values") or []:
+        cell = app.locator(f'{selector} table_cell[value*="{text}"]').element()
+        assert cell.role == "table_cell"
+
 
 def test_table_selected_cell_state(app, app_config):
     """Per-cell selection state must survive every platform bridge.
@@ -381,6 +388,30 @@ def test_table_selected_cell_state(app, app_config):
             assert not other.selected, (
                 f"unselected cell {other.name!r} reports selected=True"
             )
+
+
+def test_tree_has_no_unknown_roles(app, app_config):
+    """Opt-in guard: a fully-mapped toolkit's tree contains no unknown roles.
+
+    Unmapped platform roles silently degrade to ``unknown`` in non-strict
+    builds, which is exactly how the AT-SPI numeric/name map gaps (roles 10,
+    54, 64, 73, 110, ...) went unnoticed: the strict-roles build only runs
+    against the AccessKit app, while the diverse-toolkit matrix cells run
+    non-strict. Apps opt in via ``expect_no_unknown_roles`` once their tree
+    is verified clean; the failure message carries each element's raw
+    platform role so a regression points straight at the missing mapping.
+    """
+    if not app_config.get("expect_no_unknown_roles"):
+        pytest.skip("tree not asserted unknown-free for this app")
+
+    unknowns = app.locator("unknown").elements()
+    details = [
+        f"name={el.name!r} raw={el.raw!r}" for el in unknowns
+    ]
+    assert not unknowns, (
+        f"{len(unknowns)} element(s) with unmapped platform roles:\n  "
+        + "\n  ".join(details)
+    )
 
 
 def test_table_headers_exposed(app, app_config):

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -643,7 +643,7 @@ impl LinuxProvider {
         let (
             ((mut name, value), description),
             (
-                (states, bounds),
+                ((states, state_bits), bounds),
                 ((actions, action_index_map), (numeric_value, min_value, max_value)),
             ),
         ) = rayon::join(
@@ -665,7 +665,7 @@ impl LinuxProvider {
                 rayon::join(
                     || {
                         rayon::join(
-                            || self.parse_states(aref, role),
+                            || self.parse_states_with_bits(aref, role),
                             || {
                                 if role != Role::Application {
                                     self.get_extents(aref)
@@ -752,6 +752,14 @@ impl LinuxProvider {
                     "atspi_description".into(),
                     serde_json::Value::String(d.clone()),
                 );
+            }
+            // DEFUNCT (bit 6) marks a dead accessible — the object was
+            // destroyed provider-side but a reference still resolves. It has
+            // no cross-platform StateSet field, but it's the key diagnostic
+            // for stale-reference bugs (e.g. a churning WebKit tree), so
+            // surface it whenever set.
+            if (state_bits & (1 << 6)) != 0 {
+                raw.insert("atspi_defunct".into(), serde_json::Value::Bool(true));
             }
             raw
         };
@@ -846,6 +854,13 @@ impl LinuxProvider {
 
     /// Parse AT-SPI2 state bitfield into xa11y StateSet.
     fn parse_states(&self, aref: &AccessibleRef, role: Role) -> StateSet {
+        self.parse_states_with_bits(aref, role).0
+    }
+
+    /// Like [`parse_states`], but also returns the raw AT-SPI state bitset so
+    /// callers can surface provider-only facts (notably DEFUNCT) that have no
+    /// cross-platform `StateSet` field.
+    fn parse_states_with_bits(&self, aref: &AccessibleRef, role: Role) -> (StateSet, u64) {
         let bits = self.state_bits(aref);
 
         // AT-SPI2 state bit positions (AtspiStateType enum values)
@@ -903,7 +918,7 @@ impl LinuxProvider {
         states.modal = (bits & MODAL) != 0;
         states.required = (bits & REQUIRED) != 0;
         states.busy = (bits & BUSY) != 0;
-        states
+        (states, bits)
     }
 
     /// Find an application by PID.

--- a/xa11y-linux/src/atspi.rs
+++ b/xa11y-linux/src/atspi.rs
@@ -2042,7 +2042,7 @@ pub(crate) fn map_atspi_role(role_name: &str) -> Role {
         "application" => Role::Application,
         "window" | "frame" => Role::Window,
         "dialog" | "file chooser" => Role::Dialog,
-        "alert" | "notification" => Role::Alert,
+        "alert" | "notification" | "info bar" => Role::Alert,
         "push button" | "push button menu" => Role::Button,
         "toggle button" => Role::Switch,
         "check box" | "check menu item" => Role::CheckBox,
@@ -2052,13 +2052,15 @@ pub(crate) fn map_atspi_role(role_name: &str) -> Role {
         // "textbox" is the ARIA role name returned by WebKit2GTK for both
         // <input type="text"> and <textarea>.  Map to TextArea here so the
         // multi-line refinement below can downgrade single-line ones to TextField.
-        "text" | "textbox" => Role::TextArea,
+        // "embedded" is WebKit2GTK's numeric-path equivalent (role 78);
+        // "terminal" is VTE — text is reachable via the Text interface.
+        "text" | "textbox" | "embedded" | "terminal" => Role::TextArea,
         "label" | "static" | "caption" => Role::StaticText,
         "combo box" | "combobox" => Role::ComboBox,
         // "listbox" is the ARIA role name returned by WebKit2GTK for role="listbox".
         "list" | "list box" | "listbox" => Role::List,
         "list item" => Role::ListItem,
-        "menu" => Role::Menu,
+        "menu" | "popup menu" => Role::Menu,
         "menu item" | "tearoff menu item" => Role::MenuItem,
         "menu bar" => Role::MenuBar,
         "page tab" => Role::Tab,
@@ -2078,10 +2080,16 @@ pub(crate) fn map_atspi_role(role_name: &str) -> Role {
         "image" | "icon" | "desktop icon" => Role::Image,
         "link" => Role::Link,
         "panel" | "section" | "form" | "filler" | "viewport" | "scroll pane" | "paragraph"
-        | "header" | "footer" | "grouping" | "block quote" => Role::Group,
-        "progress bar" => Role::ProgressBar,
+        | "header" | "footer" | "grouping" | "block quote" | "redundant object" | "tree"
+        | "comment" | "title bar" | "calendar" => Role::Group,
+        "progress bar" | "level bar" => Role::ProgressBar,
         "tree item" => Role::TreeItem,
-        "document web" | "document frame" => Role::WebArea,
+        "document web"
+        | "document frame"
+        | "document spreadsheet"
+        | "document presentation"
+        | "document text"
+        | "document email" => Role::WebArea,
         "heading" => Role::Heading,
         "separator" => Role::Separator,
         "split pane" => Role::SplitGroup,
@@ -2097,6 +2105,7 @@ pub(crate) fn map_atspi_role(role_name: &str) -> Role {
 pub(crate) fn map_atspi_role_number(role: u32) -> Role {
     match role {
         2 => Role::Alert,    // Alert
+        5 => Role::Group,    // Calendar (mirrors UIA CalendarControlType)
         7 => Role::CheckBox, // CheckBox
         8 => Role::CheckBox, // CheckMenuItem
         // Bare ColumnHeader/RowHeader (10/47): WebKit and GTK emit these for
@@ -2104,6 +2113,7 @@ pub(crate) fn map_atspi_role_number(role: u32) -> Role {
         // TableColumnHeader/TableRowHeader pair (57/58) below.
         10 => Role::TableCell,   // ColumnHeader
         11 => Role::ComboBox,    // ComboBox
+        13 => Role::Image,       // DesktopIcon
         16 => Role::Dialog,      // Dialog
         19 => Role::Dialog,      // FileChooser
         20 => Role::Group,       // Filler
@@ -2120,6 +2130,7 @@ pub(crate) fn map_atspi_role_number(role: u32) -> Role {
         38 => Role::TabGroup,    // PageTabList
         39 => Role::Group,       // Panel
         40 => Role::TextField,   // PasswordText
+        41 => Role::Menu,        // PopupMenu
         42 => Role::ProgressBar, // ProgressBar
         43 => Role::Button,      // Button (push button)
         44 => Role::RadioButton, // RadioButton
@@ -2131,13 +2142,17 @@ pub(crate) fn map_atspi_role_number(role: u32) -> Role {
         51 => Role::Slider,      // Slider
         52 => Role::SpinButton,  // SpinButton
         53 => Role::SplitGroup,  // SplitPane
+        54 => Role::Status,      // StatusBar
         55 => Role::Table,       // Table
         56 => Role::TableCell,   // TableCell
         57 => Role::TableCell,   // TableColumnHeader
         58 => Role::TableCell,   // TableRowHeader
+        59 => Role::MenuItem,    // TearoffMenuItem
+        60 => Role::TextArea,    // Terminal (VTE and friends — text via the Text interface)
         61 => Role::TextArea,    // Text
         62 => Role::Switch,      // ToggleButton
         63 => Role::Toolbar,     // ToolBar
+        64 => Role::Tooltip,     // ToolTip
         65 => Role::Group,       // Tree
         66 => Role::Table,       // TreeTable
         67 => Role::Unknown,     // Unknown
@@ -2153,25 +2168,35 @@ pub(crate) fn map_atspi_role_number(role: u32) -> Role {
         75 => Role::Application, // Application
         78 => Role::TextArea, // Embedded — WebKit2GTK uses this for <input type="text"> and <textarea>;
         // multi-line refinement below downgrades single-line ones to TextField
-        79 => Role::TextField,   // Entry
-        81 => Role::StaticText,  // Caption
-        82 => Role::WebArea,     // DocumentFrame
-        83 => Role::Heading,     // Heading
-        85 => Role::Group,       // Section
-        86 => Role::Group,       // RedundantObject
-        87 => Role::Group,       // Form
-        88 => Role::Link,        // Link
-        90 => Role::TableRow,    // TableRow
-        91 => Role::TreeItem,    // TreeItem
-        95 => Role::WebArea,     // DocumentWeb
-        97 => Role::List,        // WebKit2GTK uses this for <ul role="listbox">
-        98 => Role::List,        // ListBox
-        99 => Role::Group,       // Grouping
-        105 => Role::Group,      // BlockQuote
-        93 => Role::Tooltip,     // Tooltip
-        101 => Role::Alert,      // Notification
-        116 => Role::StaticText, // Static
-        129 => Role::Button,     // PushButtonMenu
+        79 => Role::TextField,  // Entry
+        81 => Role::StaticText, // Caption
+        82 => Role::WebArea,    // DocumentFrame
+        83 => Role::Heading,    // Heading
+        85 => Role::Group,      // Section
+        86 => Role::Group,      // RedundantObject
+        87 => Role::Group,      // Form
+        88 => Role::Link,       // Link
+        90 => Role::TableRow,   // TableRow
+        91 => Role::TreeItem,   // TreeItem
+        // Document roots (92-96): LibreOffice exposes spreadsheet /
+        // presentation / text / email documents with these; all normalize to
+        // WebArea alongside DocumentFrame/DocumentWeb above.
+        92 => Role::WebArea,      // DocumentSpreadsheet
+        93 => Role::WebArea,      // DocumentPresentation
+        94 => Role::WebArea,      // DocumentText
+        95 => Role::WebArea,      // DocumentWeb
+        96 => Role::WebArea,      // DocumentEmail
+        97 => Role::Group,        // Comment (ARIA comment container)
+        98 => Role::List,         // ListBox — WebKit2GTK emits this for <ul role="listbox">
+        99 => Role::Group,        // Grouping
+        101 => Role::Alert,       // Notification
+        102 => Role::Alert,       // InfoBar (GtkInfoBar message strip)
+        103 => Role::ProgressBar, // LevelBar (GtkLevelBar)
+        104 => Role::Group,       // TitleBar (mirrors UIA TitleBar)
+        105 => Role::Group,       // BlockQuote
+        110 => Role::Navigation,  // Landmark
+        116 => Role::StaticText,  // Static
+        129 => Role::Button,      // PushButtonMenu
         _ => xa11y_core::unknown_role(&format!("AT-SPI role number {role}")),
     }
 }
@@ -2285,6 +2310,161 @@ mod tests {
         assert_eq!(map_atspi_role_number(43), Role::Button); // PushButton
         assert_eq!(map_atspi_role_number(7), Role::CheckBox);
         assert_eq!(map_atspi_role_number(67), Role::Unknown); // AT-SPI Unknown
+    }
+
+    /// The full AtspiRole enum (atspi 2.52) as (number, GetRoleName-style
+    /// name) pairs. The name form is the enum nick with dashes replaced by
+    /// spaces, which is what providers hand back over D-Bus.
+    const ATSPI_ROLE_ENUM: &[(u32, &str)] = &[
+        (0, "invalid"),
+        (1, "accelerator label"),
+        (2, "alert"),
+        (3, "animation"),
+        (4, "arrow"),
+        (5, "calendar"),
+        (6, "canvas"),
+        (7, "check box"),
+        (8, "check menu item"),
+        (9, "color chooser"),
+        (10, "column header"),
+        (11, "combo box"),
+        (12, "date editor"),
+        (13, "desktop icon"),
+        (14, "desktop frame"),
+        (15, "dial"),
+        (16, "dialog"),
+        (17, "directory pane"),
+        (18, "drawing area"),
+        (19, "file chooser"),
+        (20, "filler"),
+        (21, "focus traversable"),
+        (22, "font chooser"),
+        (23, "frame"),
+        (24, "glass pane"),
+        (25, "html container"),
+        (26, "icon"),
+        (27, "image"),
+        (28, "internal frame"),
+        (29, "label"),
+        (30, "layered pane"),
+        (31, "list"),
+        (32, "list item"),
+        (33, "menu"),
+        (34, "menu bar"),
+        (35, "menu item"),
+        (36, "option pane"),
+        (37, "page tab"),
+        (38, "page tab list"),
+        (39, "panel"),
+        (40, "password text"),
+        (41, "popup menu"),
+        (42, "progress bar"),
+        (43, "push button"),
+        (44, "radio button"),
+        (45, "radio menu item"),
+        (46, "root pane"),
+        (47, "row header"),
+        (48, "scroll bar"),
+        (49, "scroll pane"),
+        (50, "separator"),
+        (51, "slider"),
+        (52, "spin button"),
+        (53, "split pane"),
+        (54, "status bar"),
+        (55, "table"),
+        (56, "table cell"),
+        (57, "table column header"),
+        (58, "table row header"),
+        (59, "tearoff menu item"),
+        (60, "terminal"),
+        (61, "text"),
+        (62, "toggle button"),
+        (63, "tool bar"),
+        (64, "tool tip"),
+        (65, "tree"),
+        (66, "tree table"),
+        (67, "unknown"),
+        (68, "viewport"),
+        (69, "window"),
+        (70, "extended"),
+        (71, "header"),
+        (72, "footer"),
+        (73, "paragraph"),
+        (74, "ruler"),
+        (75, "application"),
+        (76, "autocomplete"),
+        (77, "editbar"),
+        (78, "embedded"),
+        (79, "entry"),
+        (80, "chart"),
+        (81, "caption"),
+        (82, "document frame"),
+        (83, "heading"),
+        (84, "page"),
+        (85, "section"),
+        (86, "redundant object"),
+        (87, "form"),
+        (88, "link"),
+        (89, "input method window"),
+        (90, "table row"),
+        (91, "tree item"),
+        (92, "document spreadsheet"),
+        (93, "document presentation"),
+        (94, "document text"),
+        (95, "document web"),
+        (96, "document email"),
+        (97, "comment"),
+        (98, "list box"),
+        (99, "grouping"),
+        (100, "image map"),
+        (101, "notification"),
+        (102, "info bar"),
+        (103, "level bar"),
+        (104, "title bar"),
+        (105, "block quote"),
+        (106, "audio"),
+        (107, "video"),
+        (108, "definition"),
+        (109, "article"),
+        (110, "landmark"),
+        (111, "log"),
+        (112, "marquee"),
+        (113, "math"),
+        (114, "rating"),
+        (115, "timer"),
+        (116, "static"),
+        (117, "math fraction"),
+        (118, "math root"),
+        (119, "subscript"),
+        (120, "superscript"),
+        (121, "description list"),
+        (122, "description term"),
+        (123, "description value"),
+        (124, "footnote"),
+        (125, "content deletion"),
+        (126, "content insertion"),
+        (127, "mark"),
+        (128, "suggestion"),
+        (129, "push button menu"),
+    ];
+
+    #[test]
+    fn numeric_and_name_role_maps_agree() {
+        // The provider resolves roles by number on some paths (resolve_role)
+        // and by name on others (build_element_data). If the two maps drift,
+        // the same element reports different roles depending on how it was
+        // reached — this happened for StatusBar (54, name-only), ToolTip
+        // (64, and 93 was mis-numbered as Tooltip), and Landmark (110).
+        // Sweep the whole enum so any future addition lands in both maps.
+        for &(num, name) in ATSPI_ROLE_ENUM {
+            let by_num = map_atspi_role_number(num);
+            let by_name = map_atspi_role(name);
+            assert_eq!(
+                by_num, by_name,
+                "AT-SPI role {num} ({name:?}) diverges: numeric map gives \
+                 {by_num:?}, name map gives {by_name:?}"
+            );
+        }
     }
 
     #[test]

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -986,6 +986,9 @@ fn map_ax_role(role: &str, subrole: Option<&str>) -> Role {
         Some("AXOutlineRow") => return Role::TreeItem,
         Some("AXHeading") => return Role::Heading,
         Some("AXSwitch") => return Role::Switch,
+        // WebKit exposes <nav>/role="navigation" as AXGroup with this
+        // subrole; matches AT-SPI's "navigation" landmark mapping.
+        Some("AXLandmarkNavigation") => return Role::Navigation,
         _ => {}
     }
 
@@ -1041,6 +1044,13 @@ fn map_ax_role(role: &str, subrole: Option<&str>) -> Role {
         "AXStatusBar" => Role::Status,
         "AXValueIndicator" => Role::ScrollThumb,
         "AXGrid" => Role::Table,
+        // Table-header sort buttons (view-based NSTableView headers).
+        "AXSortButton" => Role::Button,
+        // AppKit's help-tag tooltip role (AXToolTip above is the WebKit one).
+        "AXHelpTag" => Role::Tooltip,
+        // Transient floating container (NSPopover); a content group like its
+        // GTK popover counterpart, not a dialog.
+        "AXPopover" => Role::Group,
         "AXDockItem" => Role::Button,
         "AXGrowArea" => Role::ScrollThumb,
         "AXColorWell" | "AXRuler" | "AXMatte" => Role::Unknown,
@@ -2914,6 +2924,13 @@ mod tests {
 
     #[test]
     fn map_ax_role_covers_all_known_roles() {
+        assert_eq!(map_ax_role("AXSortButton", None), Role::Button);
+        assert_eq!(map_ax_role("AXHelpTag", None), Role::Tooltip);
+        assert_eq!(map_ax_role("AXPopover", None), Role::Group);
+        assert_eq!(
+            map_ax_role("AXGroup", Some("AXLandmarkNavigation")),
+            Role::Navigation
+        );
         assert_eq!(map_ax_role("AXWindow", Some("AXDialog")), Role::Dialog);
         assert_eq!(
             map_ax_role("AXGroup", Some("AXApplicationAlert")),

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -355,7 +355,8 @@ fn build_snapshot_data(
     walker: Option<&IUIAutomationTreeWalker>,
 ) -> ElementData {
     let control_type = unsafe { element.CachedControlType() }.unwrap_or(UIA_CONTROLTYPE_ID(0));
-    let is_table_item = control_type == UIA_DataItemControlTypeId
+    let is_table_item = (control_type == UIA_DataItemControlTypeId
+        || control_type == UIA_CustomControlTypeId)
         && uia_cached_bool(element, UIA_IsTableItemPatternAvailablePropertyId).unwrap_or(false);
     // The parent probe costs two live COM calls, so it only runs for the one
     // ambiguous case: a DataItem that doesn't implement TableItem. All other
@@ -1745,7 +1746,18 @@ fn map_uia_role(
     is_table_item: bool,
     parent_is_data_item: bool,
 ) -> Role {
-    if control_type == UIA_DataItemControlTypeId && (is_table_item || parent_is_data_item) {
+    // WPF and WinForms DataGrids expose their cells as Custom elements whose
+    // only table signal is the TableItem pattern — without this they'd map to
+    // Unknown. The structural parent signal stays DataItem-only: a custom
+    // widget embedded in a row is not a cell.
+    let is_cell = if control_type == UIA_DataItemControlTypeId {
+        is_table_item || parent_is_data_item
+    } else if control_type == UIA_CustomControlTypeId {
+        is_table_item
+    } else {
+        false
+    };
+    if is_cell {
         Role::TableCell
     } else {
         map_uia_control_type(control_type)
@@ -1814,6 +1826,8 @@ fn map_uia_control_type(control_type: UIA_CONTROLTYPE_ID) -> Role {
         UIA_ToolTipControlTypeId => Role::Tooltip,
         UIA_CalendarControlTypeId => Role::Group,
         UIA_CustomControlTypeId => Role::Unknown,
+        UIA_SemanticZoomControlTypeId => Role::Group,
+        UIA_AppBarControlTypeId => Role::Toolbar,
         _ => xa11y_core::unknown_role(&format!("UIA control type {}", control_type.0)),
     }
 }
@@ -2581,6 +2595,47 @@ mod tests {
             map_uia_role(UIA_ButtonControlTypeId, true, true),
             Role::Button
         );
+    }
+
+    #[test]
+    fn custom_control_with_table_item_pattern_is_cell() {
+        // WPF/WinForms DataGrid cells: ControlType.Custom + TableItem.
+        assert_eq!(
+            map_uia_role(UIA_CustomControlTypeId, true, false),
+            Role::TableCell
+        );
+        // Pattern-less Custom stays Unknown even under a row — an embedded
+        // custom widget inside a row is not a cell.
+        assert_eq!(
+            map_uia_role(UIA_CustomControlTypeId, false, true),
+            Role::Unknown
+        );
+        assert_eq!(
+            map_uia_role(UIA_CustomControlTypeId, false, false),
+            Role::Unknown
+        );
+    }
+
+    #[test]
+    fn control_type_map_covers_every_uia_control_type() {
+        // The complete UIA control-type range (50000..=50040). Every id must
+        // resolve without reaching the unknown_role catch-all (which panics
+        // under strict-roles); Custom (50025) is the one deliberate Unknown.
+        // Guards against the AT-SPI-style drift where common types were
+        // silently missing (SemanticZoom and AppBar were, before this test).
+        for id in 50000..=50040u32 {
+            let ct = UIA_CONTROLTYPE_ID(id as i32);
+            let role = map_uia_control_type(ct);
+            if ct == UIA_CustomControlTypeId {
+                assert_eq!(role, Role::Unknown);
+            } else {
+                assert_ne!(
+                    role,
+                    Role::Unknown,
+                    "UIA control type {id} has no explicit mapping"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #322: fixes every issue the post-merge audit confirmed, across all three providers, with regression guards so each bug class stays fixed.

## Linux: AT-SPI role-map drift (commit 1)

The numeric (`map_atspi_role_number`) and by-name (`map_atspi_role`) maps had drifted — the provider resolves by number on some paths and by name on others, so the same element could report different roles depending on how it was reached.

- **`93 => Tooltip` was mis-numbered** (93 is `DocumentPresentation`; the real `ToolTip` is 64 and was absent).
- **`97 => List` was dead** — 97 is `Comment`; WebKit's listbox arrives as 98 (verified live).
- Name-only roles now resolve by number too (`StatusBar`, `Landmark`, `TearoffMenuItem`, `DesktopIcon`), plus consistent both-map additions for common desktop roles (GTK `InfoBar`/`LevelBar`, terminals, popup menus, LibreOffice document roots, …).
- **Guard**: a parity test sweeps the full enum (0–129) asserting both maps agree — it caught the `TearoffMenuItem` gap while being written. The exotic tail stays unmapped in *both* maps so `strict-roles` builds keep surfacing genuinely unhandled roles.

## Windows: WPF/WinForms DataGrid cells + control-type sweep (commit 2)

- WPF and WinForms DataGrids expose cells as ControlType **Custom** whose only table signal is the `TableItem` pattern — these mapped to `Unknown`. `Custom`+`TableItem` now maps to `table_cell`; the structural parent signal stays DataItem-only (an embedded custom widget inside a row is not a cell).
- `SemanticZoom` and `AppBar` were the two missing control types; a sweep test asserts every id in 50000..=50040 has an explicit arm.

## macOS: missing AX roles (commit 2)

`AXSortButton` (view-based table header buttons) → button, `AXHelpTag` (AppKit's tooltip role) → tooltip, `AXPopover` → group, and WebKit's `AXLandmarkNavigation` subrole → navigation (matching the AT-SPI landmark mapping).

## Diagnostics: defunct accessibles (commit 2)

Dead AT-SPI objects (DEFUNCT, bit 6) now surface `raw["atspi_defunct"] = true`. This was the key evidence in #322's WebKitGTK churn investigation, previously indistinguishable from a merely disabled+hidden element.

## Suite guards (commit 2)

- **`test_tree_has_no_unknown_roles`** — opt-in per app config; asserts the tree contains no `unknown` roles and prints each offender's raw platform role. Enabled for gtk and accesskit (verified against live AT-SPI sessions); other apps carry explicit not-yet-verified/cannot markers. This closes the process hole that let the map gaps ship: `strict-roles` only runs against the AccessKit app, so unmapped roles in the diverse-toolkit matrix cells degraded silently.
- **`table_cell_values`** — WebKitGTK exposes cell text via the AT-SPI Text interface, which xa11y surfaces as the cell's `value`; asserted for tauri on Linux so `table_cell[value*=…]` selectors stay usable.
- Docs: WebKitGTK caveats (`<th>` churn, layout-table heuristic, Text-interface cell content); the cocoa cell-based Items list documented as a deliberate legacy-path fixture.

## Known items deliberately NOT in this PR

- **macOS `stable_id` non-uniqueness** (all Qt table nodes share the table's `AXIdentifier`) — needs a design decision, since any fix changes existing IDs for consumers.
- **Upstream reports**: the WebKitGTK `<th>` churn (minimal repro exists) and AccessKit's UIA adapter exposing no table patterns.
- The WPF `Custom`+TableItem fix has unit tests but no integration app exercising it — see the WinForms/WPF test-matrix discussion on the thread.

## Verification

`cargo xtask check` green; AccessKit Linux integ 133/133; gtk suite 34 passed and accesskit 30 passed in attach mode with the unknown-role guard active; tauri suite 85 passed in the CI-mirrored environment; `xa11y-windows` and `xa11y-macos` clippy-clean under `-Dwarnings` for their native targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aGqnGwX7BxGBSDo3Rt1rG