### PR TITLE
Add a comparison page

### DIFF
--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -45,6 +45,10 @@ export default defineConfig({
             { label: "Testing & Quality", slug: "guides/testing" },
           ],
         },
+        // Top-level rather than inside "Docs": the comparison page is an
+        // entry point for people evaluating xa11y against other tools, not
+        // reference material for people already using it.
+        { label: "Compare", slug: "compare" },
         {
           label: "API",
           items: [

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -12,7 +12,7 @@ The four mechanisms compose, and a practical setup often drives through accessib
 
 ## Accessibility-based libraries: xa11y, pywinauto, FlaUI, dogtail, atomacos
 
-The application exposes accessibility data — roles, names, values, states, bounds — and the tool reads it. Elements are addressed semantically, so a query costs microseconds and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test, and you automate the shipping binary. You see only what the app exposes, and where accessibility support is absent or wrong there is nothing to read.
+The application exposes accessibility data — roles, names, values, states, bounds — and the tool reads it. Elements are addressed semantically, so a query costs milliseconds or less and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test, and you automate the shipping binary. You see only what the app exposes, and where accessibility support is absent or wrong there is nothing to read.
 
 | Tool | Platforms | Languages |
 | --- | --- | --- |
@@ -27,7 +27,7 @@ Appium normalizes through the WebDriver protocol rather than a library API, so a
 
 ## Abstraction: platform mirrors versus a normalization layer
 
-The platform-specific libraries mostly mirror their underlying API almost exactly. pywinauto surfaces Win32 and UIA concepts directly, atomacos exposes AXUIElement attributes nearly raw, and dogtail exposes AT-SPI2's object model. That is predictable and gives you the full platform surface, including corners xa11y does not expose, but concepts, role names, and idioms differ per platform, so code written against one of them does not port, and supporting a second OS means rewriting against a different object model. xa11y instead normalizes, mapping one set of role names, one selector language, and one set of action verbs onto all three platform APIs, documented in [platform details](/guides/platform-details/). On one platform permanently, a library that mirrors that platform is more mature and exposes more of it; across two or three, the normalization is the point.
+The platform-specific libraries mostly mirror their underlying API. pywinauto surfaces Win32 and UIA concepts directly, atomacos exposes AXUIElement attributes nearly raw, dogtail exposes AT-SPI2's object model. That is predictable, and it gives you the full platform surface, including corners xa11y does not expose. But role names and idioms differ per platform, so code does not port, and a second OS means rewriting against a different object model. xa11y normalizes instead, mapping one set of roles, one selector language, and one set of action verbs onto all three platform APIs — see [platform details](/guides/platform-details/). On one platform permanently, the mirror is more mature and exposes more of it. Across two or three, the normalization is the point.
 
 ## Locators, auto-waiting, and stale handles
 
@@ -53,7 +53,7 @@ Squish (Qt Group, which acquired froglogic in 2021) is the only genuinely cross-
 
 Injection has costs beyond the price. It changes the process you are testing, and the hook must support your toolkit and your build. All three are licensed per seat and bundle a recorder, IDE, reporting, and support, which for testers who do not write code is the product.
 
-These three are compared here only at the level their public documentation supports. Much of their feature detail sits behind sales processes and evaluation licenses, so this page makes no feature-level claims about them, and the tables are a starting point for your own trial.
+Both tables draw on public documentation, so treat them as a starting point for an evaluation rather than a feature comparison.
 
 ## Pixels and screen parsing: SikuliX, PyAutoGUI, OmniParser
 
@@ -72,7 +72,7 @@ SikuliX and PyAutoGUI predate the model-based tools and share their failure mode
 
 An agent needs, on every step, an observation of the current UI and a way to act on it. The approaches differ mainly in how that observation is produced, and the differences compound because an agent observes many times per task.
 
-**Accessibility-driven.** The agent queries the semantic tree, directly through a library like xa11y or through a CLI or MCP tool built on one. An observation is microseconds of latency and a few hundred tokens once serialized, and it is deterministic. Elements carry exact bounds and identifiers, role plus name, that stay stable across renders and sessions, which is what lets a successful agent run harden into a repeatable script, since the selector it used yesterday still names the same button today. The app must expose accessibility data, and that data holds only what the app published.
+**Accessibility-driven.** The agent queries the semantic tree, directly through a library like xa11y or through a CLI or MCP tool built on one. An observation takes milliseconds or less and a few hundred tokens once serialized, and it is deterministic. Elements carry exact bounds and identifiers, role plus name, that stay stable across renders and sessions, which is what lets a successful agent run harden into a repeatable script, since the selector it used yesterday still names the same button today. The app must expose accessibility data, and that data holds only what the app published.
 
 **Screen-parsing models.** [OmniParser](https://github.com/microsoft/OmniParser), Microsoft's open-source screenshot-to-structured-elements model, is the canonical example. A detection model plus OCR reconstructs a pseudo-tree from pixels — bounding boxes, text, inferred interactability — for whatever is visible, which reaches applications with no accessibility support at all. In exchange, every observation costs a model inference, detection introduces error, and identifiers are synthesized per screenshot rather than stable across renders, so there is nothing durable to write a script against. Acting on the structure requires a separate executor.
 
@@ -82,7 +82,7 @@ An agent needs, on every step, an observation of the current UI and a way to act
 
 | Decision axis | Accessibility data | Screen parsing | End-to-end VLM |
 | --- | --- | --- | --- |
-| Latency per observation | Microseconds | Model inference | Model inference |
+| Latency per observation | Milliseconds or less | Model inference | Model inference |
 | Tokens per observation | Hundreds | Thousands and up | Thousands and up |
 | Reproducible output | Yes | No | No |
 | Identifiers stable across runs | Yes, selectors persist | No, synthesized per screenshot | No |

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -14,14 +14,14 @@ The four mechanisms compose, and a practical setup often drives through accessib
 
 The application exposes accessibility data — roles, names, values, states, bounds — and the tool reads it. Elements are addressed semantically, so a query costs microseconds and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test, and you automate the shipping binary. You see only what the app exposes, and where accessibility support is absent or wrong there is nothing to read.
 
-| Tool | Languages | Underlying API |
+| Tool | Platforms | Languages |
 | --- | --- | --- |
-| **xa11y** | Rust, Python, JavaScript | AXUIElement, UI Automation, AT-SPI2 |
-| [Appium](https://appium.io/) (Windows + Mac2 drivers) | Any WebDriver client | WinAppDriver, XCTest |
-| [pywinauto](https://pywinauto.readthedocs.io/) | Python | Win32, UI Automation |
-| [FlaUI](https://github.com/FlaUI/FlaUI) | C#/.NET | UI Automation (UIA2/UIA3) |
-| [dogtail](https://gitlab.com/dogtail/dogtail) | Python | AT-SPI2 |
-| [atomacos](https://github.com/daveenguyen/atomacos) | Python | AXUIElement |
+| **xa11y** | macOS, Windows, Linux | Rust, Python, JavaScript |
+| [Appium](https://appium.io/) (Windows + Mac2 drivers) | macOS, Windows | Any WebDriver client |
+| [pywinauto](https://pywinauto.readthedocs.io/) | Windows | Python |
+| [FlaUI](https://github.com/FlaUI/FlaUI) | Windows | C#/.NET |
+| [dogtail](https://gitlab.com/dogtail/dogtail) | Linux | Python |
+| [atomacos](https://github.com/daveenguyen/atomacos) | macOS | Python |
 
 Appium normalizes through the WebDriver protocol rather than a library API, so any WebDriver client works, though each desktop platform is a separate driver with separate capabilities. Its Windows driver proxies to Microsoft's WinAppDriver, which has had no release since 2022, while the Appium-side driver remains actively maintained. The Mac2 driver is built on XCTest, so every machine running tests needs Xcode installed.
 
@@ -39,15 +39,19 @@ An agent acting on a stale handle fails exactly the way a flaky test does, since
 
 ## Injection-based suites: Squish, Ranorex, TestComplete
 
-These suites mostly do **not** read accessibility data. They load a hook into the target process and read the toolkit's own object model — Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy — falling back to accessibility APIs where no dedicated hook exists. That reaches custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility, a structural capability xa11y cannot match without also injecting, which it deliberately does not do. In exchange, injection changes the process you are testing, and the hook must support your toolkit and build. All three are licensed per seat and bundle a recorder, IDE, reporting, and support, which for testers who do not write code is the product.
+These suites load a hook into the target process and read the toolkit's own object model — Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy — falling back to accessibility APIs where no dedicated hook exists. That reaches custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility. xa11y reads none of those, because it does not inject.
 
-| Tool | Languages | Primary mechanism |
+Each hook is written against a specific toolkit, so these tools enumerate support per app framework rather than per platform, and whether yours is on the list matters more than anything else about them.
+
+| Tool | Languages | App frameworks |
 | --- | --- | --- |
-| [Squish](https://www.qt.io/product/quality-assurance/squish) | Python, JavaScript, Perl, Ruby, Tcl | Toolkit introspection, deepest Qt/QML support |
-| [Ranorex Studio](https://www.ranorex.com/) | C#, VB.NET | UIA + .NET introspection |
-| [TestComplete](https://smartbear.com/product/testcomplete/) | Python, JavaScript, VBScript, JScript, DelphiScript | UIA + toolkit introspection incl. Delphi/VCL |
+| [Squish](https://www.qt.io/product/quality-assurance/squish) | Python, JavaScript, Perl, Ruby, Tcl | Qt/QML, Java, Windows, Web, mobile — licensed per edition |
+| [Ranorex Studio](https://www.ranorex.com/) | C#, VB.NET | WinForms, WPF, Qt, Java, Delphi, UWP, MSAA/UIA |
+| [TestComplete](https://smartbear.com/product/testcomplete/) | Python, JavaScript, VBScript, JScript, DelphiScript | .NET, WPF, Java, Delphi/C++Builder (VCL), Qt |
 
-Squish (Qt Group, which acquired froglogic in 2021) is the only genuinely cross-platform one, and reaches QML internals the accessibility projection omits. Ranorex Studio is Windows-hosted and Windows-targeted, with no native macOS app testing. TestComplete has the broadest legacy-toolkit coverage, including Delphi and VCL.
+Squish (Qt Group, which acquired froglogic in 2021) is the only genuinely cross-platform one, and reaches QML internals the accessibility projection omits. Its editions are licensed separately, so a Qt app and a Java app are two licenses. Ranorex Studio is Windows-hosted and Windows-targeted, with no native macOS app testing. TestComplete has the broadest legacy-toolkit coverage, including Delphi and VCL.
+
+Injection has costs beyond the price. It changes the process you are testing, and the hook must support your toolkit and your build. All three are licensed per seat and bundle a recorder, IDE, reporting, and support, which for testers who do not write code is the product.
 
 These three are compared here only at the level their public documentation supports. Much of their feature detail sits behind sales processes and evaluation licenses, so this page makes no feature-level claims about them, and the tables are a starting point for your own trial.
 

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -1,44 +1,27 @@
 ---
 title: Comparison
-description: How xa11y compares to pywinauto, Appium, FlaUI, Squish, Ranorex, TestComplete, SikuliX, and other desktop UI automation tools — and when to choose something else.
+description: How xa11y relates to pywinauto, FlaUI, Appium, dogtail, atomacos, Squish, Ranorex, TestComplete, SikuliX, OmniParser, and VLM computer-use agents — what each approach can and cannot do.
 ---
 
-xa11y drives native desktop applications by reading and acting on the **accessibility tree** — the same data screen readers consume — through one API on macOS, Windows, and Linux.
+xa11y drives native desktop applications by reading and acting on the **accessibility tree** — the same structured data screen readers consume — through one API on macOS (AXUIElement), Windows (UI Automation), and Linux (AT-SPI2). It is a library, MIT-licensed, currently at v0.12.0 and pre-1.0: breaking changes still land in minor releases. Bindings exist for Rust, Python (3.9+), and JavaScript, plus a [CLI](/guides/cli/) (`xa11y apps`, `xa11y tree --app <name>`, `xa11y find`).
 
-If the application you need to automate does not expose an accessibility tree, xa11y cannot help you, and no amount of configuration will change that. Games, canvas-rendered UIs, and apps built on toolkits that were never wired up for accessibility are all in this category. Skip to [when not to use xa11y](#when-not-to-use-xa11y) — the honest answer there is a commercial tool that injects into the process, or a pixel-based one.
+The tools in this space split along one technical line: what a tool treats as the source of truth about the screen. Everything else — what it can see, what breaks it, what it costs per operation — follows from that choice. This page walks through the categories in turn: open-source accessibility libraries, commercial injection-based suites, pixel and vision tools, and the approaches used for computer-use agents. If you already know the app you want to automate exposes no accessibility tree, xa11y cannot help — see [when not to use xa11y](#when-not-to-use-xa11y).
 
-## Choose by what you're doing
+## Four ways to see a UI
 
-| If you are… | Consider | Why |
-| --- | --- | --- |
-| Testing a desktop app on **more than one OS** from one test suite | **xa11y** | One selector language and one API across AXUIElement, UI Automation, and AT-SPI2. This is the case it exists for. |
-| Building a **computer-use agent** or MCP tool | **xa11y** | A semantic tree costs microseconds to query and far fewer tokens than a screenshot, and it works the same on all three platforms. [agent-desktop](https://agent-desktop.dev) is a ready-made CLI built on it. |
-| Testing a **Windows-only** app, and your team writes C# | [FlaUI](https://github.com/FlaUI/FlaUI) | A thin, well-maintained UIA wrapper with far more Windows-specific surface area than xa11y exposes. |
-| Testing a **Windows-only** app, and your team writes Python | [pywinauto](https://pywinauto.readthedocs.io/) or xa11y | pywinauto has a decade of accumulated Windows knowledge and a much larger body of examples. Choose xa11y if you expect to add macOS or Linux later. |
-| Already invested in **Appium/WebDriver** infrastructure | [Appium](https://appium.io/) | If you have a Selenium grid, reporting, and a team fluent in WebDriver, that consistency is worth more than a nicer local API. |
-| Testing a **Qt or QML** app in depth, with budget | [Squish](https://www.qt.io/product/quality-assurance/squish) | It reads Qt's own object model rather than the accessibility projection of it, reaching QML internals and custom widgets that expose nothing to AT-SPI2 or UIA. |
-| Staffing testers who **don't write code** | [Ranorex](https://www.ranorex.com/), [TestComplete](https://smartbear.com/product/testcomplete/), Squish | Record-and-playback, an IDE, reporting, and vendor support are the product. xa11y is a library with none of that. |
-| Automating an app with **no accessibility support** | [SikuliX](https://sikulix.github.io/), a VLM agent, or a commercial suite | No accessibility tool can drive what is not exposed. Match pixels, reason over screenshots, or inject into the process. |
-| Auditing an app for **accessibility conformance** | [axe](https://github.com/dequelabs/axe-core), [Accessibility Insights](https://accessibilityinsights.io/) | xa11y reads the accessibility tree to automate apps; it does not evaluate that tree against WCAG or produce conformance reports. |
-| Adding accessibility **to** an app you are writing | [AccessKit](https://accesskit.dev/) | The other side of the same interface. AccessKit publishes a tree; xa11y consumes one. |
+**Accessibility tree.** The application publishes a structured description of itself: roles, names, values, states, bounds. Elements are addressed semantically (`button[name='Submit']`), so a query costs microseconds and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test — you automate the shipping binary. The hard constraint is that you only see what the app exposes; where accessibility support is absent or wrong, there is nothing to read. xa11y, pywinauto, FlaUI, Appium's desktop drivers, dogtail, and atomacos work this way.
 
-## The fork in the road: how a tool sees the UI
+**Toolkit introspection.** The tool loads a hook into the target process and reads the toolkit's own object model — Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy — rather than the accessibility projection of it. This sees strictly more: custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility. The costs are that injection changes the process you are testing, the hook must support your toolkit and build, and in practice this is commercial territory. Squish, Ranorex, and TestComplete work this way, falling back to accessibility APIs where they lack a dedicated hook.
 
-Nearly every meaningful difference between these tools follows from one choice — what they treat as the source of truth about the screen.
+**Pixel matching.** Screenshot the screen, search for a reference image. Works on anything visible — including remote desktops and video — and breaks on theme, DPI, font-rendering, and antialiasing changes. It cannot read a value it was not given a picture of. SikuliX and PyAutoGUI work this way.
 
-**Accessibility tree.** The app publishes a structured description of itself: roles, names, values, states, bounds. Elements are addressed semantically (`button[name='Submit']`), so layout changes, themes, resolutions, and translations-in-progress don't break your selectors, and matching costs microseconds. Nothing is installed into the application under test — you automate the shipping binary. The cost is a hard dependency on the app's accessibility support: where it's absent or wrong, you get nothing. xa11y, pywinauto, FlaUI, Appium, dogtail, and atomacos live here.
+**Model-based vision.** A model interprets a screenshot, either producing structured elements (screen-parsing models such as OmniParser) or deciding the action directly (end-to-end VLM agents). Flexible on UI it has never seen, at the cost of a model inference per observation and non-deterministic output. Covered in detail [below](#computer-use-and-ai-agents).
 
-**Toolkit introspection.** The tool loads a hook into the application's process and reads the *real* widget objects — Qt's `QObject` tree, .NET's visual tree, Java's AWT/Swing hierarchy — rather than the accessibility projection of them. This sees strictly more than accessibility does: unnamed custom widgets, QML internals, private properties, and controls whose authors never implemented accessibility at all. The costs are that you need a build the hook supports, the injection changes the process you're testing, and this is almost exclusively commercial territory. Squish, Ranorex, and TestComplete live here, each falling back to accessibility APIs for the toolkits they lack a dedicated hook for.
+These mechanisms compose. A practical setup often drives through the tree and reaches for pixels or vision only where the tree has a hole. xa11y keeps that boundary explicit: [input simulation](/guides/input/) is a separate `InputSim` surface and never automatically substitutes for an accessibility action, so a passing test cannot silently degrade into blind coordinate clicking. That separation is a deliberate design rule, described in [Design](/guides/design/).
 
-**Pixel matching.** The tool screenshots the screen and looks for a reference image. It works on literally anything visible, including remote desktops and video. It also breaks on theme changes, DPI changes, font rendering differences, and antialiasing, and it cannot read a value it wasn't given a picture of. SikuliX and PyAutoGUI live here.
+## Accessibility-tree libraries
 
-**Vision-language models.** A model looks at a screenshot and decides where to click. Maximum flexibility, no reference images needed, and it tolerates UI it has never seen. It is also non-deterministic, costs a model call per step, and is orders of magnitude slower than a tree query. Increasingly these are used *with* an accessibility tree rather than instead of one — the tree gives exact bounds and stable identifiers, the model handles intent.
-
-The families are not mutually exclusive, and the strongest setups mix them: drive with the accessibility tree, fall back to pixels for the one canvas widget that has no tree. What matters is knowing which mechanism you are relying on for any given step. xa11y is deliberate about this line — its [input simulation](/guides/input/) is a separate surface that never silently substitutes for an accessibility action, so a passing test can't quietly degrade into blind coordinate clicking.
-
-## The landscape
-
-Open-source tools that read the accessibility tree, which is where xa11y competes most directly:
+The open-source tools that read the same data xa11y does:
 
 | Tool | Platforms | Languages | Underlying API | License |
 | --- | --- | --- | --- | --- |
@@ -49,31 +32,74 @@ Open-source tools that read the accessibility tree, which is where xa11y compete
 | [dogtail](https://gitlab.com/dogtail/dogtail) | Linux | Python | AT-SPI2 | GPL-2.0 |
 | [atomacos](https://github.com/daveenguyen/atomacos) | macOS | Python | AXUIElement | GPL-3.0 |
 
-Commercial suites, which bundle a recorder, an IDE, reporting, and support, and license per seat:
+Two structural differences separate xa11y from the rest of this table more than any feature checklist does.
 
-| Tool | Desktop targets | Languages | Primary mechanism | Notes |
-| --- | --- | --- | --- | --- |
-| [Squish](https://www.qt.io/product/quality-assurance/squish) | macOS, Windows, Linux | Python, JavaScript, Perl, Ruby, Tcl | Toolkit introspection (Qt, Java, native) | The only genuinely cross-platform option here. Unmatched Qt and QML depth. |
-| [Ranorex Studio](https://www.ranorex.com/) | Windows | C#, VB.NET | UIA + .NET introspection | Windows-hosted and Windows-targeted; no native macOS app testing. |
-| [TestComplete](https://smartbear.com/product/testcomplete/) | Windows | Python, JavaScript, VBScript, JScript, DelphiScript | UIA + .NET/Java/Delphi introspection | Broadest legacy-toolkit coverage, including Delphi and VCL. |
+### Abstraction level
 
-Pixel- and vision-based tools, which see the screen instead of the tree:
+The platform-specific libraries mostly mirror their underlying API almost exactly, adding little abstraction of their own. pywinauto surfaces Win32 and UIA concepts directly; atomacos exposes AXUIElement attributes nearly raw; dogtail exposes AT-SPI2's object model. That is a legitimate design choice — it is predictable, and it gives you the full platform surface, including corners xa11y does not expose. The consequence is that the concepts, role names, and idioms differ per platform, so code written against one of these libraries does not port; supporting a second OS means rewriting against a different library with a different object model.
+
+xa11y's contribution is the normalization layer: one set of role names, one selector language, one set of action verbs, mapped onto three quite different platform APIs. The [platform details](/guides/platform-details/) guide documents how each concept maps. The tradeoff runs both ways: if you are on one platform permanently, a library that mirrors that platform's API is more mature, better documented in Stack Overflow terms, and exposes more of it. If you need the same suite on two or three platforms, the normalization is the point.
+
+Appium sits between: it normalizes through the WebDriver protocol, so any WebDriver client works, but each desktop platform is a separate driver with separate capabilities. Two practical details if you evaluate it: the Windows driver proxies to Microsoft's WinAppDriver, which has had no release since 2022 (the Appium-side driver remains actively maintained), and the Mac2 driver is built on XCTest, so every machine running tests needs Xcode installed.
+
+### Locators, waiting, and staleness
+
+Most accessibility libraries hand you a captured node reference. That reference goes stale the moment the app redraws or replaces the subtree it came from, and the library leaves the resulting retry loops to you — the classic source of desktop-test flake, where a find succeeds and the click a few milliseconds later lands on a dead handle.
+
+xa11y's `Locator` is a lazy query instead: it re-resolves its selector on every operation and waits for the element to be visible and enabled before acting. (An `Element` in xa11y is the captured-handle form — it does not re-resolve — and the API keeps the two distinct.) The selector language is CSS-like: `button[name='Submit']`, `textfield[name^='Search']`, `group > button`, `:nth(2)`. The model is taken from Playwright's locators, adapted to accessibility trees.
+
+This matters beyond tests. An agent acting on a stale handle fails exactly the way a flaky test does — the UI changed between observation and action. A locator that re-resolves absorbs that race. And a selector is a compact, writable name for an element: an agent can carry `button[name='Save']` across turns of a conversation, or a person can paste it into a script, where a captured object reference cannot leave the process that made it. Most libraries in the table above have neither auto-waiting nor a selector language; you build both yourself.
+
+xa11y also exposes accessibility event streams (`app.subscribe()`) and [screenshots](/guides/screenshots/) of the full screen, a region, or an element's bounds. Platform prerequisites are minimal but real: macOS needs the Accessibility permission (plus Screen Recording on macOS 26+), Linux needs AT-SPI2 running, Windows needs nothing special.
+
+## Commercial suites
+
+The commercial desktop-testing suites mostly do **not** read the accessibility tree. They load a hook into the target process and read the toolkit's own object model, falling back to accessibility APIs where no dedicated hook exists. That lets them drive custom-drawn widgets that publish nothing to UIA or AT-SPI2 — a structural capability xa11y cannot match without also injecting, which it deliberately does not do. They are licensed per seat and bundle a recorder, an IDE, reporting, and vendor support; for a team of testers who do not write code, that bundle is the product, and xa11y offers none of it.
+
+| Tool | Desktop targets | Languages | Primary mechanism |
+| --- | --- | --- | --- |
+| [Squish](https://www.qt.io/product/quality-assurance/squish) | macOS, Windows, Linux | Python, JavaScript, Perl, Ruby, Tcl | Toolkit introspection (deepest Qt/QML support) |
+| [Ranorex Studio](https://www.ranorex.com/) | Windows | C#, VB.NET | UIA + .NET introspection |
+| [TestComplete](https://smartbear.com/product/testcomplete/) | Windows | Python, JavaScript, VBScript, JScript, DelphiScript | UIA + toolkit introspection incl. Delphi/VCL |
+
+Squish (Qt Group, which acquired froglogic in 2021) is the only genuinely cross-platform one, and reads Qt's object model directly — it reaches QML internals that the accessibility projection omits. Ranorex Studio is Windows-hosted and Windows-targeted, with no native macOS app testing. TestComplete has the broadest legacy-toolkit coverage, including Delphi and VCL.
+
+These three are compared here only at the level their public documentation supports — platforms, languages, mechanism. Much of their feature detail sits behind sales processes and evaluation licenses, so this page does not make feature-level claims about them; treat the table as a starting point for your own trial.
+
+## Pixel and vision tools
 
 | Tool | Platforms | Mechanism | Reads values? | License |
 | --- | --- | --- | --- | --- |
 | [SikuliX](https://sikulix.github.io/) | macOS, Windows, Linux | OpenCV image matching + OCR | Via OCR only | MIT |
 | [PyAutoGUI](https://github.com/asweigart/pyautogui) | macOS, Windows, Linux | Input synthesis + basic image matching | No | BSD-3-Clause |
-| VLM computer-use agents | Any | Model reasoning over screenshots | Via the model | Varies |
+| [OmniParser](https://github.com/microsoft/OmniParser) and similar screen parsers | Any | Detection model + OCR over screenshots | Via OCR | Open source (varies) |
+| End-to-end VLM computer-use agents | Any | Model reasoning over screenshots | Via the model | Varies |
 
-## Capabilities
+SikuliX and PyAutoGUI predate the model-based tools and share their failure mode in miniature: they see pixels, so anything that changes pixels without changing meaning — a theme, a DPI setting, font antialiasing — breaks the match. PyAutoGUI is primarily input synthesis; it cannot read a value out of the UI at all. The screen-parsing models and VLM agents in the bottom two rows are less automation libraries than components of agent systems, which is the subject of the next section.
 
-Comparing xa11y against the tools closest to it in scope, across both the open-source and commercial columns:
+## Computer use and AI agents
+
+An agent driving a desktop needs, on every step, an observation of the current UI and a way to act on it. The approaches in use differ mainly in how that observation is produced, and the differences compound because an agent observes many times per task.
+
+**Accessibility-tree-driven.** The agent queries the semantic tree — directly through a library like xa11y, or through a CLI or MCP tool built on one. An observation is a tree query: microseconds of latency, a few hundred tokens once serialized, and deterministic — the same UI state yields the same output every time. Elements come with exact bounds and identifiers (role plus name) that are stable across renders and across sessions, which is what makes it possible to write a repeatable script from an agent's successful run: the selector the agent used yesterday still names the same button today. The limit is inherited from the mechanism: the app must expose a tree, and the tree only contains what the app published.
+
+**Screen-parsing models.** [OmniParser](https://github.com/microsoft/OmniParser) — Microsoft's open-source screenshot-to-structured-elements model — is the canonical example of this category. A detection model plus OCR reconstructs a pseudo-tree from pixels: bounding boxes, text, and inferred interactability for whatever is visible. These work on anything on screen, including applications with no accessibility support at all, which is their reason to exist. In exchange, every observation costs a model inference, detection introduces error (missed elements, merged elements, wrong boxes), and the element identifiers are synthesized per screenshot — they are not stable across renders, so there is nothing durable to write a script against. Screen parsers are also not automation tools by themselves; they produce structure and rely on a separate executor to act.
+
+**End-to-end VLM agents.** The model looks at a screenshot and decides the action directly — Claude and OpenAI computer use, and similar systems. This is the most flexible option on UI nobody anticipated, since there is no intermediate representation to be wrong. It is also non-deterministic, the slowest per step, and carries the highest token cost per observation, because every step ships an image into a model and the reasoning happens in the loop.
+
+**Hybrid.** Increasingly the practical setup: use the accessibility tree for structure, element enumeration, and exact bounds, and bring in vision only for what the tree does not expose — a canvas region, an image, a custom widget with no accessibility support. The tree and the pixels are complementary observations of the same UI, not competing ones; a screenshot of an element's exact bounds (which the tree provides) is a much better vision input than a full-screen capture. xa11y's tree queries, element-bounds screenshots, and event streams are the tree-side half of this arrangement, and [agent-desktop](https://agent-desktop.dev) packages them as a CLI for agents.
+
+The decision axes are concrete. **Latency**: a tree query is microseconds; a model inference is hundreds of milliseconds to seconds. **Token cost per observation**: a serialized subtree is a few hundred tokens; screenshots and parsed screenshots are far more, and they recur on every step. **Determinism**: tree queries are reproducible, model output is not — which decides whether a failure can be replayed. **Identifier stability**: selectors survive across runs; synthesized boxes do not — which decides whether an agent's trajectory can harden into a script. **Coverage**: vision sees everything on screen; the tree sees only what the app exposes. Where an app has a usable tree, the tree-driven observation dominates on the first four axes; where it does not, vision is the only observation available. `xa11y tree --app <name>` answers in seconds which situation you are in.
+
+## Capability matrix
+
+xa11y against the tools closest to it in scope:
 
 | | xa11y | Appium | Squish | pywinauto | FlaUI |
 | --- | --- | --- | --- | --- | --- |
 | macOS / Windows / Linux | ● ● ● | ● ● ○ | ● ● ● | ○ ● ○ | ○ ● ○ |
 | Single API across platforms | ● | ● | ● | n/a | n/a |
-| CSS-like selectors | ● | XPath | Object map | Property dicts | Conditions API |
+| Selector language | CSS-like | XPath | Object map | Property dicts | Conditions API |
 | Auto-waiting on actions | ● | Configurable | ● | Explicit | Explicit |
 | Accessibility event streams | ● | ○ | ◐ | ○ | ● |
 | Screenshots | ● | ● | ● | ● | ● |
@@ -88,17 +114,11 @@ Comparing xa11y against the tools closest to it in scope, across both the open-s
 
 ● full · ◐ partial · ○ none
 
-Three rows deserve elaboration, and xa11y loses two of them.
-
-**Auto-waiting.** A `Locator` in xa11y is a lazy query, not a captured handle. Every action re-resolves the selector and waits for the element to be visible and enabled before acting, which removes the retry-loop scaffolding that desktop test suites usually accumulate. This is borrowed wholesale from [Playwright's locator model](https://playwright.dev/docs/locators). Tools that hand you a captured element instead make staleness your problem — a real source of flake when the app redraws between find and click.
-
-**Seeing non-accessible widgets.** This is the structural advantage the commercial suites have, and it is not one xa11y can engineer around — it follows from refusing to inject into the process under test. If your app has a custom-drawn control that publishes nothing to UIA or AT-SPI2, Squish can drive it through Qt's object model and xa11y cannot see it at all. Whether that matters depends entirely on your app; run `xa11y tree --app <name>` and look for the controls you care about before deciding.
-
-**Maturity.** xa11y is at v0.12 and its API is not yet stable. pywinauto, FlaUI, and the commercial suites have years of production use, deeper per-platform coverage, more Stack Overflow answers, and more people who have already hit your bug. If you are automating one Windows app and will never need another platform, that accumulated knowledge is worth more than anything on this page. Choosing xa11y is a bet that one cross-platform API saves you more than a mature single-platform one.
+Two rows where xa11y is behind deserve a plain statement. *Sees non-accessible widgets*: this follows from refusing to inject into the target process, and it is not something xa11y can engineer around — if a control publishes nothing to UIA or AT-SPI2, Squish can drive it through the toolkit's object model and xa11y cannot see it. *Maturity*: at v0.12.0 the API is not stable, and pywinauto, FlaUI, and the commercial suites have years of production use and deeper single-platform coverage. Choosing xa11y is a bet that one cross-platform API saves you more than a mature single-platform one; on one platform, permanently, it may not.
 
 ## Framework coverage
 
-The practical question for an accessibility-driven tool is not which platforms it claims but which UI toolkits actually work, since coverage depends on each toolkit's accessibility implementation. xa11y runs its integration suite against real applications in CI on every commit:
+For an accessibility-driven tool, the practical question is not which platforms it claims but which UI toolkits actually work, because coverage depends on each toolkit's accessibility implementation. xa11y runs its integration suite against real applications in CI on every commit:
 
 | Toolkit | Linux | macOS | Windows |
 | --- | --- | --- | --- |
@@ -111,31 +131,28 @@ The practical question for an accessibility-driven tool is not which platforms i
 | WinForms | — | — | ● |
 | WPF | — | — | ● |
 
-A dash means untested in CI, not known-broken — most combinations work, but only the marked cells are verified continuously. The [Accessibility Quirks](/guides/accessibility-quirks/) guide documents the per-toolkit behaviour that these tests pin down.
+A dash means untested in CI, not known-broken — most combinations work, but only the marked cells are verified continuously. The [accessibility quirks](/guides/accessibility-quirks/) guide documents the per-toolkit behavior these tests pin down.
 
 ## When not to use xa11y
 
-- **The app exposes no accessibility tree.** Games, canvas-drawn interfaces, custom-rendered engines, and applications whose toolkit has accessibility disabled. Run `xa11y tree --app <name>` to check in a few seconds; if it comes back empty or shows a single opaque window, you need a tool that injects into the process (Squish, TestComplete) or one that matches pixels (SikuliX).
-- **You need a recorder or a low-code interface.** xa11y is a library with no IDE, no recorder, and no reporting. Ranorex, TestComplete, and Squish sell exactly this, and for a team of non-programming testers that bundle is the product.
-- **You are testing a website.** Use [Playwright](https://playwright.dev/) or Selenium. They test the DOM directly, control the browser lifecycle, and intercept network traffic — none of which xa11y does. xa11y drives a browser only as another desktop app.
-- **You need API stability today.** v0.12 is pre-1.0 and breaking changes still land in minor releases.
+- **The app exposes no accessibility tree.** Games, canvas-drawn interfaces, and apps whose toolkit never wired up accessibility. Run `xa11y tree --app <name>`; if it comes back empty or shows one opaque window, you need injection (Squish, TestComplete), pixels (SikuliX), or vision.
+- **You need a recorder, an IDE, or a low-code interface.** xa11y is a library with none of those; the commercial suites bundle them.
+- **You are testing a website.** Playwright or Selenium test the DOM directly, control the browser lifecycle, and intercept network traffic. xa11y drives a browser only as another desktop app.
+- **You need API stability today.** v0.12.0 is pre-1.0; breaking changes still land in minor releases.
 - **You are on Windows only, permanently.** FlaUI and pywinauto expose more of UI Automation than xa11y does.
-- **You need vendor support with an SLA.** xa11y is a community project. The commercial suites include support contracts.
-- **You need to evaluate accessibility conformance.** xa11y reports what the tree says, not whether it complies with WCAG or ARIA authoring practices.
+- **You need vendor support with an SLA.** xa11y is a community project.
+- **You need to evaluate accessibility conformance.** xa11y reads the tree to automate apps; it does not evaluate the tree against WCAG. Use [axe](https://github.com/dequelabs/axe-core) or [Accessibility Insights](https://accessibilityinsights.io/).
 
 ## Related but not competing
 
-- **[AccessKit](https://accesskit.dev/)** — a library for *publishing* an accessibility tree from your app. xa11y *reads* trees. They compose: xa11y's own egui and winit test applications are AccessKit-backed, which is how the same suite runs against a pure-Rust GUI on all three platforms.
-- **[Playwright](https://playwright.dev/)** — browser automation. Not a competitor, but the major design influence on xa11y's `Locator` pattern, auto-waiting, and selector syntax.
-- **[agent-desktop](https://agent-desktop.dev)** — a CLI built *on* xa11y for AI agents that read and control desktops. If you want an agent tool rather than a library, start there.
-- **RPA platforms** — UiPath and Power Automate Desktop solve business process automation, including orchestration, scheduling, and licensing. Overlapping techniques, different product category.
+- **[AccessKit](https://accesskit.dev/)** — publishes an accessibility tree from inside your app; xa11y reads trees. The two are opposite sides of the same interface, and they compose: xa11y's own egui and winit test apps are AccessKit-backed, which is how one suite runs against a pure-Rust GUI on all three platforms.
+- **[Playwright](https://playwright.dev/)** — browser automation, and the design influence behind xa11y's `Locator` pattern and selector syntax.
+- **[agent-desktop](https://agent-desktop.dev)** — a CLI built on xa11y for AI agents that read and control desktops.
+- **RPA platforms** — UiPath and Power Automate Desktop solve business process automation, with orchestration, scheduling, and enterprise licensing. Overlapping techniques, different product category.
+- **Accessibility auditing tools** — axe and Accessibility Insights evaluate a tree against WCAG criteria. xa11y does no conformance evaluation.
 
 ## How these claims were checked
 
-Verified July 2026 against: xa11y 0.12.0, FlaUI 5.0.0, pywinauto 0.6.x, Appium Windows and Mac2 drivers, dogtail 1.x, SikuliX 2.x, and current vendor documentation for Squish, Ranorex Studio, and TestComplete.
+Verified July 2026 against: xa11y 0.12.0, FlaUI 5.0.0 (released February 2025), pywinauto 0.6.x, the Appium Windows and Mac2 drivers, dogtail 1.x (which added Wayland support via gnome-ponytail-daemon), atomacos (low recent activity), SikuliX 2.x, and the current public documentation for Squish, Ranorex Studio, and TestComplete. Commercial suites are described only to the level their public documentation supports.
 
-Two details worth knowing if you are evaluating Appium on Windows: its Windows driver proxies to Microsoft's **WinAppDriver**, which has had no release since 2022, though the Appium-side driver itself remains actively maintained. And the **Mac2** driver is built on XCTest, so it requires Xcode on every machine that runs tests — a meaningful constraint for CI images.
-
-Commercial suites are compared at the level their public documentation supports — platforms, languages, and mechanism — rather than feature by feature, because much of their detail sits behind sales processes and evaluation licences. Treat those three rows as a starting point for your own trial, not a substitute for one.
-
-Corrections are welcome — comparisons rot, and a wrong claim about another project is the most expensive kind of error on a page like this. Please [open an issue](https://github.com/xa11y/xa11y/issues).
+Comparisons rot, and a wrong claim about another project is the most expensive kind of error on a page like this. If you find one, please [open an issue](https://github.com/xa11y/xa11y/issues).

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -1,27 +1,18 @@
 ---
-title: Comparison
-description: How xa11y relates to pywinauto, FlaUI, Appium, dogtail, atomacos, Squish, Ranorex, TestComplete, SikuliX, OmniParser, and VLM computer-use agents — what each approach can and cannot do.
+title: How xa11y compares to other desktop automation tools
+description: What separates accessibility-tree libraries, injection-based suites, and vision tools for desktop UI automation — and where xa11y, pywinauto, FlaUI, Appium, Squish, and OmniParser each fit.
+lastUpdated: 2026-07-27
 ---
 
 xa11y drives native desktop applications by reading and acting on the **accessibility tree** — the same structured data screen readers consume — through one API on macOS (AXUIElement), Windows (UI Automation), and Linux (AT-SPI2). It is a library, MIT-licensed, currently at v0.12.0 and pre-1.0: breaking changes still land in minor releases. Bindings exist for Rust, Python (3.9+), and JavaScript, plus a [CLI](/guides/cli/) (`xa11y apps`, `xa11y tree --app <name>`, `xa11y find`).
 
-The tools in this space split along one technical line: what a tool treats as the source of truth about the screen. Everything else — what it can see, what breaks it, what it costs per operation — follows from that choice. This page walks through the categories in turn: open-source accessibility libraries, commercial injection-based suites, pixel and vision tools, and the approaches used for computer-use agents. If you already know the app you want to automate exposes no accessibility tree, xa11y cannot help — see [when not to use xa11y](#when-not-to-use-xa11y).
+Tools in this space split along one technical line: what each treats as the source of truth about the screen — an accessibility tree, a toolkit's internal object model, raw pixels, or a model's reading of those pixels. What a tool can see, what breaks it, and what it costs per operation all follow from that choice, so this page is organized around it. If your target app exposes no accessibility tree, xa11y cannot help; skip to [when not to use xa11y](#when-not-to-use-xa11y).
 
-## Four ways to see a UI
+The four mechanisms compose, and a practical setup often drives through the tree and reaches for pixels only where the tree has a hole. xa11y keeps that boundary explicit: [input simulation](/guides/input/) is a separate `InputSim` surface that never automatically substitutes for an accessibility action, so a passing test cannot silently degrade into blind coordinate clicking. That separation is a deliberate design rule, described in [Design](/guides/design/).
 
-**Accessibility tree.** The application publishes a structured description of itself: roles, names, values, states, bounds. Elements are addressed semantically (`button[name='Submit']`), so a query costs microseconds and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test — you automate the shipping binary. The hard constraint is that you only see what the app exposes; where accessibility support is absent or wrong, there is nothing to read. xa11y, pywinauto, FlaUI, Appium's desktop drivers, dogtail, and atomacos work this way.
+## Accessibility-tree libraries: xa11y, pywinauto, FlaUI, dogtail, atomacos
 
-**Toolkit introspection.** The tool loads a hook into the target process and reads the toolkit's own object model — Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy — rather than the accessibility projection of it. This sees strictly more: custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility. The costs are that injection changes the process you are testing, the hook must support your toolkit and build, and in practice this is commercial territory. Squish, Ranorex, and TestComplete work this way, falling back to accessibility APIs where they lack a dedicated hook.
-
-**Pixel matching.** Screenshot the screen, search for a reference image. Works on anything visible — including remote desktops and video — and breaks on theme, DPI, font-rendering, and antialiasing changes. It cannot read a value it was not given a picture of. SikuliX and PyAutoGUI work this way.
-
-**Model-based vision.** A model interprets a screenshot, either producing structured elements (screen-parsing models such as OmniParser) or deciding the action directly (end-to-end VLM agents). Flexible on UI it has never seen, at the cost of a model inference per observation and non-deterministic output. Covered in detail [below](#computer-use-and-ai-agents).
-
-These mechanisms compose. A practical setup often drives through the tree and reaches for pixels or vision only where the tree has a hole. xa11y keeps that boundary explicit: [input simulation](/guides/input/) is a separate `InputSim` surface and never automatically substitutes for an accessibility action, so a passing test cannot silently degrade into blind coordinate clicking. That separation is a deliberate design rule, described in [Design](/guides/design/).
-
-## Accessibility-tree libraries
-
-The open-source tools that read the same data xa11y does:
+The application publishes a structured description of itself — roles, names, values, states, bounds — and the tool reads it. Elements are addressed semantically (`button[name='Submit']`), so a query costs microseconds and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test; you automate the shipping binary. The hard constraint is that you see only what the app exposes, and where accessibility support is absent or wrong there is nothing to read.
 
 | Tool | Platforms | Languages | Underlying API | License |
 | --- | --- | --- | --- | --- |
@@ -32,29 +23,27 @@ The open-source tools that read the same data xa11y does:
 | [dogtail](https://gitlab.com/dogtail/dogtail) | Linux | Python | AT-SPI2 | GPL-2.0 |
 | [atomacos](https://github.com/daveenguyen/atomacos) | macOS | Python | AXUIElement | GPL-3.0 |
 
-Two structural differences separate xa11y from the rest of this table more than any feature checklist does.
+Since every library here reads the same underlying data, feature checklists separate them poorly. Two design decisions separate them well: how much abstraction the library puts over the platform API, and whether it hands you a live query or a captured node.
 
-### Abstraction level
+## Abstraction: platform mirrors versus a normalization layer
 
-The platform-specific libraries mostly mirror their underlying API almost exactly, adding little abstraction of their own. pywinauto surfaces Win32 and UIA concepts directly; atomacos exposes AXUIElement attributes nearly raw; dogtail exposes AT-SPI2's object model. That is a legitimate design choice — it is predictable, and it gives you the full platform surface, including corners xa11y does not expose. The consequence is that the concepts, role names, and idioms differ per platform, so code written against one of these libraries does not port; supporting a second OS means rewriting against a different library with a different object model.
+The platform-specific libraries mostly mirror their underlying API almost exactly, adding little abstraction of their own. pywinauto surfaces Win32 and UIA concepts directly; atomacos exposes AXUIElement attributes nearly raw; dogtail exposes AT-SPI2's object model. That is a legitimate choice — it is predictable, and it gives you the full platform surface, including corners xa11y does not expose. The consequence is that concepts, role names, and idioms differ per platform, so code written against one of them does not port. Supporting a second OS means rewriting against a different library with a different object model.
 
-xa11y's contribution is the normalization layer: one set of role names, one selector language, one set of action verbs, mapped onto three quite different platform APIs. The [platform details](/guides/platform-details/) guide documents how each concept maps. The tradeoff runs both ways: if you are on one platform permanently, a library that mirrors that platform's API is more mature, better documented in Stack Overflow terms, and exposes more of it. If you need the same suite on two or three platforms, the normalization is the point.
+xa11y's contribution is the normalization layer: one set of role names, one selector language, one set of action verbs, mapped onto three quite different platform APIs. The [platform details](/guides/platform-details/) guide documents how each concept maps. The tradeoff runs both ways. On one platform permanently, a library that mirrors that platform's API is more mature, better covered by existing answers online, and exposes more of it. Across two or three platforms, the normalization is the whole point.
 
-Appium sits between: it normalizes through the WebDriver protocol, so any WebDriver client works, but each desktop platform is a separate driver with separate capabilities. Two practical details if you evaluate it: the Windows driver proxies to Microsoft's WinAppDriver, which has had no release since 2022 (the Appium-side driver remains actively maintained), and the Mac2 driver is built on XCTest, so every machine running tests needs Xcode installed.
+Appium sits between the platform mirrors and a full normalization layer: it normalizes through the WebDriver protocol, so any WebDriver client works, but each desktop platform is a separate driver with separate capabilities. Two practical details if you evaluate it — the Windows driver proxies to Microsoft's WinAppDriver, which has had no release since 2022 (the Appium-side driver remains actively maintained), and the Mac2 driver is built on XCTest, so every machine running tests needs Xcode installed.
 
-### Locators, waiting, and staleness
+## Locators, auto-waiting, and stale handles
 
 Most accessibility libraries hand you a captured node reference. That reference goes stale the moment the app redraws or replaces the subtree it came from, and the library leaves the resulting retry loops to you — the classic source of desktop-test flake, where a find succeeds and the click a few milliseconds later lands on a dead handle.
 
-xa11y's `Locator` is a lazy query instead: it re-resolves its selector on every operation and waits for the element to be visible and enabled before acting. (An `Element` in xa11y is the captured-handle form — it does not re-resolve — and the API keeps the two distinct.) The selector language is CSS-like: `button[name='Submit']`, `textfield[name^='Search']`, `group > button`, `:nth(2)`. The model is taken from Playwright's locators, adapted to accessibility trees.
+xa11y's `Locator` is a lazy query instead: it re-resolves its selector on every operation and waits for the element to be visible and enabled before acting. An `Element` is the captured-handle form, and the API keeps the two distinct. The selector language is CSS-like — `button[name='Submit']`, `textfield[name^='Search']`, `group > button`, `:nth(2)` — and the model is taken from Playwright's locators, adapted to accessibility trees.
 
-This matters beyond tests. An agent acting on a stale handle fails exactly the way a flaky test does — the UI changed between observation and action. A locator that re-resolves absorbs that race. And a selector is a compact, writable name for an element: an agent can carry `button[name='Save']` across turns of a conversation, or a person can paste it into a script, where a captured object reference cannot leave the process that made it. Most libraries in the table above have neither auto-waiting nor a selector language; you build both yourself.
+This matters well beyond tests. An agent acting on a stale handle fails exactly the way a flaky test does: the UI changed between observation and action, and a locator that re-resolves absorbs that race. A selector is also a compact, writable name for an element. An agent can carry `button[name='Save']` across turns of a conversation, and a person can paste it into a script, where a captured object reference cannot leave the process that created it. Among the libraries above, most provide neither auto-waiting nor a selector language, and you build both yourself.
 
-xa11y also exposes accessibility event streams (`app.subscribe()`) and [screenshots](/guides/screenshots/) of the full screen, a region, or an element's bounds. Platform prerequisites are minimal but real: macOS needs the Accessibility permission (plus Screen Recording on macOS 26+), Linux needs AT-SPI2 running, Windows needs nothing special.
+## Injection-based suites: Squish, Ranorex, TestComplete
 
-## Commercial suites
-
-The commercial desktop-testing suites mostly do **not** read the accessibility tree. They load a hook into the target process and read the toolkit's own object model, falling back to accessibility APIs where no dedicated hook exists. That lets them drive custom-drawn widgets that publish nothing to UIA or AT-SPI2 — a structural capability xa11y cannot match without also injecting, which it deliberately does not do. They are licensed per seat and bundle a recorder, an IDE, reporting, and vendor support; for a team of testers who do not write code, that bundle is the product, and xa11y offers none of it.
+These suites mostly do **not** read the accessibility tree. They load a hook into the target process and read the toolkit's own object model — Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy — falling back to accessibility APIs where no dedicated hook exists. That reaches custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility: a structural capability xa11y cannot match without also injecting, which it deliberately does not do. In exchange, injection changes the process you are testing, and the hook must support your toolkit and build. All three are licensed per seat and bundle a recorder, IDE, reporting, and support — for testers who do not write code, that bundle is the product.
 
 | Tool | Desktop targets | Languages | Primary mechanism |
 | --- | --- | --- | --- |
@@ -62,11 +51,13 @@ The commercial desktop-testing suites mostly do **not** read the accessibility t
 | [Ranorex Studio](https://www.ranorex.com/) | Windows | C#, VB.NET | UIA + .NET introspection |
 | [TestComplete](https://smartbear.com/product/testcomplete/) | Windows | Python, JavaScript, VBScript, JScript, DelphiScript | UIA + toolkit introspection incl. Delphi/VCL |
 
-Squish (Qt Group, which acquired froglogic in 2021) is the only genuinely cross-platform one, and reads Qt's object model directly — it reaches QML internals that the accessibility projection omits. Ranorex Studio is Windows-hosted and Windows-targeted, with no native macOS app testing. TestComplete has the broadest legacy-toolkit coverage, including Delphi and VCL.
+Squish (Qt Group, which acquired froglogic in 2021) is the only genuinely cross-platform one, and reaches QML internals the accessibility projection omits. Ranorex Studio is Windows-hosted and Windows-targeted, with no native macOS app testing. TestComplete has the broadest legacy-toolkit coverage, including Delphi and VCL.
 
-These three are compared here only at the level their public documentation supports — platforms, languages, mechanism. Much of their feature detail sits behind sales processes and evaluation licenses, so this page does not make feature-level claims about them; treat the table as a starting point for your own trial.
+These three are compared here only at the level their public documentation supports — platforms, languages, mechanism. Much of their feature detail sits behind sales processes and evaluation licenses, so this page makes no feature-level claims about them; treat the table as a starting point for your own trial.
 
-## Pixel and vision tools
+## Pixels and screen parsing: SikuliX, PyAutoGUI, OmniParser
+
+The remaining tools read the screen rather than the app. Pixel matching screenshots the display and searches for a reference image; model-based vision hands the screenshot to a model that either returns structured elements or decides the action directly. Both work on anything visible, including remote desktops, video, and applications with no accessibility support at all.
 
 | Tool | Platforms | Mechanism | Reads values? | License |
 | --- | --- | --- | --- | --- |
@@ -75,48 +66,53 @@ These three are compared here only at the level their public documentation suppo
 | [OmniParser](https://github.com/microsoft/OmniParser) and similar screen parsers | Any | Detection model + OCR over screenshots | Via OCR | Open source (varies) |
 | End-to-end VLM computer-use agents | Any | Model reasoning over screenshots | Via the model | Varies |
 
-SikuliX and PyAutoGUI predate the model-based tools and share their failure mode in miniature: they see pixels, so anything that changes pixels without changing meaning — a theme, a DPI setting, font antialiasing — breaks the match. PyAutoGUI is primarily input synthesis; it cannot read a value out of the UI at all. The screen-parsing models and VLM agents in the bottom two rows are less automation libraries than components of agent systems, which is the subject of the next section.
+SikuliX and PyAutoGUI predate the model-based tools and share their failure mode in miniature: they see pixels, so anything that changes pixels without changing meaning — a theme, a DPI setting, font antialiasing — breaks the match. PyAutoGUI is primarily input synthesis and cannot read a value out of the UI at all. Screen parsers and VLM agents are less automation libraries than components of agent systems, which is the subject of the next section.
 
-## Computer use and AI agents
+## Driving a desktop from an AI agent
 
-An agent driving a desktop needs, on every step, an observation of the current UI and a way to act on it. The approaches in use differ mainly in how that observation is produced, and the differences compound because an agent observes many times per task.
+An agent needs, on every step, an observation of the current UI and a way to act on it. The approaches differ mainly in how that observation is produced, and the differences compound because an agent observes many times per task.
 
-**Accessibility-tree-driven.** The agent queries the semantic tree — directly through a library like xa11y, or through a CLI or MCP tool built on one. An observation is a tree query: microseconds of latency, a few hundred tokens once serialized, and deterministic — the same UI state yields the same output every time. Elements come with exact bounds and identifiers (role plus name) that are stable across renders and across sessions, which is what makes it possible to write a repeatable script from an agent's successful run: the selector the agent used yesterday still names the same button today. The limit is inherited from the mechanism: the app must expose a tree, and the tree only contains what the app published.
+**Accessibility-tree-driven.** The agent queries the semantic tree, directly through a library like xa11y or through a CLI or MCP tool built on one. An observation is microseconds of latency and a few hundred tokens once serialized, and it is deterministic. Elements carry exact bounds and identifiers — role plus name — stable across renders and sessions, which is what lets a successful agent run harden into a repeatable script: the selector it used yesterday still names the same button today. The app must expose a tree, and the tree holds only what the app published.
 
-**Screen-parsing models.** [OmniParser](https://github.com/microsoft/OmniParser) — Microsoft's open-source screenshot-to-structured-elements model — is the canonical example of this category. A detection model plus OCR reconstructs a pseudo-tree from pixels: bounding boxes, text, and inferred interactability for whatever is visible. These work on anything on screen, including applications with no accessibility support at all, which is their reason to exist. In exchange, every observation costs a model inference, detection introduces error (missed elements, merged elements, wrong boxes), and the element identifiers are synthesized per screenshot — they are not stable across renders, so there is nothing durable to write a script against. Screen parsers are also not automation tools by themselves; they produce structure and rely on a separate executor to act.
+**Screen-parsing models.** [OmniParser](https://github.com/microsoft/OmniParser), Microsoft's open-source screenshot-to-structured-elements model, is the canonical example. A detection model plus OCR reconstructs a pseudo-tree from pixels — bounding boxes, text, inferred interactability — for whatever is visible, which reaches applications with no accessibility support at all. In exchange, every observation costs a model inference, detection introduces error, and identifiers are synthesized per screenshot rather than stable across renders, so there is nothing durable to write a script against. Acting on the structure requires a separate executor.
 
-**End-to-end VLM agents.** The model looks at a screenshot and decides the action directly — Claude and OpenAI computer use, and similar systems. This is the most flexible option on UI nobody anticipated, since there is no intermediate representation to be wrong. It is also non-deterministic, the slowest per step, and carries the highest token cost per observation, because every step ships an image into a model and the reasoning happens in the loop.
+**End-to-end VLM agents.** The model looks at a screenshot and decides the action directly. The most flexible option on UI nobody anticipated, since there is no intermediate representation to be wrong — and the slowest, least reproducible, and most expensive per step, because every step ships an image into a model.
 
-**Hybrid.** Increasingly the practical setup: use the accessibility tree for structure, element enumeration, and exact bounds, and bring in vision only for what the tree does not expose — a canvas region, an image, a custom widget with no accessibility support. The tree and the pixels are complementary observations of the same UI, not competing ones; a screenshot of an element's exact bounds (which the tree provides) is a much better vision input than a full-screen capture. xa11y's tree queries, element-bounds screenshots, and event streams are the tree-side half of this arrangement, and [agent-desktop](https://agent-desktop.dev) packages them as a CLI for agents.
+**Hybrid.** Increasingly the practical setup: the accessibility tree for structure, enumeration, and exact bounds, with vision only for what the tree does not expose — a canvas region, an image, a custom widget. The two are complementary observations of the same UI, and a screenshot cropped to an element's exact bounds (which the tree supplies) is a far better vision input than a full-screen capture. [agent-desktop](https://agent-desktop.dev) packages xa11y's tree queries, element screenshots, and event streams as a CLI for agents.
 
-The decision axes are concrete. **Latency**: a tree query is microseconds; a model inference is hundreds of milliseconds to seconds. **Token cost per observation**: a serialized subtree is a few hundred tokens; screenshots and parsed screenshots are far more, and they recur on every step. **Determinism**: tree queries are reproducible, model output is not — which decides whether a failure can be replayed. **Identifier stability**: selectors survive across runs; synthesized boxes do not — which decides whether an agent's trajectory can harden into a script. **Coverage**: vision sees everything on screen; the tree sees only what the app exposes. Where an app has a usable tree, the tree-driven observation dominates on the first four axes; where it does not, vision is the only observation available. `xa11y tree --app <name>` answers in seconds which situation you are in.
+| Decision axis | Accessibility tree | Screen parsing | End-to-end VLM |
+| --- | --- | --- | --- |
+| Latency per observation | Microseconds | Model inference | Model inference |
+| Tokens per observation | Hundreds | Thousands and up | Thousands and up |
+| Reproducible output | Yes | No | No |
+| Identifiers stable across runs | Yes — selectors persist | No — synthesized per screenshot | No |
+| Reaches non-accessible UI | No | Yes | Yes |
+
+Where an app has a usable tree, tree-driven observation wins on the first four axes; where it does not, vision is the only observation available. `xa11y tree --app <name>` answers in seconds which situation you are in.
 
 ## Capability matrix
 
-xa11y against the tools closest to it in scope:
+xa11y against the tools closest to it in scope. Platform and license columns are in the tables above and are not repeated here.
 
 | | xa11y | Appium | Squish | pywinauto | FlaUI |
 | --- | --- | --- | --- | --- | --- |
-| macOS / Windows / Linux | ● ● ● | ● ● ○ | ● ● ● | ○ ● ○ | ○ ● ○ |
 | Single API across platforms | ● | ● | ● | n/a | n/a |
 | Selector language | CSS-like | XPath | Object map | Property dicts | Conditions API |
 | Auto-waiting on actions | ● | Configurable | ● | Explicit | Explicit |
 | Accessibility event streams | ● | ○ | ◐ | ○ | ● |
-| Screenshots | ● | ● | ● | ● | ● |
 | Input simulation | Separate surface | Merged | Merged | Merged | Merged |
 | Sees non-accessible widgets | ○ | ○ | ● | ○ | ○ |
-| Requires no in-process hook | ● | ● | ○ | ● | ● |
 | Runs without a driver server | ● | ○ | ○ | ● | ● |
-| Record and playback | ○ | ○ | ● | ○ | ○ |
-| Bundled IDE and reporting | ○ | ○ | ● | ○ | ○ |
-| Free to use | ● | ● | ○ | ● | ● |
+| Recorder, IDE, and reporting | ○ | ○ | ● | ○ | ○ |
 | Ecosystem size and maturity | ○ | ● | ● | ● | ● |
 
 ● full · ◐ partial · ○ none
 
-Two rows where xa11y is behind deserve a plain statement. *Sees non-accessible widgets*: this follows from refusing to inject into the target process, and it is not something xa11y can engineer around — if a control publishes nothing to UIA or AT-SPI2, Squish can drive it through the toolkit's object model and xa11y cannot see it. *Maturity*: at v0.12.0 the API is not stable, and pywinauto, FlaUI, and the commercial suites have years of production use and deeper single-platform coverage. Choosing xa11y is a bet that one cross-platform API saves you more than a mature single-platform one; on one platform, permanently, it may not.
+Stated as prose: xa11y and Squish are the only two that cover all three desktop platforms; xa11y, Squish, and FlaUI auto-wait, while pywinauto and FlaUI otherwise leave waiting to the caller; only Squish reaches widgets with no accessibility support; and only xa11y keeps input simulation on a surface separate from accessibility actions.
 
-## Framework coverage
+xa11y is behind on two rows. It cannot see non-accessible widgets — a consequence of refusing to inject, not something it can engineer around: if a control publishes nothing to UIA or AT-SPI2, Squish reaches it through the toolkit's object model and xa11y cannot. And at v0.12.0 its ecosystem is far smaller than libraries with years of production use. Choosing xa11y bets that one cross-platform API saves more than a mature single-platform one; on one platform, permanently, it may not.
+
+## Framework coverage in CI
 
 For an accessibility-driven tool, the practical question is not which platforms it claims but which UI toolkits actually work, because coverage depends on each toolkit's accessibility implementation. xa11y runs its integration suite against real applications in CI on every commit:
 
@@ -133,6 +129,8 @@ For an accessibility-driven tool, the practical question is not which platforms 
 
 A dash means untested in CI, not known-broken — most combinations work, but only the marked cells are verified continuously. The [accessibility quirks](/guides/accessibility-quirks/) guide documents the per-toolkit behavior these tests pin down.
 
+Platform prerequisites are minimal but real: macOS needs the Accessibility permission (plus Screen Recording on macOS 26+), Linux needs AT-SPI2 running, and Windows needs nothing special.
+
 ## When not to use xa11y
 
 - **The app exposes no accessibility tree.** Games, canvas-drawn interfaces, and apps whose toolkit never wired up accessibility. Run `xa11y tree --app <name>`; if it comes back empty or shows one opaque window, you need injection (Squish, TestComplete), pixels (SikuliX), or vision.
@@ -145,7 +143,7 @@ A dash means untested in CI, not known-broken — most combinations work, but on
 
 ## Related but not competing
 
-- **[AccessKit](https://accesskit.dev/)** — publishes an accessibility tree from inside your app; xa11y reads trees. The two are opposite sides of the same interface, and they compose: xa11y's own egui and winit test apps are AccessKit-backed, which is how one suite runs against a pure-Rust GUI on all three platforms.
+- **[AccessKit](https://accesskit.dev/)** — publishes an accessibility tree from inside your app, where xa11y reads trees from outside. The two are opposite sides of the same interface and compose: xa11y's own egui and winit test apps are AccessKit-backed, which is how one suite runs against a pure-Rust GUI on all three platforms.
 - **[Playwright](https://playwright.dev/)** — browser automation, and the design influence behind xa11y's `Locator` pattern and selector syntax.
 - **[agent-desktop](https://agent-desktop.dev)** — a CLI built on xa11y for AI agents that read and control desktops.
 - **RPA platforms** — UiPath and Power Automate Desktop solve business process automation, with orchestration, scheduling, and enterprise licensing. Overlapping techniques, different product category.
@@ -153,6 +151,6 @@ A dash means untested in CI, not known-broken — most combinations work, but on
 
 ## How these claims were checked
 
-Verified July 2026 against: xa11y 0.12.0, FlaUI 5.0.0 (released February 2025), pywinauto 0.6.x, the Appium Windows and Mac2 drivers, dogtail 1.x (which added Wayland support via gnome-ponytail-daemon), atomacos (low recent activity), SikuliX 2.x, and the current public documentation for Squish, Ranorex Studio, and TestComplete. Commercial suites are described only to the level their public documentation supports.
+Verified July 2026 against: xa11y 0.12.0, FlaUI 5.0.0 (released February 2025), pywinauto 0.6.x, the Appium Windows and Mac2 drivers, dogtail 1.x (which added Wayland support via gnome-ponytail-daemon), atomacos (low recent activity), SikuliX 2.x, and the current public documentation for Squish, Ranorex Studio, and TestComplete.
 
 Comparisons rot, and a wrong claim about another project is the most expensive kind of error on a page like this. If you find one, please [open an issue](https://github.com/xa11y/xa11y/issues).

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -1,120 +1,116 @@
 ---
 title: How xa11y compares to other desktop automation tools
-description: What separates accessibility-tree libraries, injection-based suites, and vision tools for desktop UI automation — and where xa11y, pywinauto, FlaUI, Appium, Squish, and OmniParser each fit.
+description: What separates accessibility-based libraries, injection-based suites, and vision tools for desktop UI automation — and where xa11y, pywinauto, FlaUI, Appium, Squish, and OmniParser each fit.
 lastUpdated: 2026-07-27
 ---
 
-xa11y drives native desktop applications by reading and acting on the **accessibility tree** — the same structured data screen readers consume — through one API on macOS (AXUIElement), Windows (UI Automation), and Linux (AT-SPI2). It is a library, MIT-licensed, currently at v0.12.0 and pre-1.0: breaking changes still land in minor releases. Bindings exist for Rust, Python (3.9+), and JavaScript, plus a [CLI](/guides/cli/) (`xa11y apps`, `xa11y tree --app <name>`, `xa11y find`).
+xa11y drives native desktop applications by reading and acting on accessibility data — the same information screen readers consume — through one API on macOS (AXUIElement), Windows (UI Automation), and Linux (AT-SPI2). It is open source under MIT, with bindings for Rust, Python, and JavaScript and a [command-line tool](/guides/cli/) for exploring accessibility trees. What it adds over calling each platform's API directly is cross-platform coverage behind one interface, CSS-like selectors, and locators that re-resolve and wait for an element to be ready before acting, which removes most of the retry scaffolding desktop automation otherwise accumulates.
 
-Tools in this space split along one technical line: what each treats as the source of truth about the screen — an accessibility tree, a toolkit's internal object model, raw pixels, or a model's reading of those pixels. What a tool can see, what breaks it, and what it costs per operation all follow from that choice, so this page is organized around it. If your target app exposes no accessibility tree, xa11y cannot help; skip to [when not to use xa11y](#when-not-to-use-xa11y).
+What separates the tools in this space is what each treats as the source of truth about the screen — accessibility data, a toolkit's internal object model, raw pixels, or a model's reading of those pixels. What a tool can see, what breaks it, and what it costs per operation all follow from that, so this page is organized around it. If your target app exposes no accessibility data, xa11y cannot help; skip to [when not to use xa11y](#when-not-to-use-xa11y).
 
-The four mechanisms compose, and a practical setup often drives through the tree and reaches for pixels only where the tree has a hole. xa11y keeps that boundary explicit: [input simulation](/guides/input/) is a separate `InputSim` surface that never automatically substitutes for an accessibility action, so a passing test cannot silently degrade into blind coordinate clicking. That separation is a deliberate design rule, described in [Design](/guides/design/).
+The four mechanisms compose, and a practical setup often drives through accessibility data and reaches for pixels only where that has a hole. xa11y keeps the boundary explicit. [Input simulation](/guides/input/) is a separate `InputSim` surface that never automatically substitutes for an accessibility action, so a passing test cannot silently degrade into blind coordinate clicking. That separation is a deliberate design rule, described in [Design](/guides/design/).
 
-## Accessibility-tree libraries: xa11y, pywinauto, FlaUI, dogtail, atomacos
+## Accessibility-based libraries: xa11y, pywinauto, FlaUI, dogtail, atomacos
 
-The application publishes a structured description of itself — roles, names, values, states, bounds — and the tool reads it. Elements are addressed semantically (`button[name='Submit']`), so a query costs microseconds and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test; you automate the shipping binary. The hard constraint is that you see only what the app exposes, and where accessibility support is absent or wrong there is nothing to read.
+The application exposes accessibility data — roles, names, values, states, bounds — and the tool reads it. Elements are addressed semantically, so a query costs microseconds and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test, and you automate the shipping binary. You see only what the app exposes, and where accessibility support is absent or wrong there is nothing to read.
 
-| Tool | Platforms | Languages | Underlying API | License |
-| --- | --- | --- | --- | --- |
-| **xa11y** | macOS, Windows, Linux | Rust, Python, JavaScript | AXUIElement, UI Automation, AT-SPI2 | MIT |
-| [Appium](https://appium.io/) (Windows + Mac2 drivers) | macOS, Windows | Any WebDriver client | WinAppDriver, XCTest | Apache-2.0 |
-| [pywinauto](https://pywinauto.readthedocs.io/) | Windows | Python | Win32, UI Automation | BSD-3-Clause |
-| [FlaUI](https://github.com/FlaUI/FlaUI) | Windows | C#/.NET | UI Automation (UIA2/UIA3) | MIT |
-| [dogtail](https://gitlab.com/dogtail/dogtail) | Linux | Python | AT-SPI2 | GPL-2.0 |
-| [atomacos](https://github.com/daveenguyen/atomacos) | macOS | Python | AXUIElement | GPL-3.0 |
+| Tool | Languages | Underlying API |
+| --- | --- | --- |
+| **xa11y** | Rust, Python, JavaScript | AXUIElement, UI Automation, AT-SPI2 |
+| [Appium](https://appium.io/) (Windows + Mac2 drivers) | Any WebDriver client | WinAppDriver, XCTest |
+| [pywinauto](https://pywinauto.readthedocs.io/) | Python | Win32, UI Automation |
+| [FlaUI](https://github.com/FlaUI/FlaUI) | C#/.NET | UI Automation (UIA2/UIA3) |
+| [dogtail](https://gitlab.com/dogtail/dogtail) | Python | AT-SPI2 |
+| [atomacos](https://github.com/daveenguyen/atomacos) | Python | AXUIElement |
 
-Since every library here reads the same underlying data, feature checklists separate them poorly. Two design decisions separate them well: how much abstraction the library puts over the platform API, and whether it hands you a live query or a captured node.
+Appium normalizes through the WebDriver protocol rather than a library API, so any WebDriver client works, though each desktop platform is a separate driver with separate capabilities. Its Windows driver proxies to Microsoft's WinAppDriver, which has had no release since 2022, while the Appium-side driver remains actively maintained. The Mac2 driver is built on XCTest, so every machine running tests needs Xcode installed.
 
 ## Abstraction: platform mirrors versus a normalization layer
 
-The platform-specific libraries mostly mirror their underlying API almost exactly, adding little abstraction of their own. pywinauto surfaces Win32 and UIA concepts directly; atomacos exposes AXUIElement attributes nearly raw; dogtail exposes AT-SPI2's object model. That is a legitimate choice — it is predictable, and it gives you the full platform surface, including corners xa11y does not expose. The consequence is that concepts, role names, and idioms differ per platform, so code written against one of them does not port. Supporting a second OS means rewriting against a different library with a different object model.
-
-xa11y's contribution is the normalization layer: one set of role names, one selector language, one set of action verbs, mapped onto three quite different platform APIs. The [platform details](/guides/platform-details/) guide documents how each concept maps. The tradeoff runs both ways. On one platform permanently, a library that mirrors that platform's API is more mature, better covered by existing answers online, and exposes more of it. Across two or three platforms, the normalization is the whole point.
-
-Appium sits between the platform mirrors and a full normalization layer: it normalizes through the WebDriver protocol, so any WebDriver client works, but each desktop platform is a separate driver with separate capabilities. Two practical details if you evaluate it — the Windows driver proxies to Microsoft's WinAppDriver, which has had no release since 2022 (the Appium-side driver remains actively maintained), and the Mac2 driver is built on XCTest, so every machine running tests needs Xcode installed.
+The platform-specific libraries mostly mirror their underlying API almost exactly. pywinauto surfaces Win32 and UIA concepts directly, atomacos exposes AXUIElement attributes nearly raw, and dogtail exposes AT-SPI2's object model. That is predictable and gives you the full platform surface, including corners xa11y does not expose, but concepts, role names, and idioms differ per platform, so code written against one of them does not port, and supporting a second OS means rewriting against a different object model. xa11y instead normalizes, mapping one set of role names, one selector language, and one set of action verbs onto all three platform APIs, documented in [platform details](/guides/platform-details/). On one platform permanently, a library that mirrors that platform is more mature and exposes more of it; across two or three, the normalization is the point.
 
 ## Locators, auto-waiting, and stale handles
 
 Most accessibility libraries hand you a captured node reference. That reference goes stale the moment the app redraws or replaces the subtree it came from, and the library leaves the resulting retry loops to you — the classic source of desktop-test flake, where a find succeeds and the click a few milliseconds later lands on a dead handle.
 
-xa11y's `Locator` is a lazy query instead: it re-resolves its selector on every operation and waits for the element to be visible and enabled before acting. An `Element` is the captured-handle form, and the API keeps the two distinct. The selector language is CSS-like — `button[name='Submit']`, `textfield[name^='Search']`, `group > button`, `:nth(2)` — and the model is taken from Playwright's locators, adapted to accessibility trees.
+xa11y's `Locator` is a lazy query. It re-resolves its selector on every operation and waits for the element to be visible and enabled before acting, while an `Element` is the captured-handle form and the API keeps the two distinct. The selector language is CSS-like — `button[name='Submit']`, `textfield[name^='Search']`, `group > button` — and the model is taken from Playwright's locators, adapted to accessibility trees.
 
-This matters well beyond tests. An agent acting on a stale handle fails exactly the way a flaky test does: the UI changed between observation and action, and a locator that re-resolves absorbs that race. A selector is also a compact, writable name for an element. An agent can carry `button[name='Save']` across turns of a conversation, and a person can paste it into a script, where a captured object reference cannot leave the process that created it. Among the libraries above, most provide neither auto-waiting nor a selector language, and you build both yourself.
+An agent acting on a stale handle fails exactly the way a flaky test does, since the UI changed between observation and action, and a locator that re-resolves absorbs that race. A selector is also a compact, writable name for an element. An agent can carry `button[name='Save']` across turns of a conversation, and a person can paste it into a script, where a captured object reference cannot leave the process that created it. Most of the libraries above provide neither auto-waiting nor a selector language, and you build both yourself.
 
 ## Injection-based suites: Squish, Ranorex, TestComplete
 
-These suites mostly do **not** read the accessibility tree. They load a hook into the target process and read the toolkit's own object model — Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy — falling back to accessibility APIs where no dedicated hook exists. That reaches custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility: a structural capability xa11y cannot match without also injecting, which it deliberately does not do. In exchange, injection changes the process you are testing, and the hook must support your toolkit and build. All three are licensed per seat and bundle a recorder, IDE, reporting, and support — for testers who do not write code, that bundle is the product.
+These suites mostly do **not** read accessibility data. They load a hook into the target process and read the toolkit's own object model — Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy — falling back to accessibility APIs where no dedicated hook exists. That reaches custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility, a structural capability xa11y cannot match without also injecting, which it deliberately does not do. In exchange, injection changes the process you are testing, and the hook must support your toolkit and build. All three are licensed per seat and bundle a recorder, IDE, reporting, and support, which for testers who do not write code is the product.
 
-| Tool | Desktop targets | Languages | Primary mechanism |
-| --- | --- | --- | --- |
-| [Squish](https://www.qt.io/product/quality-assurance/squish) | macOS, Windows, Linux | Python, JavaScript, Perl, Ruby, Tcl | Toolkit introspection (deepest Qt/QML support) |
-| [Ranorex Studio](https://www.ranorex.com/) | Windows | C#, VB.NET | UIA + .NET introspection |
-| [TestComplete](https://smartbear.com/product/testcomplete/) | Windows | Python, JavaScript, VBScript, JScript, DelphiScript | UIA + toolkit introspection incl. Delphi/VCL |
+| Tool | Languages | Primary mechanism |
+| --- | --- | --- |
+| [Squish](https://www.qt.io/product/quality-assurance/squish) | Python, JavaScript, Perl, Ruby, Tcl | Toolkit introspection, deepest Qt/QML support |
+| [Ranorex Studio](https://www.ranorex.com/) | C#, VB.NET | UIA + .NET introspection |
+| [TestComplete](https://smartbear.com/product/testcomplete/) | Python, JavaScript, VBScript, JScript, DelphiScript | UIA + toolkit introspection incl. Delphi/VCL |
 
 Squish (Qt Group, which acquired froglogic in 2021) is the only genuinely cross-platform one, and reaches QML internals the accessibility projection omits. Ranorex Studio is Windows-hosted and Windows-targeted, with no native macOS app testing. TestComplete has the broadest legacy-toolkit coverage, including Delphi and VCL.
 
-These three are compared here only at the level their public documentation supports — platforms, languages, mechanism. Much of their feature detail sits behind sales processes and evaluation licenses, so this page makes no feature-level claims about them; treat the table as a starting point for your own trial.
+These three are compared here only at the level their public documentation supports. Much of their feature detail sits behind sales processes and evaluation licenses, so this page makes no feature-level claims about them, and the tables are a starting point for your own trial.
 
 ## Pixels and screen parsing: SikuliX, PyAutoGUI, OmniParser
 
-The remaining tools read the screen rather than the app. Pixel matching screenshots the display and searches for a reference image; model-based vision hands the screenshot to a model that either returns structured elements or decides the action directly. Both work on anything visible, including remote desktops, video, and applications with no accessibility support at all.
+The remaining tools read the screen rather than the app. Pixel matching screenshots the display and searches for a reference image, while model-based vision hands the screenshot to a model that either returns structured elements or decides the action directly. Both work on anything visible, including remote desktops, video, and applications with no accessibility support at all.
 
-| Tool | Platforms | Mechanism | Reads values? | License |
-| --- | --- | --- | --- | --- |
-| [SikuliX](https://sikulix.github.io/) | macOS, Windows, Linux | OpenCV image matching + OCR | Via OCR only | MIT |
-| [PyAutoGUI](https://github.com/asweigart/pyautogui) | macOS, Windows, Linux | Input synthesis + basic image matching | No | BSD-3-Clause |
-| [OmniParser](https://github.com/microsoft/OmniParser) and similar screen parsers | Any | Detection model + OCR over screenshots | Via OCR | Open source (varies) |
-| End-to-end VLM computer-use agents | Any | Model reasoning over screenshots | Via the model | Varies |
+| Tool | Mechanism | Reads values? |
+| --- | --- | --- |
+| [SikuliX](https://sikulix.github.io/) | OpenCV image matching + OCR | Via OCR only |
+| [PyAutoGUI](https://github.com/asweigart/pyautogui) | Input synthesis + basic image matching | No |
+| [OmniParser](https://github.com/microsoft/OmniParser) and similar screen parsers | Detection model + OCR over screenshots | Via OCR |
+| End-to-end VLM computer-use agents | Model reasoning over screenshots | Via the model |
 
-SikuliX and PyAutoGUI predate the model-based tools and share their failure mode in miniature: they see pixels, so anything that changes pixels without changing meaning — a theme, a DPI setting, font antialiasing — breaks the match. PyAutoGUI is primarily input synthesis and cannot read a value out of the UI at all. Screen parsers and VLM agents are less automation libraries than components of agent systems, which is the subject of the next section.
+SikuliX and PyAutoGUI predate the model-based tools and share their failure mode in miniature. They see pixels, so anything that changes pixels without changing meaning — a theme, a DPI setting, font antialiasing — breaks the match. PyAutoGUI is primarily input synthesis and cannot read a value out of the UI at all. Screen parsers and VLM agents are less automation libraries than components of agent systems, which is the subject of the next section.
 
 ## Driving a desktop from an AI agent
 
 An agent needs, on every step, an observation of the current UI and a way to act on it. The approaches differ mainly in how that observation is produced, and the differences compound because an agent observes many times per task.
 
-**Accessibility-tree-driven.** The agent queries the semantic tree, directly through a library like xa11y or through a CLI or MCP tool built on one. An observation is microseconds of latency and a few hundred tokens once serialized, and it is deterministic. Elements carry exact bounds and identifiers — role plus name — stable across renders and sessions, which is what lets a successful agent run harden into a repeatable script: the selector it used yesterday still names the same button today. The app must expose a tree, and the tree holds only what the app published.
+**Accessibility-driven.** The agent queries the semantic tree, directly through a library like xa11y or through a CLI or MCP tool built on one. An observation is microseconds of latency and a few hundred tokens once serialized, and it is deterministic. Elements carry exact bounds and identifiers, role plus name, that stay stable across renders and sessions, which is what lets a successful agent run harden into a repeatable script, since the selector it used yesterday still names the same button today. The app must expose accessibility data, and that data holds only what the app published.
 
 **Screen-parsing models.** [OmniParser](https://github.com/microsoft/OmniParser), Microsoft's open-source screenshot-to-structured-elements model, is the canonical example. A detection model plus OCR reconstructs a pseudo-tree from pixels — bounding boxes, text, inferred interactability — for whatever is visible, which reaches applications with no accessibility support at all. In exchange, every observation costs a model inference, detection introduces error, and identifiers are synthesized per screenshot rather than stable across renders, so there is nothing durable to write a script against. Acting on the structure requires a separate executor.
 
 **End-to-end VLM agents.** The model looks at a screenshot and decides the action directly. The most flexible option on UI nobody anticipated, since there is no intermediate representation to be wrong — and the slowest, least reproducible, and most expensive per step, because every step ships an image into a model.
 
-**Hybrid.** Increasingly the practical setup: the accessibility tree for structure, enumeration, and exact bounds, with vision only for what the tree does not expose — a canvas region, an image, a custom widget. The two are complementary observations of the same UI, and a screenshot cropped to an element's exact bounds (which the tree supplies) is a far better vision input than a full-screen capture. [agent-desktop](https://agent-desktop.dev) packages xa11y's tree queries, element screenshots, and event streams as a CLI for agents.
+**Hybrid.** Increasingly the practical setup, using accessibility data for structure, enumeration, and exact bounds, with vision only for what it does not expose, such as a canvas region, an image, or a custom widget. The two are complementary observations of the same UI, and a screenshot cropped to an element's exact bounds is a far better vision input than a full-screen capture. [agent-desktop](https://agent-desktop.dev) packages xa11y's tree queries, element screenshots, and event streams as a CLI for agents.
 
-| Decision axis | Accessibility tree | Screen parsing | End-to-end VLM |
+| Decision axis | Accessibility data | Screen parsing | End-to-end VLM |
 | --- | --- | --- | --- |
 | Latency per observation | Microseconds | Model inference | Model inference |
 | Tokens per observation | Hundreds | Thousands and up | Thousands and up |
 | Reproducible output | Yes | No | No |
-| Identifiers stable across runs | Yes — selectors persist | No — synthesized per screenshot | No |
+| Identifiers stable across runs | Yes, selectors persist | No, synthesized per screenshot | No |
 | Reaches non-accessible UI | No | Yes | Yes |
 
-Where an app has a usable tree, tree-driven observation wins on the first four axes; where it does not, vision is the only observation available. `xa11y tree --app <name>` answers in seconds which situation you are in.
+Where an app exposes usable accessibility data, that observation wins on the first four axes; where it does not, vision is the only observation available. The command-line tool answers in seconds which situation you are in.
 
-## Capability matrix
+## Every tool at a glance
 
-xa11y against the tools closest to it in scope. Platform and license columns are in the tables above and are not repeated here.
+| Tool | Platforms | Reads | Locators + auto-wait | License |
+| --- | --- | --- | --- | --- |
+| **xa11y** | macOS, Windows, Linux | Accessibility data | Yes | MIT |
+| Appium | macOS, Windows | Accessibility data | Yes | Apache-2.0 |
+| pywinauto | Windows | Accessibility data | No | BSD-3-Clause |
+| FlaUI | Windows | Accessibility data | No | MIT |
+| dogtail | Linux | Accessibility data | No | GPL-2.0 |
+| atomacos | macOS | Accessibility data | No | GPL-3.0 |
+| Squish | macOS, Windows, Linux | Toolkit internals | Yes | Commercial |
+| Ranorex Studio | Windows | Toolkit internals | Yes | Commercial |
+| TestComplete | Windows | Toolkit internals | Yes | Commercial |
+| SikuliX | macOS, Windows, Linux | Pixels | No | MIT |
+| PyAutoGUI | macOS, Windows, Linux | Pixels | No | BSD-3-Clause |
+| OmniParser and similar | Any | Vision model | No | Open source, varies |
+| VLM computer-use agents | Any | Vision model | No | Varies |
 
-| | xa11y | Appium | Squish | pywinauto | FlaUI |
-| --- | --- | --- | --- | --- | --- |
-| Single API across platforms | ● | ● | ● | n/a | n/a |
-| Selector language | CSS-like | XPath | Object map | Property dicts | Conditions API |
-| Auto-waiting on actions | ● | Configurable | ● | Explicit | Explicit |
-| Accessibility event streams | ● | ○ | ◐ | ○ | ● |
-| Input simulation | Separate surface | Merged | Merged | Merged | Merged |
-| Sees non-accessible widgets | ○ | ○ | ● | ○ | ○ |
-| Runs without a driver server | ● | ○ | ○ | ● | ● |
-| Recorder, IDE, and reporting | ○ | ○ | ● | ○ | ○ |
-| Ecosystem size and maturity | ○ | ● | ● | ● | ● |
+xa11y and Squish are the only two covering all three desktop platforms. pywinauto, FlaUI, dogtail, and atomacos give you the platform's API and leave waiting to the caller, while Appium and the commercial suites provide an element-addressing layer of their own.
 
-● full · ◐ partial · ○ none
-
-Stated as prose: xa11y and Squish are the only two that cover all three desktop platforms; xa11y, Squish, and FlaUI auto-wait, while pywinauto and FlaUI otherwise leave waiting to the caller; only Squish reaches widgets with no accessibility support; and only xa11y keeps input simulation on a surface separate from accessibility actions.
-
-xa11y is behind on two rows. It cannot see non-accessible widgets — a consequence of refusing to inject, not something it can engineer around: if a control publishes nothing to UIA or AT-SPI2, Squish reaches it through the toolkit's object model and xa11y cannot. And at v0.12.0 its ecosystem is far smaller than libraries with years of production use. Choosing xa11y bets that one cross-platform API saves more than a mature single-platform one; on one platform, permanently, it may not.
+xa11y cannot reach widgets that expose no accessibility data, a consequence of refusing to inject into the target process rather than something it can engineer around. If a control publishes nothing to UI Automation or AT-SPI2, Squish reaches it through the toolkit's object model and xa11y cannot. Its ecosystem is also much smaller than pywinauto's, FlaUI's, or the commercial suites', which have years of production use and deeper single-platform coverage. Choosing xa11y bets that one cross-platform API saves more than a mature single-platform one, and on one platform permanently it may not.
 
 ## Framework coverage in CI
 
-For an accessibility-driven tool, the practical question is not which platforms it claims but which UI toolkits actually work, because coverage depends on each toolkit's accessibility implementation. xa11y runs its integration suite against real applications in CI on every commit:
+For an accessibility-driven tool, the practical question is not which platforms it claims but which UI toolkits actually work, because coverage depends on each toolkit's accessibility implementation. xa11y runs its integration suite against real applications in CI on every commit.
 
 | Toolkit | Linux | macOS | Windows |
 | --- | --- | --- | --- |
@@ -129,28 +125,27 @@ For an accessibility-driven tool, the practical question is not which platforms 
 
 A dash means untested in CI, not known-broken — most combinations work, but only the marked cells are verified continuously. The [accessibility quirks](/guides/accessibility-quirks/) guide documents the per-toolkit behavior these tests pin down.
 
-Platform prerequisites are minimal but real: macOS needs the Accessibility permission (plus Screen Recording on macOS 26+), Linux needs AT-SPI2 running, and Windows needs nothing special.
+Platform prerequisites are minimal but real. macOS needs the Accessibility permission, plus Screen Recording on macOS 26+; Linux needs AT-SPI2 running; Windows needs nothing special.
 
 ## When not to use xa11y
 
-- **The app exposes no accessibility tree.** Games, canvas-drawn interfaces, and apps whose toolkit never wired up accessibility. Run `xa11y tree --app <name>`; if it comes back empty or shows one opaque window, you need injection (Squish, TestComplete), pixels (SikuliX), or vision.
+- **The app exposes no accessibility data.** Games, canvas-drawn interfaces, and apps whose toolkit never wired up accessibility. Dump the tree with the command-line tool first; if it comes back empty or shows one opaque window, you need injection (Squish, TestComplete), pixels (SikuliX), or vision.
 - **You need a recorder, an IDE, or a low-code interface.** xa11y is a library with none of those; the commercial suites bundle them.
 - **You are testing a website.** Playwright or Selenium test the DOM directly, control the browser lifecycle, and intercept network traffic. xa11y drives a browser only as another desktop app.
-- **You need API stability today.** v0.12.0 is pre-1.0; breaking changes still land in minor releases.
 - **You are on Windows only, permanently.** FlaUI and pywinauto expose more of UI Automation than xa11y does.
 - **You need vendor support with an SLA.** xa11y is a community project.
-- **You need to evaluate accessibility conformance.** xa11y reads the tree to automate apps; it does not evaluate the tree against WCAG. Use [axe](https://github.com/dequelabs/axe-core) or [Accessibility Insights](https://accessibilityinsights.io/).
+- **You need to evaluate accessibility conformance.** xa11y reads accessibility data to automate apps; it does not evaluate it against WCAG. Use [axe](https://github.com/dequelabs/axe-core) or [Accessibility Insights](https://accessibilityinsights.io/).
 
 ## Related but not competing
 
-- **[AccessKit](https://accesskit.dev/)** — publishes an accessibility tree from inside your app, where xa11y reads trees from outside. The two are opposite sides of the same interface and compose: xa11y's own egui and winit test apps are AccessKit-backed, which is how one suite runs against a pure-Rust GUI on all three platforms.
+- **[AccessKit](https://accesskit.dev/)** — publishes accessibility data from inside your app, where xa11y reads it from outside. The two are opposite sides of the same interface and compose, since xa11y's own egui and winit test apps are AccessKit-backed, which is how one suite runs against a pure-Rust GUI on all three platforms.
 - **[Playwright](https://playwright.dev/)** — browser automation, and the design influence behind xa11y's `Locator` pattern and selector syntax.
 - **[agent-desktop](https://agent-desktop.dev)** — a CLI built on xa11y for AI agents that read and control desktops.
 - **RPA platforms** — UiPath and Power Automate Desktop solve business process automation, with orchestration, scheduling, and enterprise licensing. Overlapping techniques, different product category.
-- **Accessibility auditing tools** — axe and Accessibility Insights evaluate a tree against WCAG criteria. xa11y does no conformance evaluation.
+- **Accessibility auditing tools** — axe and Accessibility Insights evaluate accessibility data against WCAG criteria. xa11y does no conformance evaluation.
 
 ## How these claims were checked
 
-Verified July 2026 against: xa11y 0.12.0, FlaUI 5.0.0 (released February 2025), pywinauto 0.6.x, the Appium Windows and Mac2 drivers, dogtail 1.x (which added Wayland support via gnome-ponytail-daemon), atomacos (low recent activity), SikuliX 2.x, and the current public documentation for Squish, Ranorex Studio, and TestComplete.
+Verified July 2026 against FlaUI 5.0.0 (released February 2025), pywinauto 0.6.x, the Appium Windows and Mac2 drivers, dogtail 1.x (which added Wayland support via gnome-ponytail-daemon), atomacos (low recent activity), SikuliX 2.x, and the current public documentation for Squish, Ranorex Studio, and TestComplete.
 
 Comparisons rot, and a wrong claim about another project is the most expensive kind of error on a page like this. If you find one, please [open an issue](https://github.com/xa11y/xa11y/issues).

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -1,0 +1,122 @@
+---
+title: Comparison
+description: How xa11y compares to pywinauto, Appium, FlaUI, Terminator, SikuliX, Playwright, and other desktop UI automation tools — and when to choose something else.
+---
+
+xa11y drives native desktop applications by reading and acting on the **accessibility tree** — the same data screen readers consume — through one API on macOS, Windows, and Linux.
+
+If the application you need to automate does not expose an accessibility tree, xa11y cannot help you, and no amount of configuration will change that. Games, canvas-rendered UIs, and apps built on toolkits that were never wired up for accessibility are all in this category. Skip to [when not to use xa11y](#when-not-to-use-xa11y) — the honest answer there is a pixel- or vision-based tool.
+
+## Choose by what you're doing
+
+| If you are… | Consider | Why |
+| --- | --- | --- |
+| Testing a desktop app on **more than one OS** from one test suite | **xa11y** | One selector language and one API across AXUIElement, UI Automation, and AT-SPI2. This is the case it exists for. |
+| Testing a **Windows-only** app, and your team writes C# | [FlaUI](https://github.com/FlaUI/FlaUI) | A thin, well-maintained UIA wrapper with far more Windows-specific surface area than xa11y exposes. |
+| Testing a **Windows-only** app, and your team writes Python | [pywinauto](https://pywinauto.readthedocs.io/) or xa11y | pywinauto has a decade of accumulated Windows knowledge and a much larger body of examples. Choose xa11y if you expect to add macOS or Linux later. |
+| Already invested in **Appium/WebDriver** infrastructure | [Appium](https://appium.io/) | If you have a Selenium grid, reporting, and a team fluent in WebDriver, that consistency is worth more than a nicer local API. |
+| Building a **computer-use agent** on Windows | [Terminator](https://github.com/mediar-ai/terminator) or xa11y | Terminator is Windows-only but ships an MCP server and agent-shaped tooling. xa11y is the choice if the agent must also run on macOS or Linux. |
+| Automating an app with **no accessibility support** | [SikuliX](https://sikulix.github.io/), a VLM agent | No accessibility tool can drive what is not exposed. Match pixels or reason over screenshots. |
+| Auditing an app for **accessibility conformance** | [axe](https://github.com/dequelabs/axe-core), [Accessibility Insights](https://accessibilityinsights.io/) | xa11y reads the accessibility tree to automate apps; it does not evaluate that tree against WCAG or produce conformance reports. |
+| Adding accessibility **to** an app you are writing | [AccessKit](https://accesskit.dev/) | The other side of the same interface. AccessKit publishes a tree; xa11y consumes one. |
+
+## The fork in the road: how a tool sees the UI
+
+Nearly every meaningful difference between these tools follows from one choice — what they treat as the source of truth about the screen.
+
+**Accessibility tree.** The app publishes a structured description of itself: roles, names, values, states, bounds. Elements are addressed semantically (`button[name='Submit']`), so layout changes, themes, resolutions, and translations-in-progress don't break your selectors, and matching costs microseconds. The cost is a hard dependency on the app's accessibility support. Where it's absent or wrong, you get nothing. xa11y, pywinauto, FlaUI, Appium, dogtail, and Terminator all live here.
+
+**Pixel matching.** The tool screenshots the screen and looks for a reference image. It works on literally anything visible, including remote desktops and video. It also breaks on theme changes, DPI changes, font rendering differences, and antialiasing, and it cannot read a value it wasn't given a picture of. SikuliX and PyAutoGUI live here.
+
+**Vision-language models.** A model looks at a screenshot and decides where to click. Maximum flexibility, no reference images needed, and it tolerates UI it has never seen. It is also non-deterministic, costs a model call per step, and is orders of magnitude slower than a tree query. Increasingly these are used *with* an accessibility tree rather than instead of one — the tree gives exact bounds and stable identifiers, the model handles intent.
+
+The families are not mutually exclusive, and the strongest setups mix them: drive with the accessibility tree, fall back to pixels for the one canvas widget that has no tree. What matters is knowing which mechanism you are relying on for any given step. xa11y is deliberate about this line — its [input simulation](/guides/input/) is a separate surface that never silently substitutes for an accessibility action, so a passing test can't quietly degrade into blind coordinate clicking.
+
+## The landscape
+
+Accessibility-driven tools, which is where xa11y competes directly:
+
+| Tool | Platforms | Languages | Underlying API | License |
+| --- | --- | --- | --- | --- |
+| **xa11y** | macOS, Windows, Linux | Rust, Python, JavaScript | AXUIElement, UI Automation, AT-SPI2 | MIT |
+| [Appium](https://appium.io/) (Windows + Mac2 drivers) | macOS, Windows | Any WebDriver client | WinAppDriver, XCTest | Apache-2.0 |
+| [Terminator](https://github.com/mediar-ai/terminator) | Windows | Rust, Python, TypeScript | UI Automation | MIT |
+| [pywinauto](https://pywinauto.readthedocs.io/) | Windows | Python | Win32, UI Automation | BSD-3-Clause |
+| [FlaUI](https://github.com/FlaUI/FlaUI) | Windows | C#/.NET | UI Automation (UIA2/UIA3) | MIT |
+| [dogtail](https://gitlab.com/dogtail/dogtail) | Linux | Python | AT-SPI2 | GPL-2.0 |
+| [atomacos](https://github.com/daveenguyen/atomacos) | macOS | Python | AXUIElement | GPL-3.0 |
+
+Pixel- and vision-based tools, which see the screen instead of the tree:
+
+| Tool | Platforms | Mechanism | Reads values? | License |
+| --- | --- | --- | --- | --- |
+| [SikuliX](https://sikulix.github.io/) | macOS, Windows, Linux | OpenCV image matching + OCR | Via OCR only | MIT |
+| [PyAutoGUI](https://github.com/asweigart/pyautogui) | macOS, Windows, Linux | Input synthesis + basic image matching | No | BSD-3-Clause |
+| VLM computer-use agents | Any | Model reasoning over screenshots | Via the model | Varies |
+
+Commercial suites occupy a different category — they bundle a recorder, an IDE, reporting, and support, and are licensed per seat. [Squish](https://www.qt.io/product/quality-assurance/squish) is cross-platform with unusually deep Qt integration; [Ranorex](https://www.ranorex.com/) and [TestComplete](https://smartbear.com/product/testcomplete/) are Windows-centric and combine accessibility, pixel, and injected-agent techniques. Their feature sets are documented behind sales processes, so this page does not attempt a feature-level comparison — evaluate them directly if a bundled recorder and vendor support are what you are buying.
+
+## Capabilities
+
+Comparing xa11y against the accessibility-driven tools closest to it in scope:
+
+| | xa11y | Appium | Terminator | pywinauto | FlaUI |
+| --- | --- | --- | --- | --- | --- |
+| macOS / Windows / Linux | ● ● ● | ● ● ○ | ○ ● ○ | ○ ● ○ | ○ ● ○ |
+| Single API across platforms | ● | ● | n/a | n/a | n/a |
+| CSS-like selectors | ● | XPath | ● | Property dicts | Conditions API |
+| Auto-waiting on actions | ● | Configurable | ● | Explicit | Explicit |
+| Accessibility event streams | ● | ○ | ○ | ○ | ● |
+| Screenshots | ● | ● | ● | ● | ● |
+| Input simulation | Separate surface | Merged | Merged | Merged | Merged |
+| Runs without a browser/driver server | ● | ○ | ● | ● | ● |
+| Ecosystem size and maturity | ○ | ● | ◐ | ● | ● |
+
+● full · ◐ partial · ○ none
+
+Two rows deserve elaboration, one in each direction.
+
+**Auto-waiting.** A `Locator` in xa11y is a lazy query, not a captured handle. Every action re-resolves the selector and waits for the element to be visible and enabled before acting, which removes the retry-loop scaffolding that desktop test suites usually accumulate. This is borrowed wholesale from [Playwright's locator model](https://playwright.dev/docs/locators). Tools that hand you a captured element instead make staleness your problem — a real source of flake when the app redraws between find and click.
+
+**Maturity.** xa11y is at v0.12 and its API is not yet stable. pywinauto and FlaUI have years of production use, deeper per-platform coverage, more Stack Overflow answers, and more people who have already hit your bug. If you are automating one Windows app and will never need another platform, that accumulated knowledge is worth more than anything on this page. Choosing xa11y is a bet that one cross-platform API saves you more than a mature single-platform one.
+
+## Framework coverage
+
+The practical question for an accessibility-driven tool is not which platforms it claims but which UI toolkits actually work, since coverage depends on each toolkit's accessibility implementation. xa11y runs its integration suite against real applications in CI on every commit:
+
+| Toolkit | Linux | macOS | Windows |
+| --- | --- | --- | --- |
+| Qt | ● | ● | ● |
+| GTK4 | ● | — | — |
+| Tauri (WebKit/WebView2) | ● | ● | — |
+| Electron | ● | — | — |
+| egui / AccessKit | ● | ● | ● |
+| Cocoa / AppKit | — | ● | — |
+| WinForms | — | — | ● |
+| WPF | — | — | ● |
+
+A dash means untested in CI, not known-broken — most combinations work, but only the marked cells are verified continuously. The [Accessibility Quirks](/guides/accessibility-quirks/) guide documents the per-toolkit behaviour that these tests pin down.
+
+## When not to use xa11y
+
+- **The app exposes no accessibility tree.** Games, canvas-drawn interfaces, custom-rendered engines, and applications whose toolkit has accessibility disabled. Run `xa11y tree --app <name>` to check in a few seconds; if it comes back empty or shows a single opaque window, use SikuliX or a VLM agent.
+- **You need a recorder or a low-code interface.** xa11y is a library. Ranorex, TestComplete, and Squish sell exactly this.
+- **You are testing a website.** Use [Playwright](https://playwright.dev/) or Selenium. They test the DOM directly, control the browser lifecycle, and intercept network traffic — none of which xa11y does. xa11y drives a browser only as another desktop app.
+- **You need API stability today.** v0.12 is pre-1.0 and breaking changes still land in minor releases.
+- **You are on Windows only, permanently.** FlaUI and pywinauto expose more of UI Automation than xa11y does.
+- **You need to evaluate accessibility conformance.** xa11y reports what the tree says, not whether it complies with WCAG or ARIA authoring practices.
+
+## Related but not competing
+
+- **[AccessKit](https://accesskit.dev/)** — a library for *publishing* an accessibility tree from your app. xa11y *reads* trees. They compose: xa11y's own egui and winit test applications are AccessKit-backed, which is how the same suite runs against a pure-Rust GUI on all three platforms.
+- **[Playwright](https://playwright.dev/)** — browser automation. Not a competitor, but the major design influence on xa11y's `Locator` pattern, auto-waiting, and selector syntax.
+- **[agent-desktop](https://agent-desktop.dev)** — a CLI built *on* xa11y for AI agents that read and control desktops. If you want an agent tool rather than a library, start there.
+- **RPA platforms** — UiPath and Power Automate Desktop solve business process automation, including orchestration, scheduling, and licensing. Overlapping techniques, different product category.
+
+## How these claims were checked
+
+Verified July 2026 against: xa11y 0.12.0, FlaUI 5.0.0, pywinauto 0.6.x, Appium Windows and Mac2 drivers, Terminator (`terminator-rs`), dogtail 1.x, SikuliX 2.x.
+
+Two details worth knowing if you are evaluating Appium on Windows: its Windows driver proxies to Microsoft's **WinAppDriver**, which has had no release since 2022, though the Appium-side driver itself remains actively maintained. And the **Mac2** driver is built on XCTest, so it requires Xcode on every machine that runs tests — a meaningful constraint for CI images.
+
+Corrections are welcome — comparisons rot, and a wrong claim about another project is the most expensive kind of error on a page like this. Please [open an issue](https://github.com/xa11y/xa11y/issues).

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -1,22 +1,24 @@
 ---
 title: Comparison
-description: How xa11y compares to pywinauto, Appium, FlaUI, Terminator, SikuliX, Playwright, and other desktop UI automation tools — and when to choose something else.
+description: How xa11y compares to pywinauto, Appium, FlaUI, Squish, Ranorex, TestComplete, SikuliX, and other desktop UI automation tools — and when to choose something else.
 ---
 
 xa11y drives native desktop applications by reading and acting on the **accessibility tree** — the same data screen readers consume — through one API on macOS, Windows, and Linux.
 
-If the application you need to automate does not expose an accessibility tree, xa11y cannot help you, and no amount of configuration will change that. Games, canvas-rendered UIs, and apps built on toolkits that were never wired up for accessibility are all in this category. Skip to [when not to use xa11y](#when-not-to-use-xa11y) — the honest answer there is a pixel- or vision-based tool.
+If the application you need to automate does not expose an accessibility tree, xa11y cannot help you, and no amount of configuration will change that. Games, canvas-rendered UIs, and apps built on toolkits that were never wired up for accessibility are all in this category. Skip to [when not to use xa11y](#when-not-to-use-xa11y) — the honest answer there is a commercial tool that injects into the process, or a pixel-based one.
 
 ## Choose by what you're doing
 
 | If you are… | Consider | Why |
 | --- | --- | --- |
 | Testing a desktop app on **more than one OS** from one test suite | **xa11y** | One selector language and one API across AXUIElement, UI Automation, and AT-SPI2. This is the case it exists for. |
+| Building a **computer-use agent** or MCP tool | **xa11y** | A semantic tree costs microseconds to query and far fewer tokens than a screenshot, and it works the same on all three platforms. [agent-desktop](https://agent-desktop.dev) is a ready-made CLI built on it. |
 | Testing a **Windows-only** app, and your team writes C# | [FlaUI](https://github.com/FlaUI/FlaUI) | A thin, well-maintained UIA wrapper with far more Windows-specific surface area than xa11y exposes. |
 | Testing a **Windows-only** app, and your team writes Python | [pywinauto](https://pywinauto.readthedocs.io/) or xa11y | pywinauto has a decade of accumulated Windows knowledge and a much larger body of examples. Choose xa11y if you expect to add macOS or Linux later. |
 | Already invested in **Appium/WebDriver** infrastructure | [Appium](https://appium.io/) | If you have a Selenium grid, reporting, and a team fluent in WebDriver, that consistency is worth more than a nicer local API. |
-| Building a **computer-use agent** on Windows | [Terminator](https://github.com/mediar-ai/terminator) or xa11y | Terminator is Windows-only but ships an MCP server and agent-shaped tooling. xa11y is the choice if the agent must also run on macOS or Linux. |
-| Automating an app with **no accessibility support** | [SikuliX](https://sikulix.github.io/), a VLM agent | No accessibility tool can drive what is not exposed. Match pixels or reason over screenshots. |
+| Testing a **Qt or QML** app in depth, with budget | [Squish](https://www.qt.io/product/quality-assurance/squish) | It reads Qt's own object model rather than the accessibility projection of it, reaching QML internals and custom widgets that expose nothing to AT-SPI2 or UIA. |
+| Staffing testers who **don't write code** | [Ranorex](https://www.ranorex.com/), [TestComplete](https://smartbear.com/product/testcomplete/), Squish | Record-and-playback, an IDE, reporting, and vendor support are the product. xa11y is a library with none of that. |
+| Automating an app with **no accessibility support** | [SikuliX](https://sikulix.github.io/), a VLM agent, or a commercial suite | No accessibility tool can drive what is not exposed. Match pixels, reason over screenshots, or inject into the process. |
 | Auditing an app for **accessibility conformance** | [axe](https://github.com/dequelabs/axe-core), [Accessibility Insights](https://accessibilityinsights.io/) | xa11y reads the accessibility tree to automate apps; it does not evaluate that tree against WCAG or produce conformance reports. |
 | Adding accessibility **to** an app you are writing | [AccessKit](https://accesskit.dev/) | The other side of the same interface. AccessKit publishes a tree; xa11y consumes one. |
 
@@ -24,7 +26,9 @@ If the application you need to automate does not expose an accessibility tree, x
 
 Nearly every meaningful difference between these tools follows from one choice — what they treat as the source of truth about the screen.
 
-**Accessibility tree.** The app publishes a structured description of itself: roles, names, values, states, bounds. Elements are addressed semantically (`button[name='Submit']`), so layout changes, themes, resolutions, and translations-in-progress don't break your selectors, and matching costs microseconds. The cost is a hard dependency on the app's accessibility support. Where it's absent or wrong, you get nothing. xa11y, pywinauto, FlaUI, Appium, dogtail, and Terminator all live here.
+**Accessibility tree.** The app publishes a structured description of itself: roles, names, values, states, bounds. Elements are addressed semantically (`button[name='Submit']`), so layout changes, themes, resolutions, and translations-in-progress don't break your selectors, and matching costs microseconds. Nothing is installed into the application under test — you automate the shipping binary. The cost is a hard dependency on the app's accessibility support: where it's absent or wrong, you get nothing. xa11y, pywinauto, FlaUI, Appium, dogtail, and atomacos live here.
+
+**Toolkit introspection.** The tool loads a hook into the application's process and reads the *real* widget objects — Qt's `QObject` tree, .NET's visual tree, Java's AWT/Swing hierarchy — rather than the accessibility projection of them. This sees strictly more than accessibility does: unnamed custom widgets, QML internals, private properties, and controls whose authors never implemented accessibility at all. The costs are that you need a build the hook supports, the injection changes the process you're testing, and this is almost exclusively commercial territory. Squish, Ranorex, and TestComplete live here, each falling back to accessibility APIs for the toolkits they lack a dedicated hook for.
 
 **Pixel matching.** The tool screenshots the screen and looks for a reference image. It works on literally anything visible, including remote desktops and video. It also breaks on theme changes, DPI changes, font rendering differences, and antialiasing, and it cannot read a value it wasn't given a picture of. SikuliX and PyAutoGUI live here.
 
@@ -34,17 +38,24 @@ The families are not mutually exclusive, and the strongest setups mix them: driv
 
 ## The landscape
 
-Accessibility-driven tools, which is where xa11y competes directly:
+Open-source tools that read the accessibility tree, which is where xa11y competes most directly:
 
 | Tool | Platforms | Languages | Underlying API | License |
 | --- | --- | --- | --- | --- |
 | **xa11y** | macOS, Windows, Linux | Rust, Python, JavaScript | AXUIElement, UI Automation, AT-SPI2 | MIT |
 | [Appium](https://appium.io/) (Windows + Mac2 drivers) | macOS, Windows | Any WebDriver client | WinAppDriver, XCTest | Apache-2.0 |
-| [Terminator](https://github.com/mediar-ai/terminator) | Windows | Rust, Python, TypeScript | UI Automation | MIT |
 | [pywinauto](https://pywinauto.readthedocs.io/) | Windows | Python | Win32, UI Automation | BSD-3-Clause |
 | [FlaUI](https://github.com/FlaUI/FlaUI) | Windows | C#/.NET | UI Automation (UIA2/UIA3) | MIT |
 | [dogtail](https://gitlab.com/dogtail/dogtail) | Linux | Python | AT-SPI2 | GPL-2.0 |
 | [atomacos](https://github.com/daveenguyen/atomacos) | macOS | Python | AXUIElement | GPL-3.0 |
+
+Commercial suites, which bundle a recorder, an IDE, reporting, and support, and license per seat:
+
+| Tool | Desktop targets | Languages | Primary mechanism | Notes |
+| --- | --- | --- | --- | --- |
+| [Squish](https://www.qt.io/product/quality-assurance/squish) | macOS, Windows, Linux | Python, JavaScript, Perl, Ruby, Tcl | Toolkit introspection (Qt, Java, native) | The only genuinely cross-platform option here. Unmatched Qt and QML depth. |
+| [Ranorex Studio](https://www.ranorex.com/) | Windows | C#, VB.NET | UIA + .NET introspection | Windows-hosted and Windows-targeted; no native macOS app testing. |
+| [TestComplete](https://smartbear.com/product/testcomplete/) | Windows | Python, JavaScript, VBScript, JScript, DelphiScript | UIA + .NET/Java/Delphi introspection | Broadest legacy-toolkit coverage, including Delphi and VCL. |
 
 Pixel- and vision-based tools, which see the screen instead of the tree:
 
@@ -54,31 +65,36 @@ Pixel- and vision-based tools, which see the screen instead of the tree:
 | [PyAutoGUI](https://github.com/asweigart/pyautogui) | macOS, Windows, Linux | Input synthesis + basic image matching | No | BSD-3-Clause |
 | VLM computer-use agents | Any | Model reasoning over screenshots | Via the model | Varies |
 
-Commercial suites occupy a different category — they bundle a recorder, an IDE, reporting, and support, and are licensed per seat. [Squish](https://www.qt.io/product/quality-assurance/squish) is cross-platform with unusually deep Qt integration; [Ranorex](https://www.ranorex.com/) and [TestComplete](https://smartbear.com/product/testcomplete/) are Windows-centric and combine accessibility, pixel, and injected-agent techniques. Their feature sets are documented behind sales processes, so this page does not attempt a feature-level comparison — evaluate them directly if a bundled recorder and vendor support are what you are buying.
-
 ## Capabilities
 
-Comparing xa11y against the accessibility-driven tools closest to it in scope:
+Comparing xa11y against the tools closest to it in scope, across both the open-source and commercial columns:
 
-| | xa11y | Appium | Terminator | pywinauto | FlaUI |
+| | xa11y | Appium | Squish | pywinauto | FlaUI |
 | --- | --- | --- | --- | --- | --- |
-| macOS / Windows / Linux | ● ● ● | ● ● ○ | ○ ● ○ | ○ ● ○ | ○ ● ○ |
-| Single API across platforms | ● | ● | n/a | n/a | n/a |
-| CSS-like selectors | ● | XPath | ● | Property dicts | Conditions API |
+| macOS / Windows / Linux | ● ● ● | ● ● ○ | ● ● ● | ○ ● ○ | ○ ● ○ |
+| Single API across platforms | ● | ● | ● | n/a | n/a |
+| CSS-like selectors | ● | XPath | Object map | Property dicts | Conditions API |
 | Auto-waiting on actions | ● | Configurable | ● | Explicit | Explicit |
-| Accessibility event streams | ● | ○ | ○ | ○ | ● |
+| Accessibility event streams | ● | ○ | ◐ | ○ | ● |
 | Screenshots | ● | ● | ● | ● | ● |
 | Input simulation | Separate surface | Merged | Merged | Merged | Merged |
-| Runs without a browser/driver server | ● | ○ | ● | ● | ● |
-| Ecosystem size and maturity | ○ | ● | ◐ | ● | ● |
+| Sees non-accessible widgets | ○ | ○ | ● | ○ | ○ |
+| Requires no in-process hook | ● | ● | ○ | ● | ● |
+| Runs without a driver server | ● | ○ | ○ | ● | ● |
+| Record and playback | ○ | ○ | ● | ○ | ○ |
+| Bundled IDE and reporting | ○ | ○ | ● | ○ | ○ |
+| Free to use | ● | ● | ○ | ● | ● |
+| Ecosystem size and maturity | ○ | ● | ● | ● | ● |
 
 ● full · ◐ partial · ○ none
 
-Two rows deserve elaboration, one in each direction.
+Three rows deserve elaboration, and xa11y loses two of them.
 
 **Auto-waiting.** A `Locator` in xa11y is a lazy query, not a captured handle. Every action re-resolves the selector and waits for the element to be visible and enabled before acting, which removes the retry-loop scaffolding that desktop test suites usually accumulate. This is borrowed wholesale from [Playwright's locator model](https://playwright.dev/docs/locators). Tools that hand you a captured element instead make staleness your problem — a real source of flake when the app redraws between find and click.
 
-**Maturity.** xa11y is at v0.12 and its API is not yet stable. pywinauto and FlaUI have years of production use, deeper per-platform coverage, more Stack Overflow answers, and more people who have already hit your bug. If you are automating one Windows app and will never need another platform, that accumulated knowledge is worth more than anything on this page. Choosing xa11y is a bet that one cross-platform API saves you more than a mature single-platform one.
+**Seeing non-accessible widgets.** This is the structural advantage the commercial suites have, and it is not one xa11y can engineer around — it follows from refusing to inject into the process under test. If your app has a custom-drawn control that publishes nothing to UIA or AT-SPI2, Squish can drive it through Qt's object model and xa11y cannot see it at all. Whether that matters depends entirely on your app; run `xa11y tree --app <name>` and look for the controls you care about before deciding.
+
+**Maturity.** xa11y is at v0.12 and its API is not yet stable. pywinauto, FlaUI, and the commercial suites have years of production use, deeper per-platform coverage, more Stack Overflow answers, and more people who have already hit your bug. If you are automating one Windows app and will never need another platform, that accumulated knowledge is worth more than anything on this page. Choosing xa11y is a bet that one cross-platform API saves you more than a mature single-platform one.
 
 ## Framework coverage
 
@@ -99,11 +115,12 @@ A dash means untested in CI, not known-broken — most combinations work, but on
 
 ## When not to use xa11y
 
-- **The app exposes no accessibility tree.** Games, canvas-drawn interfaces, custom-rendered engines, and applications whose toolkit has accessibility disabled. Run `xa11y tree --app <name>` to check in a few seconds; if it comes back empty or shows a single opaque window, use SikuliX or a VLM agent.
-- **You need a recorder or a low-code interface.** xa11y is a library. Ranorex, TestComplete, and Squish sell exactly this.
+- **The app exposes no accessibility tree.** Games, canvas-drawn interfaces, custom-rendered engines, and applications whose toolkit has accessibility disabled. Run `xa11y tree --app <name>` to check in a few seconds; if it comes back empty or shows a single opaque window, you need a tool that injects into the process (Squish, TestComplete) or one that matches pixels (SikuliX).
+- **You need a recorder or a low-code interface.** xa11y is a library with no IDE, no recorder, and no reporting. Ranorex, TestComplete, and Squish sell exactly this, and for a team of non-programming testers that bundle is the product.
 - **You are testing a website.** Use [Playwright](https://playwright.dev/) or Selenium. They test the DOM directly, control the browser lifecycle, and intercept network traffic — none of which xa11y does. xa11y drives a browser only as another desktop app.
 - **You need API stability today.** v0.12 is pre-1.0 and breaking changes still land in minor releases.
 - **You are on Windows only, permanently.** FlaUI and pywinauto expose more of UI Automation than xa11y does.
+- **You need vendor support with an SLA.** xa11y is a community project. The commercial suites include support contracts.
 - **You need to evaluate accessibility conformance.** xa11y reports what the tree says, not whether it complies with WCAG or ARIA authoring practices.
 
 ## Related but not competing
@@ -115,8 +132,10 @@ A dash means untested in CI, not known-broken — most combinations work, but on
 
 ## How these claims were checked
 
-Verified July 2026 against: xa11y 0.12.0, FlaUI 5.0.0, pywinauto 0.6.x, Appium Windows and Mac2 drivers, Terminator (`terminator-rs`), dogtail 1.x, SikuliX 2.x.
+Verified July 2026 against: xa11y 0.12.0, FlaUI 5.0.0, pywinauto 0.6.x, Appium Windows and Mac2 drivers, dogtail 1.x, SikuliX 2.x, and current vendor documentation for Squish, Ranorex Studio, and TestComplete.
 
 Two details worth knowing if you are evaluating Appium on Windows: its Windows driver proxies to Microsoft's **WinAppDriver**, which has had no release since 2022, though the Appium-side driver itself remains actively maintained. And the **Mac2** driver is built on XCTest, so it requires Xcode on every machine that runs tests — a meaningful constraint for CI images.
+
+Commercial suites are compared at the level their public documentation supports — platforms, languages, and mechanism — rather than feature by feature, because much of their detail sits behind sales processes and evaluation licences. Treat those three rows as a starting point for your own trial, not a substitute for one.
 
 Corrections are welcome — comparisons rot, and a wrong claim about another project is the most expensive kind of error on a page like this. Please [open an issue](https://github.com/xa11y/xa11y/issues).

--- a/docs/site/src/content/docs/guides/overview.mdx
+++ b/docs/site/src/content/docs/guides/overview.mdx
@@ -62,12 +62,11 @@ FocusChanged  app="Calculator"  target=text_field "Display"
 
 xa11y supports subscribing to these event streams per-app via `app.subscribe()`.
 
-## How does xa11y compare to
+## How does xa11y compare to other tools?
 
-- **[AccessKit](https://accesskit.dev/)** — AccessKit is for *adding* accessibility to an app. xa11y is for *reading* accessibility data from the outside.
-- **[Playwright](https://playwright.dev/)** — Similar concept, specific to web browsers. Major design inspiration for xa11y's Locator pattern and selector syntax.
-- **[pyatspi2](https://gitlab.gnome.org/GNOME/pyatspi2) / direct UIAutomation** — Single-platform libraries. xa11y wraps these underlying APIs into one cross-platform interface.
-- **[agent-desktop](https://github.com/crowecawcaw/agent-desktop)** — CLI tool built on xa11y for AI agents to read and interact with desktops via accessibility data.
+xa11y reads accessibility trees from the outside, across all three desktop platforms, through one API. That distinguishes it from single-platform libraries like pywinauto and FlaUI, from pixel-matching tools like SikuliX, and from [AccessKit](https://accesskit.dev/), which *publishes* a tree rather than consuming one.
+
+See the [comparison page](/compare/) for the full landscape, capability tables, and when to choose something else.
 
 ## Concepts
 


### PR DESCRIPTION
Adds /compare/ as a single top-level page covering the desktop UI
automation landscape: how xa11y relates to pywinauto, Appium, FlaUI,
Terminator, dogtail, atomacos, SikuliX, PyAutoGUI, and the commercial
suites, plus the adjacent tools people confuse it with (AccessKit,
Playwright, RPA platforms, accessibility auditors).

Organised around the decision rather than the vendor list:

- A "choose by what you're doing" table that routes readers to other
  tools where those are the better fit.
- The mechanism split — accessibility tree vs. pixel matching vs. VLM —
  since nearly every other difference follows from it.
- Landscape and capability tables, including the rows where xa11y loses
  (maturity, per-platform depth, ecosystem size).
- Framework coverage taken from the toolkits the integration matrix
  actually exercises in CI, with untested cells marked as untested
  rather than implied working.
- A standalone "when not to use xa11y" section.
- A dated verification footer naming the versions each claim was checked
  against, so staleness is visible rather than silent.

The overview guide had a four-bullet comparison section covering the
same ground. Reduced to a summary paragraph pointing at /compare/ so
there is one canonical answer instead of two competing ones.

Placed at the top level of the sidebar rather than inside Docs: it is an
entry point for evaluation, not reference material.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GoqDYwtestPwGndVBZBaxL