### PR TITLE
Check _native.pyi signatures against the compiled module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,19 @@ Interface declarations are the other case: `declare module './native.js' { inter
 
 `native.d.ts` is generated, so a `MouseButton` parameter arrives as plain `string`. Add an entry to `xa11y-js/scripts/patch-native-dts.mjs` narrowing it to a literal union (`MouseButtonName`, `AnchorName`, …), and export the alias from `index.d.ts`. Each entry is a guarded substitution — `all: N` asserts the occurrence count, so a new call site that quietly picks up the wide type fails the build instead of shipping.
 
+### Signatures are checked on the Python side only
+
+The parity check compares member **names**. Signature drift — an added parameter, a renamed keyword, a changed default — is caught by `test_stub_method_signatures_match_runtime` in `xa11y-python/tests/test_typing.py`.
+
+It works because PyO3 emits a `__text_signature__` for every method, so `inspect.signature` reports the compiled module's real parameter names, keyword-only split, and defaults. The stub is then checkable against the thing it claims to describe, with no Rust parsing and no extra dependency. Dunders are compared by arity only: the interpreter invokes them positionally, and PyO3 owns the rendered signature of slot-backed ones (`Rect.__eq__` reports its parameter as `value` whatever the Rust source calls it).
+
+Two things it deliberately does not do:
+
+- **Types are not compared.** PyO3 attaches no annotations, so `param: str` in the stub has no runtime counterpart. Catching a wrong *type* still needs the Rust→PyO3 mapping table.
+- **There is no JS equivalent.** napi-generated prototype methods report `Function.length === 0`, so there is no arity to compare — and `native.d.ts` is generated from the Rust anyway, so only the hand-written `index.d.ts` wrapper layer could drift. `__test__/unit/typing.test.js` covers that at name level.
+
+Generating `_native.pyi` instead (with `pyo3-stub-gen`) is blocked: every version fails to compile against a PyO3 built with `abi3-py39`, which is what lets one wheel serve every Python version. See the notes on issue #331.
+
 ### Notes
 
 - `#[doc(hidden)]` items are not public API and never need an allowlist entry — rustdoc excludes them.

--- a/xa11y-python/tests/test_typing.py
+++ b/xa11y-python/tests/test_typing.py
@@ -2,6 +2,7 @@
 
 import ast
 import importlib.resources as resources
+import inspect
 
 import xa11y
 from xa11y import _native
@@ -190,3 +191,163 @@ def test_stub_file_exists():
     files = resources.files("xa11y")
     stub = files / "_native.pyi"
     assert stub.is_file()
+
+
+# ── Signature parity ─────────────────────────────────────────────────────────
+#
+# The checks above compare member *names*. Renaming `Screenshot.to_png` to
+# `to_pngg` is caught there; changing only its signature was caught by
+# nothing — not by `cargo xtask check-bindings-parity` (names only) and not
+# by a type checker, which has no source of truth beyond the stub itself.
+#
+# PyO3 emits a `__text_signature__` for every method, so `inspect.signature`
+# reports the real parameter names, keyword-only split, and default values of
+# the compiled module. That makes the stub checkable against the thing it
+# claims to describe, with no Rust parsing and no extra dependency.
+#
+# What this does NOT compare is *types*: PyO3 attaches no annotations, so
+# `param: str` in the stub has no runtime counterpart. Catching a wrong type
+# annotation needs the Rust->PyO3 type-mapping table tracked separately.
+
+
+def _normalise_default(value: object) -> str:
+    """Render a runtime default the way ``ast.unparse`` renders a stub one."""
+    if value is Ellipsis:
+        return "..."
+    return repr(value)
+
+
+def _stub_shape(fn: ast.FunctionDef) -> tuple[list[str], list[str], dict[str, str]]:
+    """Positional names, keyword-only names, and defaults declared in the stub."""
+    args = fn.args
+    positional = [p.arg for p in args.args if p.arg not in ("self", "cls")]
+    keyword_only = sorted(p.arg for p in args.kwonlyargs)
+
+    defaults: dict[str, str] = {}
+    # Defaults align to the *tail* of the positional list.
+    for param, default in zip(args.args[len(args.args) - len(args.defaults) :], args.defaults):
+        defaults[param.arg] = ast.unparse(default)
+    for param, default in zip(args.kwonlyargs, args.kw_defaults):
+        if default is not None:
+            defaults[param.arg] = ast.unparse(default)
+    return positional, keyword_only, defaults
+
+
+def _runtime_shape(fn: object) -> tuple[list[str], list[str], dict[str, str]] | None:
+    """The same shape, read off the compiled module. ``None`` when PyO3
+    exposes no signature (slot wrappers without a text signature)."""
+    try:
+        signature = inspect.signature(fn)  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        return None
+
+    positional: list[str] = []
+    keyword_only: list[str] = []
+    defaults: dict[str, str] = {}
+    for name, param in signature.parameters.items():
+        if name in ("self", "cls"):
+            continue
+        if param.kind is param.KEYWORD_ONLY:
+            keyword_only.append(name)
+        elif param.kind is param.VAR_POSITIONAL:
+            positional.append(f"*{name}")
+        elif param.kind is param.VAR_KEYWORD:
+            keyword_only.append(f"**{name}")
+        else:
+            positional.append(name)
+        if param.default is not param.empty:
+            defaults[name] = _normalise_default(param.default)
+    return positional, sorted(keyword_only), defaults
+
+
+def _is_property(fn: ast.FunctionDef) -> bool:
+    return any(isinstance(d, ast.Name) and d.id == "property" for d in fn.decorator_list)
+
+
+def _signature_problems(label: str, stub: ast.FunctionDef, runtime: object) -> list[str]:
+    shape = _runtime_shape(runtime)
+    if shape is None:
+        return []
+    rt_positional, rt_keyword_only, rt_defaults = shape
+    st_positional, st_keyword_only, st_defaults = _stub_shape(stub)
+
+    # Dunders are invoked positionally by the interpreter, and PyO3 owns the
+    # rendered signature of slot-backed ones — `Rect.__eq__` reports its
+    # parameter as `value` no matter what the Rust source calls it. Compare
+    # how many parameters they take and leave the naming alone.
+    if stub.name.startswith("__") and stub.name.endswith("__"):
+        if len(rt_positional) != len(st_positional):
+            return [
+                f"{label}: takes {len(rt_positional)} argument(s), "
+                f"stub declares {len(st_positional)}"
+            ]
+        return []
+
+    problems = []
+    if rt_positional != st_positional:
+        problems.append(
+            f"{label}: positional parameters are {rt_positional}, stub declares {st_positional}"
+        )
+    if rt_keyword_only != st_keyword_only:
+        problems.append(
+            f"{label}: keyword-only parameters are {rt_keyword_only}, "
+            f"stub declares {st_keyword_only}"
+        )
+    if rt_defaults != st_defaults:
+        problems.append(f"{label}: defaults are {rt_defaults}, stub declares {st_defaults}")
+    return problems
+
+
+def test_stub_method_signatures_match_runtime():
+    """Every method the stub declares must have the signature the compiled
+    module actually exposes — parameter names, keyword-only split, defaults.
+
+    Members missing from one side entirely are the other tests' job; this one
+    compares the ones both sides agree exist.
+    """
+    tree = _load_stub_tree()
+    problems: list[str] = []
+    compared = 0
+
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        runtime_cls = getattr(_native, node.name, None)
+        if runtime_cls is None:
+            continue
+        for item in node.body:
+            if not isinstance(item, ast.FunctionDef) or _is_property(item):
+                continue
+            runtime_fn = getattr(runtime_cls, item.name, None)
+            if runtime_fn is None:
+                continue
+            compared += 1
+            problems.extend(_signature_problems(f"{node.name}.{item.name}", item, runtime_fn))
+
+    # A refactor that stopped resolving runtime members would otherwise make
+    # this test pass by comparing nothing at all.
+    assert compared > 50, f"only compared {compared} methods; the lookup is probably broken"
+    assert not problems, "stub signatures disagree with the native module:\n  " + "\n  ".join(
+        problems
+    )
+
+
+def test_stub_function_signatures_match_runtime():
+    """The same check for module-level functions."""
+    tree = _load_stub_tree()
+    problems: list[str] = []
+    compared = 0
+
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        runtime_fn = getattr(_native, node.name, None)
+        if runtime_fn is None:
+            continue
+        compared += 1
+        problems.extend(_signature_problems(node.name, node, runtime_fn))
+
+    assert compared >= 5, f"only compared {compared} functions; the lookup is probably broken"
+    assert not problems, "stub signatures disagree with the native module:\n  " + "\n  ".join(
+        problems
+    )


