### PR TITLE
Run the CLI suite on Windows, and make silent suite skips impossible (#327)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
           # AccessKit on macOS/Windows is covered by the Windows Rust integ
           # job and the local macOS harness; those integ cells ran no language
           # suites (cli+js are skipped for accesskit, and python is skipped off
-          # Linux — see suite_skips_by_app in tests/harness/launch.py), so they
+          # Linux — see declared_suite_skips in tests/harness/launch.py), so they
           # only burned a build with nothing to test. Dropped.
           - { os: ubuntu-latest,  app: qt }
           - { os: ubuntu-latest,  app: gtk }
@@ -657,6 +657,14 @@ jobs:
       - name: Run tests
         working-directory: xa11y-python
         run: ../.venv/bin/pytest tests/ -v
+
+      # The shared integ harness (tests/harness/launch.py) decides which suites
+      # run in every `integ` matrix cell, so its bugs are invisible by
+      # construction — it stops covering something and the cell stays green
+      # (issue #327). Its self-tests launch no app and need no bindings, so
+      # they ride along in this job, which already has a venv with pytest.
+      - name: Run integ-harness self-tests
+        run: .venv/bin/pytest tests/harness -v
 
   # ── Docs build ──────────────────────────────────────────────────
   docs:

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,45 +22,45 @@ accessibility-framework compatibility. Testing them against every app would be r
 The vehicle is the Tauri app (it runs on Linux, macOS, and Windows), which also has a
 dedicated event-log page for verifying synthesised pointer and keyboard events end-to-end.
 
-The JS integ suite additionally has smoke tests for input_sim and screenshot against the
-AccessKit app; these complement (not duplicate) the Tauri Python tests.
+The JS integ suite additionally has smoke tests for input_sim and screenshot; they gate
+themselves to the Tauri and Electron apps (see the top of
+`tests/suites/js/03_input_sim.test.js` and `04_screenshot.test.js`) and complement — not
+duplicate — the Tauri Python tests.
 
 ### Per-app compat tests verify a11y API surface compatibility
 
 These tests (find, tree navigation, roles, widget discovery, actions, events) confirm that
 each framework's accessibility API works correctly end-to-end with xa11y. They are written
-in Python (primary) and JS (partial coverage). CLI integration tests do not yet exist —
-see Known Gaps.
+in Python (primary), JS, and CLI (`tests/suites/cli/`, which drives the `xa11y`
+binary against the live app).
 
 ---
 
 ## Coverage Matrix
 
-`✅` = covered | `❌` = not covered (gap) | `⚠️` = partial or platform-limited
+The coverage index lives in [`matrix.yaml`](matrix.yaml) and is rendered — and
+validated — by:
 
-| App        | Platform(s)           | Python compat | Python actions | Python events | Python input_sim | Python screenshot | JS compat | JS actions | JS input_sim | JS screenshot | CLI |
-|------------|-----------------------|:-------------:|:--------------:|:-------------:|:----------------:|:-----------------:|:---------:|:----------:|:------------:|:-------------:|:---:|
-| accesskit  | linux, macos, windows | ✅¹           | ✅¹            | ⚠️¹           | —                | —                 | ✅        | ✅         | ✅²          | ✅²           | ❌  |
-| qt         | linux, macos, windows | ✅            | ✅             | ✅            | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
-| gtk        | linux                 | ✅            | ✅             | ❌³           | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
-| cocoa      | macos                 | ✅            | ✅             | ✅            | —                | —                 | ❌        | ❌         | —            | —             | ❌  |
-| tauri      | linux, macos, windows | ✅            | ✅             | ✅            | ✅               | ✅                | ❌        | ❌         | —            | —             | ❌  |
-| electron   | linux                 | ❌            | ❌             | ❌            | —                | —                 | ✅        | ✅         | ✅²          | ✅²           | ❌  |
+```bash
+python tests/matrix_check.py     # or: cargo xtask test-matrix-check
+```
 
-**Notes:**
-1. The accesskit Python compat/actions suites run **on Linux only** (the harness gates this on `sys.platform`). Linux is where AccessKit's AT-SPI bridge — and its `"click"`-not-`"toggle"` action naming, which the toggle()-via-press fallback in `xa11y-linux/src/atspi.rs` depends on — is exercised. The events module also runs but its assertions are `xfail`-guarded (⚠️). On macOS/Windows the Rust integ suite in `xa11y/tests/integ/` stays the canonical AccessKit coverage, so Python is not duplicated there.
-2. JS input_sim and screenshot run against the AccessKit app for the `integ` suite, and against Electron for the `integ-electron` suite.
-3. GTK has no event subscription tests. Only widget/compat and actions are covered.
+That command prints the per-app × per-language matrix, the documented gaps, and
+the platform exclusions, then checks two things CI enforces: that every empty
+cell has a matching documented gap, and that every claimed `(app, language,
+feature)` maps to a test file that actually exists.
 
----
+This README deliberately does **not** duplicate the table. It used to, and the
+copy rotted — it was still listing a `cli_integ` gap that no longer existed and
+omitting three test apps that had since landed.
 
-## Known Gaps
-
-| ID              | Description                                                                                  | Severity | Workaround                                               |
-|-----------------|----------------------------------------------------------------------------------------------|:--------:|----------------------------------------------------------|
-| `cli_integ`     | No CLI integration tests exist for any app. The `xa11y` binary is not exercised end-to-end against a live app in CI. | **high** | Unit tests in `xa11y-python/tests/test_cli.py` cover CLI error paths only. |
-| `js_app_coverage` | JS integ tests cover only the AccessKit app and Electron. No JS tests for Qt, GTK, Cocoa, or Tauri. | medium | Python suites cover those apps.                   |
-| `gtk_events`    | No event subscription tests for GTK. Only compat and actions are covered.                    | low      | GTK event subscription is exercised in the Rust integ suite via AT-SPI2. |
+> **A green matrix cell is not proof a suite ran.** `matrix_check.py` validates
+> claims against *test files on disk*, not against execution. What guarantees
+> execution is the harness: `tests/harness/launch.py` fails the run when a
+> requested suite cannot start, and prints a per-suite ledger at the end of
+> every cell saying whether each suite ran, was deliberately skipped
+> (`declared_suite_skips`), or did not run. See issue #327 for the four Windows
+> cells that claimed CLI coverage they had never once executed.
 
 ---
 
@@ -73,24 +73,32 @@ cargo xtask test-apps
 # Rust core suite (AccessKit app, fast-path)
 cargo xtask test-integ
 
-# Per-framework Python suites
+# Per-app suites. Each launches the app once and runs the python, js and cli
+# suites against it — the same tests/harness/launch.py entry point CI uses.
+# Pass an explicit suite list to narrow it, e.g. `cargo xtask test-qt python`.
 cargo xtask test-qt          # Qt/PySide6
 cargo xtask test-gtk         # GTK4
 cargo xtask test-cocoa       # Cocoa/AppKit (macOS only)
 cargo xtask test-tauri       # Tauri
+cargo xtask test-electron    # Electron (Linux only)
+cargo xtask test-egui        # egui/eframe
+cargo xtask test-winforms    # WinForms (Windows only)
+cargo xtask test-wpf         # WPF (Windows only)
 
-# JS integration tests (AccessKit app)
-cd xa11y-js && node --test __test__/integ/
-
-# JS Electron integration tests
-cd xa11y-js && node --test __test__/integ-electron/
+# Unit-test the harness itself (no app launched)
+cargo xtask test-harness
 
 # Linux integration tests via container
 cargo xtask test-integ-container
 
-# All pre-PR checks (fmt, lint, unit tests, Python bindings)
+# All pre-PR checks (fmt, lint, unit tests, Python bindings, harness)
 cargo xtask check
 ```
+
+The `cli` suite needs the `xa11y` binary (`cargo build -p xa11y`) and the `js`
+suite needs the built bindings; `scripts/run_app_suite.sh` builds both on
+demand. If the CLI binary is missing the harness **fails** rather than skipping
+— see the note under Coverage Matrix.
 
 CI configuration: see `.github/workflows/ci.yml`.
 
@@ -98,52 +106,40 @@ CI configuration: see `.github/workflows/ci.yml`.
 
 ## Test Layout
 
+The per-app suites are app-agnostic: one set of tests per language, parameterised
+by `XA11Y_TEST_APP`, rather than a directory per framework.
+
 ```
 tests/
   README.md            <- this file
   matrix.yaml          <- machine-readable coverage matrix
   matrix_check.py      <- CI validator (prints coverage summary; gaps must be documented)
   helpers.py           <- shared Python launch helpers (launch_test_app fixture)
-  qt/                  <- Qt/PySide6 Python integ tests
-    conftest.py
-    test_01_widgets.py     <- compat + actions
-    test_02_events.py      <- event subscription
-    test_03_a11y_tree.py   <- tree structure
-    test_04_widgets_extra.py
-  gtk/                 <- GTK4 Python integ tests
-    conftest.py
-    test_widgets.py        <- compat + actions (no events yet)
-  cocoa/               <- Cocoa/AppKit Python integ tests (macOS only)
-    conftest.py
-    test_01_widgets.py     <- compat + actions
-    test_02_events.py      <- event subscription
-    test_03_widgets_extra.py
-  tauri/               <- Tauri Python integ tests (all platforms)
-    conftest.py
-    test_01_widgets.py     <- compat + actions
-    test_02_events.py      <- event subscription
-    test_03_widgets_extra.py
-    test_input_sim.py      <- input simulation (one-per-platform)
-    test_screenshot.py     <- screenshot capture (one-per-platform)
+  harness/
+    launch.py          <- THE entry point: launches an app once, runs the
+                          requested suites against it, audits what actually ran
+    test_launch.py     <- unit tests for the harness (cargo xtask test-harness)
+  suites/
+    python/            <- Python integ suite (compat, actions, events, errors,
+                          input_sim, screenshot, foreground)
+    js/                <- JS integ suite (numbered NN_<feature>.test.js)
+    cli/               <- CLI integ suite — drives the `xa11y` binary
+                          (tree, find, actions, input_sim, screenshot)
 
 xa11y/tests/integ/     <- Rust core suite (AccessKit app, fast-path)
   mod.rs               <- shared helpers (app_tree, one, named, act)
   tree.rs              <- tree traversal + find
   actions.rs           <- press, toggle, focus, expand/collapse
+  errors.rs            <- error paths
+  multi_window.rs      <- multi-window traversal
   events_linux.rs      <- AT-SPI2 event subscription
   events_macos.rs      <- AX notification event subscription
   events_windows.rs    <- UIA event subscription
   screenshot.rs        <- screenshot capture
 
 xa11y-js/__test__/
-  integ/               <- JS integ tests (AccessKit app)
-    01_tree.test.js    <- compat
-    02_actions.test.js <- actions
-    03_input_sim.test.js
-    04_screenshot.test.js
-  integ-electron/      <- JS Electron integ tests
-    electron_a11y.test.js  <- compat + AccessibilityNotEnabled detection
   unit/                <- JS unit tests (no live app)
+  types/               <- TypeScript type tests
 
 xa11y-python/tests/    <- Python unit tests + CLI unit tests
   test_cli.py          <- CLI error-path unit tests (no live app)

--- a/tests/harness/launch.py
+++ b/tests/harness/launch.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -338,43 +339,90 @@ def _kill_app(proc: subprocess.Popen[bytes]) -> None:
 # CLI binary discovery
 # ---------------------------------------------------------------------------
 
-def _find_cli_binary() -> str | None:
-    """Return the path to the xa11y CLI binary, or None if not found."""
-    # Prefer the workspace debug build.
-    debug_bin = PROJECT_ROOT / "target" / "debug" / "xa11y"
-    if debug_bin.exists():
-        return str(debug_bin)
-    release_bin = PROJECT_ROOT / "target" / "release" / "xa11y"
-    if release_bin.exists():
-        return str(release_bin)
-    # Fall back to whatever is on PATH.
-    import shutil
+# `cargo build` emits `xa11y.exe` on Windows and bare `xa11y` everywhere else.
+# Probing without the suffix meant the CLI suite never once ran on a Windows
+# matrix cell (issue #327). `shutil.which` applies PATHEXT itself, so only the
+# explicit target/ probes below need the suffix.
+EXE_SUFFIX = ".exe" if sys.platform == "win32" else ""
+CLI_BINARY_NAME = f"xa11y{EXE_SUFFIX}"
+
+
+def cli_binary_candidates() -> list[Path]:
+    """The explicit build-output paths probed for the xa11y CLI, in order."""
+    return [
+        PROJECT_ROOT / "target" / "debug" / CLI_BINARY_NAME,
+        PROJECT_ROOT / "target" / "release" / CLI_BINARY_NAME,
+    ]
+
+
+def find_cli_binary() -> str | None:
+    """Return the path to the xa11y CLI binary, or None if not found.
+
+    Public because tests/suites/cli/conftest.py resolves the CLI through this
+    same function. It previously ran its own independent discovery, so the
+    binary the harness located had no effect on what the suite actually
+    executed — which is part of why the Windows suffix bug stayed invisible.
+    """
+    for candidate in cli_binary_candidates():
+        if candidate.is_file():
+            return str(candidate)
+    # Not a fallback in the tenet-1 sense: this is the last step of one
+    # tool-discovery probe, and coming up empty is a hard error at every call
+    # site (see cli_binary_not_found_message).
     return shutil.which("xa11y")
+
+
+def cli_binary_not_found_message() -> str:
+    """Explain exactly where the CLI was looked for and how to produce it."""
+    probed = "\n".join(f"  - {p}" for p in cli_binary_candidates())
+    return (
+        f"xa11y CLI binary ({CLI_BINARY_NAME}) not found. Probed:\n"
+        f"{probed}\n"
+        f"  - 'xa11y' on PATH\n"
+        f"Build it with: cargo build -p xa11y"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Suite runner
 # ---------------------------------------------------------------------------
 
-def _suite_command(suite: str) -> list[str]:
-    """Build the command to run a suite. JS test files are listed explicitly
-    because Node's ``--test`` flag does not auto-discover files in a directory
-    on all supported versions.
+def _suite_command(suite: str, report_path: Path) -> list[str]:
+    """Build the command to run a suite, writing a junit report to report_path.
+
+    Every suite reports in junit XML so the same "did this actually run
+    anything?" guard applies to all three (see _check_suite_ran_tests). JS test
+    files are listed explicitly because Node's ``--test`` flag does not
+    auto-discover files in a directory on all supported versions.
     """
     if suite == "python":
-        return [sys.executable, "-m", "pytest", "tests/suites/python/", "-v"]
+        return [
+            sys.executable, "-m", "pytest", "tests/suites/python/", "-v",
+            f"--junitxml={report_path}",
+        ]
     if suite == "cli":
-        return [sys.executable, "-m", "pytest", "tests/suites/cli/", "-v"]
+        return [
+            sys.executable, "-m", "pytest", "tests/suites/cli/", "-v",
+            f"--junitxml={report_path}",
+        ]
     if suite == "js":
         js_files = sorted(
             str(p.relative_to(PROJECT_ROOT))
             for p in (PROJECT_ROOT / "tests" / "suites" / "js").glob("*.test.js")
         )
-        return ["node", "--test", *js_files]
+        # Two reporters: `spec` keeps the human-readable log on stdout (the
+        # default reporter is replaced as soon as --test-reporter is passed),
+        # `junit` gives us the machine-readable copy to audit.
+        return [
+            "node", "--test",
+            "--test-reporter=spec", "--test-reporter-destination=stdout",
+            "--test-reporter=junit", f"--test-reporter-destination={report_path}",
+            *js_files,
+        ]
     raise ValueError(f"Unknown suite: {suite!r}")
 
 
-def _check_pytest_ran_tests(suite: str, junit_path: Path) -> int:
+def _check_suite_ran_tests(suite: str, report_path: Path) -> int:
     """Guard against a matrix cell silently running zero tests.
 
     pytest exits 5 when it *collects* nothing, which already fails the cell.
@@ -382,10 +430,16 @@ def _check_pytest_ran_tests(suite: str, junit_path: Path) -> int:
     looks green while covering nothing. Parse the junit report and require at
     least one executed (non-skipped) test.
 
+    Counting is done over ``<testcase>`` elements rather than the ``tests=`` /
+    ``skipped=`` attributes of ``<testsuite>``, because Node's junit reporter
+    emits top-level test cases as direct children of ``<testsuites>`` with no
+    enclosing ``<testsuite>`` at all. Per-case counting is correct for both
+    pytest's and Node's output.
+
     Returns 0 when the suite really executed tests, 1 otherwise.
     """
     try:
-        root = ET.parse(junit_path).getroot()
+        root = ET.parse(report_path).getroot()
     except (ET.ParseError, OSError) as exc:
         print(
             f"ERROR: {suite} suite produced no readable junit report "
@@ -393,11 +447,9 @@ def _check_pytest_ran_tests(suite: str, junit_path: Path) -> int:
         )
         return 1
 
-    total = skipped = 0
-    # The root is <testsuites> (or a bare <testsuite>); iter() covers both.
-    for ts in root.iter("testsuite"):
-        total += int(ts.get("tests", 0))
-        skipped += int(ts.get("skipped", 0))
+    cases = list(root.iter("testcase"))
+    total = len(cases)
+    skipped = sum(1 for case in cases if case.find("skipped") is not None)
 
     if total == 0:
         print(f"ERROR: {suite} suite reported zero collected tests.")
@@ -410,6 +462,59 @@ def _check_pytest_ran_tests(suite: str, junit_path: Path) -> int:
         return 1
     print(f"{suite} suite executed {total - skipped} tests ({skipped} skipped).")
     return 0
+
+
+def declared_suite_skips(app: str) -> set[str]:
+    """Suites this app deliberately does not run, by design.
+
+    A skip listed here is a *declared* one: it shows up in the end-of-run
+    ledger as an intentional exclusion. Anything else that fails to run is an
+    error, never a warning (issue #327).
+
+    The AccessKit app's widget schema differs from the shared OK-button
+    fixtures, so the CLI and JS suites (which have their own AccessKit
+    coverage) stay skipped for it.
+
+    The Python suite IS wired up for AccessKit (full APP_CONFIGS entry:
+    Submit/Cancel schema, single checkbox, no dialog), but only on Linux.
+    Linux is the one platform where AccessKit's AT-SPI bridge (accesskit_unix)
+    is exercised, and where its hardcoded "click"-not-"toggle" action naming
+    makes the toggle()-via-press fallback in xa11y-linux/src/atspi.rs
+    load-bearing — exactly the gap that went uncaught before (see
+    tests/matrix.yaml accesskit_python_compat_on_linux). On macOS/Windows the
+    Rust integ suite remains the canonical AccessKit coverage, so the Python
+    suite is skipped there.
+    """
+    if app != "accesskit":
+        return set()
+    skips = {"cli", "js"}
+    if sys.platform != "linux":
+        skips.add("python")
+    return skips
+
+
+# Ledger statuses, printed in the end-of-run recap.
+_RAN = "ran"
+_DECLARED_SKIP = "skipped (declared)"
+_DID_NOT_RUN = "DID NOT RUN"
+
+
+def _print_ledger(app: str, ledger: list[tuple[str, str, str]]) -> None:
+    """Print what each requested suite actually did.
+
+    The whole point of issue #327 is that "the CLI suite never ran" was
+    indistinguishable from "the CLI suite is not part of this cell". This
+    recap states the outcome of every requested suite explicitly, so a cell
+    that quietly stops covering something is visible in the log even before
+    the non-zero exit code lands.
+    """
+    width = max(len(name) for name, _, _ in ledger)
+    print(f"\n=== suite ledger for {app} ===")
+    for name, status, detail in ledger:
+        line = f"  {name:<{width}}  {status}"
+        if detail:
+            line += f" — {detail}"
+        print(line)
 
 
 def _run_suites(
@@ -425,69 +530,58 @@ def _run_suites(
     env["XA11Y_TEST_APP_NAME"] = discovered_name
 
     worst_rc = 0
+    ledger: list[tuple[str, str, str]] = []
 
-    # Per-app suite skips. The AccessKit app's widget schema differs from the
-    # shared OK-button fixtures, so the CLI and JS suites (which have their own
-    # AccessKit coverage) stay skipped for it.
-    #
-    # The Python suite IS wired up for AccessKit (full APP_CONFIGS entry:
-    # Submit/Cancel schema, single checkbox, no dialog), but only on Linux.
-    # Linux is the one platform where AccessKit's AT-SPI bridge
-    # (accesskit_unix) is exercised, and where its hardcoded
-    # "click"-not-"toggle" action naming makes the toggle()-via-press fallback
-    # in xa11y-linux/src/atspi.rs load-bearing — exactly the gap that went
-    # uncaught before (see tests/matrix.yaml accesskit_python_compat_on_linux).
-    # On macOS/Windows the Rust integ suite remains the canonical AccessKit
-    # coverage, so the Python suite is skipped there.
-    accesskit_skips = {"cli", "js"}
-    if sys.platform != "linux":
-        accesskit_skips.add("python")
-    suite_skips_by_app = {
-        "accesskit": accesskit_skips,
-    }
+    declared_skips = declared_suite_skips(app)
 
     for suite in suites:
-        if suite in suite_skips_by_app.get(app, set()):
+        if suite in declared_skips:
             print(
                 f"\nSkipping {suite} suite for {app} "
-                f"(see suite_skips_by_app in tests/harness/launch.py)"
+                f"(see declared_suite_skips in tests/harness/launch.py)"
             )
+            ledger.append((suite, _DECLARED_SKIP, f"declared for {app}"))
             continue
 
         if suite == "cli":
-            cli_bin = _find_cli_binary()
+            # A requested suite whose prerequisites are missing is an error,
+            # not a warning. This used to `continue` with a WARNING line, which
+            # is how the CLI suite went four Windows matrix cells and an
+            # unknown number of runs without ever executing (issue #327).
+            cli_bin = find_cli_binary()
             if cli_bin is None:
-                print(
-                    f"WARNING: xa11y CLI binary not found; skipping 'cli' suite. "
-                    f"Build it with: cargo build -p xa11y"
-                )
+                print(f"\nERROR: cannot run the cli suite against {app}.")
+                print(cli_binary_not_found_message())
+                ledger.append((suite, _DID_NOT_RUN, "xa11y CLI binary not found"))
+                worst_rc = max(worst_rc, 1)
                 continue
+            print(f"\nUsing xa11y CLI: {cli_bin}")
             suite_env = {**env, "XA11Y_CLI": cli_bin}
         else:
             suite_env = env
 
-        cmd = _suite_command(suite)
-
-        # pytest-based suites get a junit report so we can verify the cell
-        # actually executed tests (see _check_pytest_ran_tests).
-        junit_path: Path | None = None
-        if suite in ("python", "cli"):
-            fd, junit_name = tempfile.mkstemp(prefix=f"xa11y-{suite}-junit-", suffix=".xml")
-            os.close(fd)
-            junit_path = Path(junit_name)
-            cmd = [*cmd, f"--junitxml={junit_path}"]
+        fd, report_name = tempfile.mkstemp(prefix=f"xa11y-{suite}-junit-", suffix=".xml")
+        os.close(fd)
+        report_path = Path(report_name)
+        cmd = _suite_command(suite, report_path)
 
         print(f"\n=== Running {suite} suite against {app} ===\n")
         result = subprocess.run(cmd, env=suite_env, cwd=str(PROJECT_ROOT))
         rc = result.returncode
-        if junit_path is not None:
-            if rc == 0:
-                rc = _check_pytest_ran_tests(suite, junit_path)
-            junit_path.unlink(missing_ok=True)
+        if rc == 0:
+            rc = _check_suite_ran_tests(suite, report_path)
+        report_path.unlink(missing_ok=True)
+
         if rc != 0:
             print(f"\n--- {suite} suite exited with code {rc} ---")
+            ledger.append((suite, _RAN, f"failed (exit {rc})"))
+        else:
+            ledger.append((suite, _RAN, ""))
         if rc > worst_rc:
             worst_rc = rc
+
+    if ledger:
+        _print_ledger(app, ledger)
 
     return worst_rc
 

--- a/tests/harness/test_launch.py
+++ b/tests/harness/test_launch.py
@@ -1,0 +1,224 @@
+"""Unit tests for the shared integration-test harness.
+
+These are plain unit tests — they never launch a test app. They exist because
+the harness is the one piece of test infrastructure whose bugs are invisible by
+construction: when it declines to run a suite, the matrix cell stays green and
+nothing else in CI notices.
+
+Issue #327 is the worked example. `_find_cli_binary()` probed
+``target/debug/xa11y`` with no ``.exe`` suffix, so on Windows it never found
+the binary `cargo build --workspace` had just produced, and the harness skipped
+the CLI suite with a warning. Four Windows matrix cells claimed CLI coverage
+they had never once executed.
+
+Run with:  cargo xtask test-harness   (or: python -m pytest tests/harness)
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.harness import launch
+
+
+# ── CLI binary discovery (issue #327) ────────────────────────────────────────
+
+
+def test_cli_binary_name_carries_the_platform_exe_suffix():
+    """The probed filename must match what cargo actually emits per platform."""
+    if sys.platform == "win32":
+        assert launch.CLI_BINARY_NAME == "xa11y.exe"
+    else:
+        assert launch.CLI_BINARY_NAME == "xa11y"
+
+
+def test_cli_binary_candidates_probe_debug_then_release():
+    candidates = launch.cli_binary_candidates()
+    assert [p.parent.name for p in candidates] == ["debug", "release"]
+    assert all(p.name == launch.CLI_BINARY_NAME for p in candidates)
+    assert all(p.parent.parent.name == "target" for p in candidates)
+
+
+def test_find_cli_binary_finds_a_debug_build(tmp_path, monkeypatch):
+    """A binary at target/debug/<name> is found, suffix and all."""
+    debug_dir = tmp_path / "target" / "debug"
+    debug_dir.mkdir(parents=True)
+    built = debug_dir / launch.CLI_BINARY_NAME
+    built.write_text("")
+
+    monkeypatch.setattr(launch, "PROJECT_ROOT", tmp_path)
+    assert launch.find_cli_binary() == str(built)
+
+
+def test_find_cli_binary_prefers_debug_over_release(tmp_path, monkeypatch):
+    for profile in ("debug", "release"):
+        d = tmp_path / "target" / profile
+        d.mkdir(parents=True)
+        (d / launch.CLI_BINARY_NAME).write_text("")
+
+    monkeypatch.setattr(launch, "PROJECT_ROOT", tmp_path)
+    assert Path(launch.find_cli_binary()).parent.name == "debug"
+
+
+def test_find_cli_binary_ignores_a_suffixless_file_on_windows(tmp_path, monkeypatch):
+    """Guards the inverse of #327: on Windows a bare `xa11y` is not the binary.
+
+    On Windows `cargo build` never emits a suffixless `xa11y`, so if one is
+    present it is not the executable and must not be handed to the suite.
+    """
+    if sys.platform != "win32":
+        pytest.skip("suffix disambiguation only differs on Windows")
+    debug_dir = tmp_path / "target" / "debug"
+    debug_dir.mkdir(parents=True)
+    (debug_dir / "xa11y").write_text("")
+
+    monkeypatch.setattr(launch, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(launch.shutil, "which", lambda _name: None)
+    assert launch.find_cli_binary() is None
+
+
+def test_cli_binary_not_found_message_names_every_probed_location(tmp_path, monkeypatch):
+    monkeypatch.setattr(launch, "PROJECT_ROOT", tmp_path)
+    message = launch.cli_binary_not_found_message()
+    assert launch.CLI_BINARY_NAME in message
+    for candidate in launch.cli_binary_candidates():
+        assert str(candidate) in message
+    assert "cargo build -p xa11y" in message
+
+
+# ── A requested suite that cannot run is an error, never a warning ───────────
+
+
+class _FakeProc:
+    pid = 4242
+
+
+def test_missing_cli_binary_fails_the_run(tmp_path, monkeypatch, capsys):
+    """The core regression guard: no binary, no silent skip.
+
+    Before #327 this path printed a WARNING and `continue`d, so the harness
+    exited 0 having run nothing.
+    """
+    monkeypatch.setattr(launch, "find_cli_binary", lambda: None)
+
+    rc = launch._run_suites("qt", ["cli"], _FakeProc(), "xa11y-qt-test-app")
+
+    assert rc != 0, "a requested suite that could not run must fail the harness"
+    out = capsys.readouterr().out
+    assert "ERROR" in out
+    assert launch._DID_NOT_RUN in out
+
+
+def test_declared_skip_is_not_an_error(monkeypatch, capsys):
+    """Declared per-app skips stay green — they are documented exclusions."""
+    assert "cli" in launch.declared_suite_skips("accesskit")
+
+    rc = launch._run_suites("accesskit", ["cli"], _FakeProc(), "xa11y-test-app")
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert launch._DECLARED_SKIP in out
+
+
+def test_no_app_declares_a_skip_except_accesskit():
+    """Keeps the exclusion list from quietly growing."""
+    for app in launch.VALID_APPS:
+        if app == "accesskit":
+            continue
+        assert launch.declared_suite_skips(app) == set(), (
+            f"{app} declares suite skips; add it to this test (and to "
+            f"tests/matrix.yaml) deliberately"
+        )
+
+
+def test_ledger_reports_every_requested_suite(monkeypatch, capsys):
+    """Every requested suite appears in the recap with an explicit outcome."""
+    monkeypatch.setattr(launch, "find_cli_binary", lambda: None)
+    monkeypatch.setattr(
+        launch.subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess(a[0] if a else [], 1),
+    )
+
+    launch._run_suites("qt", ["python", "js", "cli"], _FakeProc(), "app")
+
+    out = capsys.readouterr().out
+    assert "=== suite ledger for qt ===" in out
+    for suite in ("python", "js", "cli"):
+        assert suite in out
+
+
+# ── Zero-executed-test guard ─────────────────────────────────────────────────
+
+
+def _write(tmp_path: Path, xml: str) -> Path:
+    path = tmp_path / "report.xml"
+    path.write_text(xml)
+    return path
+
+
+def test_all_skipped_pytest_report_fails(tmp_path):
+    report = _write(
+        tmp_path,
+        """<testsuites><testsuite name="pytest" tests="2" skipped="2">
+             <testcase name="a"><skipped message="nope"/></testcase>
+             <testcase name="b"><skipped message="nope"/></testcase>
+           </testsuite></testsuites>""",
+    )
+    assert launch._check_suite_ran_tests("python", report) == 1
+
+
+def test_partially_skipped_pytest_report_passes(tmp_path):
+    report = _write(
+        tmp_path,
+        """<testsuites><testsuite name="pytest" tests="2" skipped="1">
+             <testcase name="a"><skipped message="nope"/></testcase>
+             <testcase name="b"/>
+           </testsuite></testsuites>""",
+    )
+    assert launch._check_suite_ran_tests("python", report) == 0
+
+
+def test_node_junit_top_level_cases_are_counted(tmp_path):
+    """Node emits top-level cases as direct children of <testsuites>.
+
+    Counting the `tests=`/`skipped=` attributes of <testsuite> — as the old
+    implementation did — would see zero here and fail a healthy JS run.
+    """
+    report = _write(
+        tmp_path,
+        """<testsuites>
+             <testcase name="one" classname="test"/>
+             <testcase name="two" classname="test"><skipped type="skipped"/></testcase>
+             <testsuite name="grp" tests="1" skipped="0">
+               <testcase name="three" classname="test"/>
+             </testsuite>
+           </testsuites>""",
+    )
+    assert launch._check_suite_ran_tests("js", report) == 0
+
+
+def test_empty_report_fails(tmp_path):
+    report = _write(tmp_path, "<testsuites></testsuites>")
+    assert launch._check_suite_ran_tests("js", report) == 1
+
+
+def test_unreadable_report_fails(tmp_path):
+    assert launch._check_suite_ran_tests("js", tmp_path / "does-not-exist.xml") == 1
+
+
+# ── Every suite is audited ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("suite", launch.VALID_SUITES)
+def test_every_suite_writes_a_junit_report(suite, tmp_path):
+    """No suite may opt out of the did-anything-run audit."""
+    report = tmp_path / "report.xml"
+    cmd = launch._suite_command(suite, report)
+    assert any(str(report) in arg for arg in cmd), (
+        f"{suite} suite command does not write a junit report: {cmd}"
+    )

--- a/tests/suites/cli/conftest.py
+++ b/tests/suites/cli/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -11,6 +10,7 @@ from typing import Generator
 
 import pytest
 
+from tests.harness.launch import cli_binary_not_found_message, find_cli_binary
 from tests.helpers import launch_test_app
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
@@ -255,24 +255,28 @@ _LAUNCHERS = {
 def cli_bin() -> list[str]:
     """Return the command prefix to invoke the xa11y CLI.
 
-    Tries, in order:
-    1. An installed ``xa11y`` binary on PATH.
-    2. ``python -m xa11y._cli`` if the xa11y Python package is importable.
-    Falls back to skipping the entire session if neither is found.
+    ``XA11Y_CLI`` — set by tests/harness/launch.py — is authoritative when
+    present. Before issue #327 this fixture ran its own discovery and ignored
+    the harness's choice entirely, so under CI it silently exercised the
+    ``python -m xa11y._cli`` wrapper rather than the ``xa11y`` binary the
+    harness had located and the workspace build had just produced.
+
+    Standalone runs (no harness) fall back to the *same* discovery function the
+    harness uses, so both paths agree on what "the CLI" is. Not finding one is
+    a hard failure: a session-wide skip here is indistinguishable from "the CLI
+    is intentionally not covered", which is the exact failure mode this suite
+    is meant to catch.
     """
-    found = shutil.which("xa11y")
-    if found:
-        return [found]
+    from_env = os.environ.get("XA11Y_CLI")
+    if from_env:
+        if not Path(from_env).is_file():
+            pytest.fail(f"XA11Y_CLI points at a non-existent file: {from_env}")
+        return [from_env]
 
-    result = subprocess.run(
-        [sys.executable, "-c", "import xa11y; print('ok')"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        return [sys.executable, "-m", "xa11y._cli"]
-
-    pytest.skip("xa11y CLI not found — install xa11y-python first")
+    found = find_cli_binary()
+    if found is None:
+        pytest.fail(cli_binary_not_found_message())
+    return [found]
 
 
 # ── run_cli helper ────────────────────────────────────────────────────────────
@@ -283,10 +287,16 @@ def run_cli(cli_bin: list[str]):
     """Return a callable that runs the CLI and returns (returncode, stdout, stderr)."""
 
     def _run(*args: str, **kwargs) -> tuple[int, str, str]:
+        # Decode as UTF-8 explicitly. The CLI writes UTF-8 (the tree formatter
+        # emits box-drawing connectors), but `text=True` alone decodes with the
+        # locale encoding — cp1252 on Windows runners — which silently turns
+        # those connectors into mojibake instead of failing loudly.
         result = subprocess.run(
             cli_bin + list(args),
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             **kwargs,
         )

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,13 +31,14 @@ COMMANDS:
     test-apps           Run the Python suite for every app (qt, gtk, cocoa, tauri, electron, egui, winforms, wpf)
     test-compat [APP]   Run shared harness (python + js + cli suites) against APP (default: tauri)
     test-matrix-check   Validate the tests/matrix.yaml coverage index
+    test-harness        Unit-test the shared integ harness (tests/harness/)
     docs                Build documentation
     coverage            Generate code coverage report
     fuzz [ARGS..]       Run provider fuzzer (pass-through args)
     sync-readmes [--check]  Generate crates.io/PyPI READMEs from root README.md
     check-macos-ffi     Verify xa11y-macos/src/ax.rs only uses safe_* CF/AX wrappers
     check-bindings-parity  Verify Python/JS bindings mirror xa11y-core's public API
-    check               Run ALL pre-PR checks (fmt, lint, test, test-python, test-js, docs)
+    check               Run ALL pre-PR checks (fmt, lint, test, test-python, test-js, test-harness)
     help                Show this help
 ";
 
@@ -69,6 +70,7 @@ fn main() -> ExitCode {
         "test-apps" => do_test_apps(),
         "test-compat" => do_test_compat(rest),
         "test-matrix-check" => do_test_matrix_check(),
+        "test-harness" => do_test_harness(),
         "docs" => do_docs(),
         "coverage" => do_coverage(),
         "fuzz" => do_fuzz(rest),
@@ -503,6 +505,18 @@ fn do_test_matrix_check() -> bool {
     heading("Test coverage matrix check");
     let root = project_root();
     run_in("python", &["tests/matrix_check.py"], &root)
+}
+
+/// Unit-test the shared integration harness itself.
+///
+/// The harness decides which suites run in every CI matrix cell, so a bug in
+/// it is invisible: it just stops covering something and the cell stays green
+/// (issue #327). These tests never launch an app — plain pytest, no venv, no
+/// bindings required.
+fn do_test_harness() -> bool {
+    heading("Integ harness self-tests");
+    let root = project_root();
+    run_in("python", &["-m", "pytest", "tests/harness", "-v"], &root)
 }
 
 fn do_docs() -> bool {
@@ -1758,6 +1772,12 @@ fn do_check() -> bool {
     heading("PRE-PR CHECK: test-js");
     if !do_test_js() {
         eprintln!("!! JS unit tests failed.");
+        ok = false;
+    }
+
+    heading("PRE-PR CHECK: test-harness");
+    if !do_test_harness() {
+        eprintln!("!! Integ harness self-tests failed.");
         ok = false;
     }
 


### PR DESCRIPTION
Fixes #327.

`_find_cli_binary()` probed `target/debug/xa11y` with no executable suffix, so on Windows — where `cargo build --workspace` emits `xa11y.exe` — it never found the binary it had just built. The harness took the skip branch, printed a warning, and the cell stayed green. **The CLI suite has never executed on any Windows integ cell**: `qt`, `egui`, `winforms`, and `wpf` all claimed `cli: [compat, actions]` coverage they had never once run.

The suffix bug is one line. Why it survived is the interesting part, and this PR closes all three mechanisms that hid it.

## 1. Probe the right filename

`CLI_BINARY_NAME` now carries the platform executable suffix. `shutil.which` already applies `PATHEXT` itself, so only the two explicit `target/` probes needed changing.

## 2. A requested suite that cannot run is an error, not a warning

The missing-binary branch used to `continue`. It now records the failure, prints every location it probed plus how to build the binary, and fails the harness.

Every run also ends with a per-suite ledger, so "the CLI suite never ran" is no longer indistinguishable from "the CLI suite isn't part of this cell":

```
=== suite ledger for wpf ===
  python  ran
  js      ran
  cli     ran
```

The per-app skip map is now `declared_suite_skips()` — named to make the distinction between a *declared* exclusion (green) and a suite that merely failed to start (red) explicit.

## 3. The suite now actually uses the binary the harness found

`XA11Y_CLI` was set by the harness and read by nobody. The `cli_bin` fixture ran its own independent discovery and, in CI, landed on the `python -m xa11y._cli` wrapper rather than the built binary — so the harness's CLI discovery had **no observable effect anywhere**. That is the deeper reason nothing noticed it was broken on Windows: the suite passed on Linux and macOS via a completely different code path.

The fixture now honours `XA11Y_CLI`, falls back to the *same* discovery function the harness uses, and hard-fails instead of skipping the session. On Linux/macOS this switches the suite from the Python wrapper to the `xa11y` binary; both go through the same `xa11y::cli::run`, and `scripts/run_app_suite.sh` already builds the binary for the `cli` suite.

## Supporting changes

- **The zero-executed-tests guard now covers all three suites.** `_check_pytest_ran_tests` only ran for the two pytest suites — the JS suite could skip everything and exit 0. Renamed to `_check_suite_ran_tests`; every suite now writes a junit report (`node --test` gets `--test-reporter=spec` for the human log plus `--test-reporter=junit` for the audit). Node emits top-level cases as direct children of `<testsuites>`, so counting moved from `<testsuite tests=/skipped=>` attributes to `<testcase>` elements — correct for both reporters.
- **`run_cli` decodes as UTF-8 explicitly.** `text=True` alone uses the locale encoding — cp1252 on Windows runners — which would turn the tree formatter's box-drawing connectors into mojibake rather than failing loudly.
- **`tests/harness/test_launch.py`** unit-tests the harness: suffix handling, debug-over-release preference, the hard-fail path, the ledger, and a parametrised check that no suite can opt out of the audit. Wired up as `cargo xtask test-harness`, added to `cargo xtask check`, and run in CI's Python bindings job (which already has a venv with pytest).
- **`tests/README.md`** had drifted badly — it duplicated the coverage matrix by hand (still listing a `cli_integ` gap that no longer exists, omitting egui/winforms/wpf) and documented a per-framework `tests/qt/`, `tests/tauri/` layout that no longer exists. The duplicated tables are replaced with a pointer to the CI-validated `matrix.yaml` / `matrix_check.py`; the layout section now matches reality.

## Note on the blast radius

Per the issue, this lights up four matrix cells at once, which is why it lands on its own PR. If `tests/suites/cli/` has Windows-specific problems, they will surface here — those are real gaps this was hiding, and I'll drive CI to green.

## Testing

- `python -m pytest tests/harness -v` — 17 passed, 1 skipped (the Windows-only suffix-disambiguation case)
- `python tests/matrix_check.py` — matrix consistent, reality check OK
- `cargo fmt --all --check`, `cargo clippy -p xtask --all-targets` — clean

The CLI binary can't be built in this environment (`libxkbcommon` is unavailable for linking), so the end-to-end suite run is CI's to verify.

---
_Generated by [Claude Code](https://claude.ai/code/session_015vApuMoDCgk8CBCLParhgN)_