### PR DESCRIPTION
Issue #331, item 3.

## The gap

The parity check compares member **names**. Renaming `Screenshot.to_png` to `to_pngg` is caught; changing *only* its signature was caught by nothing — not by the name-level gates, and not by a type checker, which has no source of truth beyond the stub itself.

## The approach

PyO3 emits a `__text_signature__` for every method, so `inspect.signature` reports the compiled module's real parameter names, keyword-only split, and default values:

```
click        (self, /, target, *, button='left', count=1, held=None, anchor=None)
drag         (self, /, start, end, *, button='left', held=None, duration=0.15)
```

That makes the stub checkable against the thing it claims to describe — no Rust parsing, no new dependency, and the comparison is against what users actually get rather than against a second declaration.

The issue anticipated needing a "Rust→PyO3→napi type-mapping table" that "will be noisy up front". For names, kinds and defaults that turns out to be unnecessary: across the existing 100 methods and 8 module functions there were **three** divergences, all in dunders. So this lands as a hard gate with **no allowlist**.

Dunders compare by arity only. The interpreter invokes them positionally, and PyO3 owns the rendered signature of slot-backed ones — `Rect.__eq__` reports its parameter as `value` whatever the Rust source calls it, which is not something the stub can or should track.

## Verified against real mutations

| Mutation | Result |
|---|---|
| Rename keyword-only `button` → `buton` | caught |
| Change default `count=1` → `2` | caught |
| Add a phantom `extra: int = 0` parameter | caught |

Both tests also assert a floor on how much they compared — without it, a refactor that stopped resolving runtime members would leave them green while checking nothing.

## Two deliberate gaps

Written down in AGENTS.md rather than left implicit:

- **Types are not compared.** PyO3 attaches no annotations, so `param: str` in the stub has no runtime counterpart. A wrong *type* annotation still needs the mapping table.
- **No JS equivalent.** napi-generated prototype methods report `Function.length === 0`, so there is no arity to compare — and `native.d.ts` is generated from the Rust anyway, so only the hand-written `index.d.ts` layer can drift, which `__test__/unit/typing.test.js` covers by name.

## On item 4

I spiked `pyo3-stub-gen` first, as the cheaper way to close item 3 by construction. The issue's premise holds — it does carry doc comments through — but it is blocked: **every version fails to compile against a PyO3 built with `abi3-py39`** (0.23.0 on `PyEncodingWarning`, 0.8.2 on `PyDate`/`PyDateTime`, both absent from the limited API). Confirmed by flipping only that feature. abi3 is what lets one wheel serve every Python version, so that is not a trade worth making. Recorded in AGENTS.md and worth a note on #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfPJnjghsG5Qeo4VD6SX5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfPJnjghsG5Qeo4VD6SX5W)_