### PR TITLE
Add Vale prose linting for README and docs, fix the findings

### DIFF
--- a/.github/styles/config/vocabularies/xa11y/accept.txt
+++ b/.github/styles/config/vocabularies/xa11y/accept.txt
@@ -1,0 +1,93 @@
+# Terms Vale's dictionary doesn't know but this project uses in prose.
+#
+# Entries are regular expressions. An all-lowercase entry matches
+# case-insensitively, which also makes `Vale.Terms` enforce that lowercase
+# spelling; a word this project writes in both cases is therefore given a
+# character class so neither casing is declared canonical.
+#
+# Keep alphabetical within each group.
+
+# ── Accessibility APIs ──────────────────────────────────────────────
+APIs
+AX[A-Z][A-Za-z]+
+QObject
+UIs
+input_sim
+interactability
+showmenu
+static_text
+subrole
+[Ss]ubtrees?
+
+# ── Platforms, toolkits, and desktop stacks ─────────────────────────
+CGEvent
+Cmd
+GTK
+GUIs
+Hyprland
+JScript
+Qt
+Tauri
+Tcl
+VBScript
+XTest
+XWayland
+Xcode
+Xvfb
+[Bb]idi
+dbus
+eframe
+egui
+evdev
+libei
+libevdev
+tmpfs
+toolkits?
+tooltip
+uinput
+weston
+widget
+winit
+wlroots
+
+# ── Tooling and ecosystem names ─────────────────────────────────────
+Appium
+Docker
+Ranorex
+XCTest
+atomacos
+clippy
+dogtail
+froglogic
+libFuzzer
+maturin
+napi
+pytest
+pywinauto
+serde
+
+# ── Software-writing vocabulary ─────────────────────────────────────
+antialiasing
+combinators?
+compat
+deduplicated
+env
+fuzzers?
+greppable
+[Ii]nteg
+lookups
+memoization
+outer
+renderers
+repo
+runtime
+subprocess
+substring
+surfaceably
+teardown
+tearoff
+typechecks
+uncheck
+unstripped
+upscaled
+viewport

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,56 @@
+name: Docs Lint
+
+# Prose linting for the root README and the hand-written pages of the docs
+# site. Scoped by path so a Rust-only change doesn't pay for a Vale run, and
+# so a change to the rules or the vocabulary re-lints everything.
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - README.md
+      - "docs/site/src/content/docs/**"
+      - .vale.ini
+      - ".github/styles/config/**"
+      - .github/workflows/docs-lint.yml
+  pull_request:
+    branches: [main, master]
+    paths:
+      - README.md
+      - "docs/site/src/content/docs/**"
+      - .vale.ini
+      - ".github/styles/config/**"
+      - .github/workflows/docs-lint.yml
+
+concurrency:
+  group: docs-lint-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  vale:
+    name: Vale
+    runs-on: ubuntu-latest
+    env:
+      # Pinned so an upstream Vale release can't change what passes without a
+      # commit here. The style package is pinned separately, in .vale.ini.
+      VALE_VERSION: 3.9.1
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Vale
+        run: |
+          set -euo pipefail
+          url="https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          curl -fsSL "$url" | tar -xz -C /usr/local/bin vale
+          vale --version
+
+      # Fetches the style package named in .vale.ini into .github/styles/.
+      # That directory is gitignored apart from the project vocabulary, so
+      # the rules are downloaded rather than vendored.
+      - name: Sync Vale styles
+        run: vale sync
+
+      - name: Lint README and docs
+        run: vale README.md docs/site/src/content/docs

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ docs/site/src/content/docs/api/javascript.mdx
 # unpinned previously let an incompatible transitive release (alloc-no-stdlib
 # 3.0.0 via brotli) break CI on every PR.
 
+# Vale styles fetched by `vale sync` from the `Packages` line in .vale.ini.
+# The config and the project vocabulary are committed; the downloaded rule
+# files are not, the same way vendored dependencies aren't.
+/.github/styles/*
+!/.github/styles/config/
+
 # Scratch files written by the release-note workflows (.github/workflows/
 # publish.yml and update-release-notes.yml) into the checkout root.
 /release-notes-context.txt

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,42 @@
+StylesPath = .github/styles
+MinAlertLevel = error
+
+# `Vale` is the built-in style that ships with the binary (spelling,
+# repetition, and a small set of Vale-maintained checks). `ai-tells` is
+# downloaded by `vale sync`. The release is pinned so a new upstream rule
+# cannot turn a green CI run red without a commit here.
+Packages = https://github.com/tbhb/vale-ai-tells/releases/download/v1.26.0/ai-tells.zip
+
+Vocab = xa11y
+
+# The docs site is Starlight, so the guides are MDX. Vale has no MDX parser
+# of its own; treating it as Markdown works because the JSX we use is
+# block-level components whose children are ordinary prose.
+[formats]
+mdx = md
+
+[*.{md,mdx}]
+BasedOnStyles = Vale, ai-tells
+
+# Two things Vale's Markdown parser does not skip on its own.
+#
+# 1. MDX `import` statements read as an ordinary paragraph, so the component
+#    and module names land in the spell checker.
+# 2. A fenced code block indented inside a JSX element (every `<TabItem>` in
+#    these guides) is not recognised as a fence, so the code inside it is
+#    linted as prose. Top-level fences are already skipped by the parser;
+#    matching them again here is harmless.
+BlockIgnores = (?m)^import .*$
+BlockIgnores = (?s) *(```.*?```)
+
+# Vale lints YAML frontmatter as prose, so every `title:` / `description:`
+# key trips the colon rule on every page. Drop the keys rather than the whole
+# block: the values stay linted, and `description` is the page's meta
+# description, which is exactly the text worth checking. A frontmatter key
+# not listed here surfaces as an alert, which is the cue to add it.
+TokenIgnores = (?m)^\s*-?\s*(title|description|template|lastUpdated|hero|tagline|image|html|actions|text|link|icon|variant):
+
+# Generated API reference pages come out of `cargo xtask docs` and are not
+# hand-written prose, so no style applies to them.
+[**/docs/api/**]
+BasedOnStyles =

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,8 @@ CI runs with `RUSTFLAGS: -Dwarnings`, so all warnings are errors. Individual che
 3. **Unit tests** — `cargo xtask test`
 4. **Integration tests** (if touching provider/test-app code) — `cargo xtask test-integ`
 5. **Python bindings** — `cargo xtask test-python`
-6. **No new `#[allow(...)]` without justification** — if you must suppress a warning, add a comment explaining why
+6. **Docs prose** (if touching `README.md` or `docs/site/src/content/docs/`) — `cargo xtask lint-docs`
+7. **No new `#[allow(...)]` without justification** — if you must suppress a warning, add a comment explaining why
 
 Common CI failures:
 - `unused import` / `dead_code` — remove the unused code or add `#[allow(dead_code)]` with a reason
@@ -251,10 +252,45 @@ cargo xtask fuzz                              # provider fuzzer
 cargo xtask fuzz --seed 42 -n 5000            # reproducible fuzz run
 cargo xtask coverage                          # code coverage report
 cargo xtask docs                              # build documentation
+cargo xtask lint-docs                         # Vale prose lint for README + docs site
 
 # Core fuzz tests (requires nightly)
 cd xa11y/fuzz && cargo +nightly fuzz run tree_ops -- -max_total_time=60
 ```
+
+## Docs Prose Linting
+
+`README.md` and the hand-written pages under `docs/site/src/content/docs/` are
+linted with [Vale](https://vale.sh). `cargo xtask lint-docs` runs it locally;
+the `Docs Lint` workflow runs it in CI whenever one of those files, `.vale.ini`,
+or the project vocabulary changes.
+
+Two style sets are configured in `.vale.ini`:
+
+- **`Vale`** — the built-in style that ships with the binary (spelling,
+  repetition).
+- **[`ai-tells`](https://github.com/tbhb/vale-ai-tells)** — flags the prose
+  patterns that read as machine-written: em-dash asides, three-item verb
+  series, "not X but Y" contrasts, hedges, filler adverbs. The release is
+  pinned in `.vale.ini` so an upstream rule addition cannot turn CI red
+  without a commit here.
+
+`vale sync` downloads the style package into `.github/styles/`, which is
+gitignored apart from `config/vocabularies/xa11y/accept.txt`. That file is the
+project's term list: everything Vale's dictionary doesn't know but this
+codebase writes in prose (`AXUIElement`, `uinput`, `pywinauto`, `subrole`, and
+so on). Add a term there rather than rewording around the spell checker.
+
+Two things worth knowing before adding pages:
+
+- **Frontmatter is linted**, minus the keys themselves. `description` is the
+  page's meta description, so it gets the same treatment as body prose. A
+  frontmatter key not listed in the `TokenIgnores` line shows up as a colon
+  alert, which is the cue to add it.
+- **A fenced code block indented inside a JSX element** (every `<TabItem>` in
+  these guides) is not recognised as a fence by Vale's Markdown parser, so
+  `.vale.ini` skips those blocks explicitly. Top-level fences are handled by
+  the parser.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ pip install xa11y
 Requires Python 3.9+. Pre-built wheels available for Linux, macOS, and Windows.
 <!-- /python-only -->
 
-> **macOS:** Grant your terminal **two** permissions in **System Settings > Privacy & Security**:
-> 1. **Accessibility** — required for all accessibility API access.
-> 2. **Screen & System Audio Recording** (macOS 26+) — required to read window content. Without this, only menu bars are visible.
+> On **macOS**, grant your terminal **two** permissions in **System Settings > Privacy & Security**:
+> 1. **Accessibility**, required for all accessibility API access.
+> 2. **Screen & System Audio Recording** (macOS 26+), required to read window content. Without it, only menu bars are visible.
 >
 > Restart your terminal after changing permissions.
 >
-> **Linux:** AT-SPI2 must be running (default on GNOME/most DEs). No special permissions needed.
+> On **Linux**, AT-SPI2 must be running (the default on GNOME and most desktop environments). Nothing else to grant.
 >
-> **Windows:** No special permissions needed.
+> **Windows** works as installed.
 
 ## Selector Syntax
 

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -1,18 +1,18 @@
 ---
 title: How xa11y compares to other desktop automation tools
-description: What separates accessibility-based libraries, injection-based suites, and vision tools for desktop UI automation — and where xa11y, pywinauto, FlaUI, Appium, Squish, and OmniParser each fit.
+description: What separates accessibility-based libraries, injection-based suites, and vision tools for desktop UI automation, and where xa11y, pywinauto, FlaUI, Appium, Squish, and OmniParser each fit.
 lastUpdated: 2026-07-27
 ---
 
-xa11y drives native desktop applications by reading and acting on accessibility data — the same information screen readers consume — through one API on macOS (AXUIElement), Windows (UI Automation), and Linux (AT-SPI2). It is open source under MIT, with bindings for Rust, Python, and JavaScript and a [command-line tool](/guides/cli/) for exploring accessibility trees. What it adds over calling each platform's API directly is cross-platform coverage behind one interface, CSS-like selectors, and locators that re-resolve and wait for an element to be ready before acting, which removes most of the retry scaffolding desktop automation otherwise accumulates.
+xa11y drives native desktop applications by reading and acting on accessibility data (the same information screen readers consume) through one API on macOS (AXUIElement), Windows (UI Automation), and Linux (AT-SPI2). It is open source under MIT, with bindings for Rust, Python, and JavaScript and a [command-line tool](/guides/cli/) for exploring accessibility trees. What it adds over calling each platform's API directly is cross-platform coverage behind one interface, CSS-like selectors, and locators that re-resolve and wait for an element to be ready before acting, which removes most of the retry scaffolding desktop automation otherwise accumulates.
 
-What separates the tools in this space is what each treats as the source of truth about the screen — accessibility data, a toolkit's internal object model, raw pixels, or a model's reading of those pixels. What a tool can see, what breaks it, and what it costs per operation all follow from that, so this page is organized around it. If your target app exposes no accessibility data, xa11y cannot help; skip to [when not to use xa11y](#when-not-to-use-xa11y).
+What separates the tools in this space is what each treats as the source of truth about the screen: accessibility data, a toolkit's internal object model, raw pixels, or a model's reading of those pixels. What a tool can see, what breaks it, and what it costs per operation all follow from that, so this page is organized around it. If your target app exposes no accessibility data, xa11y cannot help. Skip to [when not to use xa11y](#when-not-to-use-xa11y).
 
-The four mechanisms compose, and a practical setup often drives through accessibility data and reaches for pixels only where that has a hole. xa11y keeps the boundary explicit. [Input simulation](/guides/input/) is a separate `InputSim` surface that never automatically substitutes for an accessibility action, so a passing test cannot silently degrade into blind coordinate clicking. That separation is a deliberate design rule, described in [Design](/guides/design/).
+These mechanisms compose, and a practical setup often drives through accessibility data and reaches for pixels only where that has a hole. xa11y keeps the boundary explicit. [Input simulation](/guides/input/) is a separate `InputSim` surface that never automatically substitutes for an accessibility action, so a passing test cannot silently degrade into blind coordinate clicking. That separation is a deliberate design rule, described in [Design](/guides/design/).
 
 ## Accessibility-based libraries: xa11y, pywinauto, FlaUI, dogtail, atomacos
 
-The application exposes accessibility data — roles, names, values, states, bounds — and the tool reads it. Elements are addressed semantically, so a query costs milliseconds or less and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test, and you automate the shipping binary. You see only what the app exposes, and where accessibility support is absent or wrong there is nothing to read.
+The application exposes accessibility data (roles, names, values, states, bounds) and the tool reads it. Elements are addressed semantically, so a query costs milliseconds or less and survives layout changes, themes, and resolution differences. Nothing is installed into the application under test, so you automate the released binary. You see only what the app exposes. Where accessibility support is absent or wrong, there is nothing to read.
 
 | Tool | Platforms | Languages |
 | --- | --- | --- |
@@ -27,33 +27,33 @@ Appium normalizes through the WebDriver protocol rather than a library API, so a
 
 ## Abstraction: platform mirrors versus a normalization layer
 
-The platform-specific libraries mostly mirror their underlying API. pywinauto surfaces Win32 and UIA concepts directly, atomacos exposes AXUIElement attributes nearly raw, dogtail exposes AT-SPI2's object model. That is predictable, and it gives you the full platform surface, including corners xa11y does not expose. But role names and idioms differ per platform, so code does not port, and a second OS means rewriting against a different object model. xa11y normalizes instead, mapping one set of roles, one selector language, and one set of action verbs onto all three platform APIs — see [platform details](/guides/platform-details/). On one platform permanently, the mirror is more mature and exposes more of it. Across two or three, the normalization is the point.
+The platform-specific libraries mostly mirror their underlying API. pywinauto surfaces Win32 and UIA concepts directly, atomacos exposes AXUIElement attributes nearly raw, dogtail exposes AT-SPI2's object model. That is predictable, and it exposes the full platform surface, including corners xa11y leaves out. But role names and idioms differ per platform. Code does not port, and a second OS means rewriting against a different object model. xa11y normalizes instead, mapping one set of roles, one selector language, and one set of action verbs onto all three platform APIs. See [platform details](/guides/platform-details/). On one platform permanently, the mirror is more mature and exposes more of it. Across two or three, the normalization is the point.
 
 ## Locators, auto-waiting, and stale handles
 
-Most accessibility libraries hand you a captured node reference. That reference goes stale the moment the app redraws or replaces the subtree it came from, and the library leaves the resulting retry loops to you — the classic source of desktop-test flake, where a find succeeds and the click a few milliseconds later lands on a dead handle.
+Most accessibility libraries hand you a captured node reference. That reference goes stale the moment the app redraws or replaces the subtree it came from, and the library leaves the resulting retry loops to you, the classic source of desktop-test flake, where a find succeeds and the click a few milliseconds later targets a dead handle.
 
-xa11y's `Locator` is a lazy query. It re-resolves its selector on every operation and waits for the element to be visible and enabled before acting, while an `Element` is the captured-handle form and the API keeps the two distinct. The selector language is CSS-like — `button[name='Submit']`, `textfield[name^='Search']`, `group > button` — and the model is taken from Playwright's locators, adapted to accessibility trees.
+xa11y's `Locator` is a lazy query. It re-resolves its selector on every operation and waits for the element to be visible and enabled before acting, while an `Element` is the captured-handle form and the API keeps the two distinct. The selector language is CSS-like (`button[name='Submit']`, `textfield[name^='Search']`, `group > button`), taken from Playwright's locators and adapted to accessibility trees.
 
-An agent acting on a stale handle fails exactly the way a flaky test does, since the UI changed between observation and action, and a locator that re-resolves absorbs that race. A selector is also a compact, writable name for an element. An agent can carry `button[name='Save']` across turns of a conversation, and a person can paste it into a script, where a captured object reference cannot leave the process that created it. Most of the libraries above provide neither auto-waiting nor a selector language, and you build both yourself.
+An agent acting on a stale handle fails exactly the way a flaky test does, since the UI changed between observation and action, and a locator that re-resolves absorbs that race. A selector is also a compact, writable name for an element. An agent can carry `button[name='Save']` across turns of a conversation, and a person can paste it into a script. A captured object reference cannot leave the process that created it. Most of the libraries above provide neither auto-waiting nor a selector language, so you build both yourself.
 
 ## Injection-based suites: Squish, Ranorex, TestComplete
 
-These suites load a hook into the target process and read the toolkit's own object model — Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy — falling back to accessibility APIs where no dedicated hook exists. That reaches custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility. xa11y reads none of those, because it does not inject.
+These suites load a hook into the target process and read the toolkit's own object model (Qt's QObject tree, the .NET visual tree, Java's AWT/Swing hierarchy), falling back to accessibility APIs where no dedicated hook exists. That reaches custom-drawn widgets, QML internals, and controls whose authors never implemented accessibility. xa11y reads none of those, because it does not inject.
 
-Each hook is written against a specific toolkit, so these tools enumerate support per app framework rather than per platform, and whether yours is on the list matters more than anything else about them.
+Each hook is written against a specific toolkit, so these tools enumerate support per app framework rather than per platform. Whether yours is on the list is the first question to settle about any of them.
 
 | Tool | Languages | App frameworks |
 | --- | --- | --- |
-| [Squish](https://www.qt.io/product/quality-assurance/squish) | Python, JavaScript, Perl, Ruby, Tcl | Qt/QML, Java, Windows, Web, mobile — licensed per edition |
+| [Squish](https://www.qt.io/product/quality-assurance/squish) | Python, JavaScript, Perl, Ruby, Tcl | Qt/QML, Java, Windows, Web, mobile (licensed per edition) |
 | [Ranorex Studio](https://www.ranorex.com/) | C#, VB.NET | WinForms, WPF, Qt, Java, Delphi, UWP, MSAA/UIA |
 | [TestComplete](https://smartbear.com/product/testcomplete/) | Python, JavaScript, VBScript, JScript, DelphiScript | .NET, WPF, Java, Delphi/C++Builder (VCL), Qt |
 
-Squish (Qt Group, which acquired froglogic in 2021) is the only genuinely cross-platform one, and reaches QML internals the accessibility projection omits. Its editions are licensed separately, so a Qt app and a Java app are two licenses. Ranorex Studio is Windows-hosted and Windows-targeted, with no native macOS app testing. TestComplete has the broadest legacy-toolkit coverage, including Delphi and VCL.
+Squish (Qt Group, which acquired froglogic in 2021) is the only cross-platform one of the three, and reaches QML internals the accessibility projection omits. Its editions are licensed separately, so a Qt app and a Java app are two licenses. Ranorex Studio is Windows-hosted and Windows-targeted, with no native macOS app testing. TestComplete has the broadest legacy-toolkit coverage, including Delphi and VCL.
 
 Injection has costs beyond the price. It changes the process you are testing, and the hook must support your toolkit and your build. All three are licensed per seat and bundle a recorder, IDE, reporting, and support, which for testers who do not write code is the product.
 
-Both tables draw on public documentation, so treat them as a starting point for an evaluation rather than a feature comparison.
+Both tables come from public documentation, so treat them as a starting point for an evaluation rather than a feature comparison.
 
 ## Pixels and screen parsing: SikuliX, PyAutoGUI, OmniParser
 
@@ -66,19 +66,19 @@ The remaining tools read the screen rather than the app. Pixel matching screensh
 | [OmniParser](https://github.com/microsoft/OmniParser) and similar screen parsers | Detection model + OCR over screenshots | Via OCR |
 | End-to-end VLM computer-use agents | Model reasoning over screenshots | Via the model |
 
-SikuliX and PyAutoGUI predate the model-based tools and share their failure mode in miniature. They see pixels, so anything that changes pixels without changing meaning — a theme, a DPI setting, font antialiasing — breaks the match. PyAutoGUI is primarily input synthesis and cannot read a value out of the UI at all. Screen parsers and VLM agents are less automation libraries than components of agent systems, which is the subject of the next section.
+SikuliX and PyAutoGUI predate the model-based tools and share their failure mode in miniature. They see pixels. A theme, a DPI setting, or font antialiasing changes those pixels without changing meaning, and the match breaks. PyAutoGUI is primarily input synthesis and cannot read a value out of the UI at all. Screen parsers and VLM agents are less automation libraries than components of agent systems, which is the subject of the next section.
 
 ## Driving a desktop from an AI agent
 
 An agent needs, on every step, an observation of the current UI and a way to act on it. The approaches differ mainly in how that observation is produced, and the differences compound because an agent observes many times per task.
 
-**Accessibility-driven.** The agent queries the semantic tree, directly through a library like xa11y or through a CLI or MCP tool built on one. An observation takes milliseconds or less and a few hundred tokens once serialized, and it is deterministic. Elements carry exact bounds and identifiers, role plus name, that stay stable across renders and sessions, which is what lets a successful agent run harden into a repeatable script, since the selector it used yesterday still names the same button today. The app must expose accessibility data, and that data holds only what the app published.
+**Accessibility-driven.** The agent queries the semantic tree, directly through a library like xa11y or through a CLI or MCP tool built on one. An observation takes milliseconds or less and a few hundred tokens once serialized, and it is deterministic. Elements carry exact bounds and identifiers, role plus name, that stay stable across renders and sessions. So a successful agent run can harden into a repeatable script: the selector it used yesterday still names the same button today. The app must expose accessibility data, and that data holds only what the app published.
 
-**Screen-parsing models.** [OmniParser](https://github.com/microsoft/OmniParser), Microsoft's open-source screenshot-to-structured-elements model, is the canonical example. A detection model plus OCR reconstructs a pseudo-tree from pixels — bounding boxes, text, inferred interactability — for whatever is visible, which reaches applications with no accessibility support at all. In exchange, every observation costs a model inference, detection introduces error, and identifiers are synthesized per screenshot rather than stable across renders, so there is nothing durable to write a script against. Acting on the structure requires a separate executor.
+**Screen-parsing models.** [OmniParser](https://github.com/microsoft/OmniParser), Microsoft's open-source screenshot-to-structured-elements model, is the canonical example. A detection model plus OCR reconstructs a pseudo-tree from pixels (bounding boxes, text, inferred interactability) for whatever is visible, which reaches applications with no accessibility support at all. In exchange, every observation costs a model inference, detection introduces error, and identifiers are synthesized per screenshot rather than stable across renders, so there is nothing durable to write a script against. Acting on the structure requires a separate executor.
 
-**End-to-end VLM agents.** The model looks at a screenshot and decides the action directly. The most flexible option on UI nobody anticipated, since there is no intermediate representation to be wrong — and the slowest, least reproducible, and most expensive per step, because every step ships an image into a model.
+**End-to-end VLM agents.** The model looks at a screenshot and decides the action directly. This is the most flexible option on UI nobody anticipated, since there is no intermediate representation to be wrong. It is also the slowest and least reproducible option, and the most expensive per step, because every step sends an image to a model.
 
-**Hybrid.** Increasingly the practical setup, using accessibility data for structure, enumeration, and exact bounds, with vision only for what it does not expose, such as a canvas region, an image, or a custom widget. The two are complementary observations of the same UI, and a screenshot cropped to an element's exact bounds is a far better vision input than a full-screen capture. [agent-desktop](https://agent-desktop.dev) packages xa11y's tree queries, element screenshots, and event streams as a CLI for agents.
+**Hybrid.** Increasingly the practical setup, using accessibility data for structure, enumeration, and exact bounds, with vision only for what it does not expose, such as a canvas region, an image, or a custom widget. Accessibility data and vision are complementary observations of the same UI, and a screenshot cropped to an element's exact bounds is a far better vision input than a full-screen capture. [agent-desktop](https://agent-desktop.dev) packages xa11y's tree queries, element screenshots, and event streams as a CLI for agents.
 
 | Decision axis | Accessibility data | Screen parsing | End-to-end VLM |
 | --- | --- | --- | --- |
@@ -114,27 +114,27 @@ xa11y cannot reach widgets that expose no accessibility data, a consequence of r
 
 ## Framework coverage in CI
 
-For an accessibility-driven tool, the practical question is not which platforms it claims but which UI toolkits actually work, because coverage depends on each toolkit's accessibility implementation. xa11y runs its integration suite against real applications in CI on every commit.
+For an accessibility-driven tool, the practical question is not which platforms it claims but which UI toolkits actually work, because coverage depends on how much accessibility support each toolkit provides. xa11y runs its integration suite against real applications in CI on every commit.
 
 | Toolkit | Linux | macOS | Windows |
 | --- | --- | --- | --- |
 | Qt | ● | ● | ● |
-| GTK4 | ● | — | — |
-| Tauri (WebKit/WebView2) | ● | ● | — |
-| Electron | ● | — | — |
+| GTK4 | ● | ○ | ○ |
+| Tauri (WebKit/WebView2) | ● | ● | ○ |
+| Electron | ● | ○ | ○ |
 | egui / AccessKit | ● | ● | ● |
-| Cocoa / AppKit | — | ● | — |
-| WinForms | — | — | ● |
-| WPF | — | — | ● |
+| Cocoa / AppKit | ○ | ● | ○ |
+| WinForms | ○ | ○ | ● |
+| WPF | ○ | ○ | ● |
 
-A dash means untested in CI, not known-broken — most combinations work, but only the marked cells are verified continuously. The [accessibility quirks](/guides/accessibility-quirks/) guide documents the per-toolkit behavior these tests pin down.
+A hollow circle means untested in CI rather than known-broken. Most combinations work, but only the filled cells are verified continuously. The [accessibility quirks](/guides/accessibility-quirks/) guide documents the per-toolkit behavior these tests pin down.
 
-Platform prerequisites are minimal but real. macOS needs the Accessibility permission, plus Screen Recording on macOS 26+; Linux needs AT-SPI2 running; Windows needs nothing special.
+Platform prerequisites are minimal but real. macOS needs the Accessibility permission, plus Screen Recording on macOS 26+. Linux needs AT-SPI2 running. Windows works as installed.
 
 ## When not to use xa11y
 
 - **The app exposes no accessibility data.** Games, canvas-drawn interfaces, and apps whose toolkit never wired up accessibility. Dump the tree with the command-line tool first; if it comes back empty or shows one opaque window, you need injection (Squish, TestComplete), pixels (SikuliX), or vision.
-- **You need a recorder, an IDE, or a low-code interface.** xa11y is a library with none of those; the commercial suites bundle them.
+- **You want a point-and-click front end.** The commercial suites bundle a recorder, an IDE, and reporting. xa11y is a library with none of them.
 - **You are testing a website.** Playwright or Selenium test the DOM directly, control the browser lifecycle, and intercept network traffic. xa11y drives a browser only as another desktop app.
 - **You are on Windows only, permanently.** FlaUI and pywinauto expose more of UI Automation than xa11y does.
 - **You need vendor support with an SLA.** xa11y is a community project.
@@ -142,11 +142,11 @@ Platform prerequisites are minimal but real. macOS needs the Accessibility permi
 
 ## Related but not competing
 
-- **[AccessKit](https://accesskit.dev/)** — publishes accessibility data from inside your app, where xa11y reads it from outside. The two are opposite sides of the same interface and compose, since xa11y's own egui and winit test apps are AccessKit-backed, which is how one suite runs against a pure-Rust GUI on all three platforms.
-- **[Playwright](https://playwright.dev/)** — browser automation, and the design influence behind xa11y's `Locator` pattern and selector syntax.
-- **[agent-desktop](https://agent-desktop.dev)** — a CLI built on xa11y for AI agents that read and control desktops.
-- **RPA platforms** — UiPath and Power Automate Desktop solve business process automation, with orchestration, scheduling, and enterprise licensing. Overlapping techniques, different product category.
-- **Accessibility auditing tools** — axe and Accessibility Insights evaluate accessibility data against WCAG criteria. xa11y does no conformance evaluation.
+- **[AccessKit](https://accesskit.dev/)** publishes accessibility data from inside your app, where xa11y reads it from outside. They sit on opposite sides of the same interface and compose, since xa11y's own egui and winit test apps are AccessKit-backed, which is how one suite runs against a pure-Rust GUI on all three platforms.
+- **[Playwright](https://playwright.dev/)** does browser automation, and is the design influence behind xa11y's `Locator` pattern and selector syntax.
+- **[agent-desktop](https://agent-desktop.dev)** is a CLI built on xa11y for AI agents that read and control desktops.
+- **RPA platforms** such as UiPath and Power Automate Desktop solve business process automation, with orchestration, scheduling, and enterprise licensing. Overlapping techniques, different product category.
+- **Accessibility auditing tools** such as axe and Accessibility Insights evaluate accessibility data against WCAG criteria. xa11y does no conformance evaluation.
 
 ## How these claims were checked
 

--- a/docs/site/src/content/docs/compare.mdx
+++ b/docs/site/src/content/docs/compare.mdx
@@ -134,7 +134,7 @@ Platform prerequisites are minimal but real. macOS needs the Accessibility permi
 ## When not to use xa11y
 
 - **The app exposes no accessibility data.** Games, canvas-drawn interfaces, and apps whose toolkit never wired up accessibility. Dump the tree with the command-line tool first; if it comes back empty or shows one opaque window, you need injection (Squish, TestComplete), pixels (SikuliX), or vision.
-- **You want a point-and-click front end.** The commercial suites bundle a recorder, an IDE, and reporting. xa11y is a library with none of them.
+- **A recorder, an IDE, or a low-code authoring mode.** xa11y is a library with none of those. The commercial suites bundle them.
 - **You are testing a website.** Playwright or Selenium test the DOM directly, control the browser lifecycle, and intercept network traffic. xa11y drives a browser only as another desktop app.
 - **You are on Windows only, permanently.** FlaUI and pywinauto expose more of UI Automation than xa11y does.
 - **You need vendor support with an SLA.** xa11y is a community project.

--- a/docs/site/src/content/docs/guides/accessibility-quirks.mdx
+++ b/docs/site/src/content/docs/guides/accessibility-quirks.mdx
@@ -1,10 +1,10 @@
 ---
 title: Accessibility API Quirks
-description: A field guide to the platform-specific bugs, gotchas, and surprising behaviors of the desktop accessibility APIs — AT-SPI2 on Linux, AXUIElement on macOS, and UI Automation on Windows — plus the toolkits (Chromium, Electron, Qt, GTK, WebKit, AccessKit) layered on top of them.
+description: A field guide to the platform-specific bugs, gotchas, and surprising behaviors of the desktop accessibility APIs (AT-SPI2 on Linux, AXUIElement on macOS, UI Automation on Windows) plus the toolkits (Chromium, Electron, Qt, GTK, WebKit, AccessKit) layered on top of them.
 ---
 
-Building anything on top of the desktop accessibility stack — a screen reader,
-a test framework, an automation tool, or an AI computer-use agent — means
+Building anything on top of the desktop accessibility stack (a screen reader,
+a test framework, an automation tool, an AI computer-use agent) means
 meeting three completely different APIs (Linux **AT-SPI2** over D-Bus, macOS
 **AXUIElement**, Windows **UI Automation**) and a long tail of toolkit-specific
 behavior on top of them. The APIs disagree on roles, actions, threading, and
@@ -13,7 +13,7 @@ or documented only in a vendor's source tree.
 
 This page is a running catalog of those quirks, collected while building and
 testing [xa11y](/) against real applications across all three platforms. None
-of them are bugs in xa11y — they are inherent to the platform APIs and toolkits.
+of them are bugs in xa11y. They are inherent to the platform APIs and toolkits.
 We publish them here so the next person who hits an empty tree, a phantom error
 code, or a role that changed between OS releases can find the answer with a
 search instead of a week of bisecting.
@@ -22,15 +22,15 @@ Each entry names the platform, the symptom, the verbatim error or flag where
 one exists, and a workaround.
 
 :::tip[Contributions welcome]
-Hit a quirk that isn't here? [Open an issue or PR](https://github.com/xa11y/xa11y/issues) —
-this list is meant to grow.
+Hit a quirk that isn't here? [Open an issue or PR](https://github.com/xa11y/xa11y/issues).
+This list is meant to grow.
 :::
 
-## Accessibility is opt-in — and often silently off
+## Accessibility is opt-in, and often silently off
 
 The single most common failure across every platform: the API connects, the
 app is found, but the tree is **empty or a bare skeleton**, with no error to
-tell you why. Accessibility is opt-in at the application *and* the OS-policy
+tell you why. Accessibility is opt-in at both the application and the OS-policy
 level, and the "off" state usually looks identical to "this app has no UI."
 
 ### Linux: AT-SPI2 must be enabled on the bus
@@ -52,7 +52,7 @@ You also need the bridge processes actually running:
 /usr/libexec/at-spi2-registryd &
 ```
 
-To check whether a given app registered with AT-SPI2 at all:
+To check whether an app registered with AT-SPI2 at all:
 
 ```bash
 busctl --user tree org.a11y.atspi.Registry | grep -i "<app-name>"
@@ -61,13 +61,13 @@ busctl --user tree org.a11y.atspi.Registry | grep -i "<app-name>"
 If the app's subtree is missing, the problem is the app's accessibility
 configuration, not your client.
 
-### Linux: Chromium and Electron ship the renderer bridge disabled
+### Linux: Chromium and Electron leave the renderer bridge disabled
 
 Chromium-based apps (Google Chrome, Chromium, VS Code, Cursor, Slack, Discord,
 and every other Electron app) register with AT-SPI2 but expose **only an
 `application → frame` skeleton** until launched with `--force-renderer-accessibility`.
 Without it, `locator("button").count()` returns `0` even though buttons are
-plainly visible — and the only place this is documented is Chromium's own source
+plainly visible, and the only place this is documented is Chromium's own source
 tree.
 
 ```bash
@@ -76,8 +76,8 @@ code         --force-renderer-accessibility   # VS Code
 cursor       --force-renderer-accessibility
 ```
 
-The environment variable `ACCESSIBILITY_ENABLED=1` has the same effect for some
-Chromium builds.
+The environment variable `ACCESSIBILITY_ENABLED=1` has the same effect on some
+Chromium builds, though the launch flag is the reliable route.
 
 Representative node counts on Ubuntu 24.04 + GNOME 46 (Wayland):
 
@@ -87,22 +87,22 @@ Representative node counts on Ubuntu 24.04 + GNOME 46 (Wayland):
 | Cursor  |            1 |       116 |
 | Chrome  |            1 |       210 |
 
-You can detect the condition programmatically: Chromium reports
+You can detect the condition programmatically. Chromium reports
 `Application.ToolkitName == "Chromium"`, so a Chromium/Electron frame that yields
-zero filtered children is almost certainly the renderer bridge being off rather
+zero filtered children is most likely the renderer bridge being off rather
 than a bad selector.
 
 ### Linux: Firefox needs an environment variable
 
 Firefox exposes its tree only when launched with `MOZ_ACCESSIBILITY_ATK2=1` set
-in the environment — the same class of issue as Chromium, with a different knob.
+in the environment, the same class of issue as Chromium with a different knob.
 
 ```bash
 MOZ_ACCESSIBILITY_ATK2=1 firefox
 ```
 
 Native GTK apps (Nautilus, GNOME Terminal, GNOME Calculator, gnome-text-editor)
-need no flag — their AT-SPI2 bridge is enabled by default.
+need no flag, because their AT-SPI2 bridge is enabled by default.
 
 ### macOS: the client process needs the Accessibility (TCC) permission
 
@@ -114,7 +114,7 @@ return an **empty tree, not an error**.
 In CI you grant it by writing the system TCC database and restarting `tccd`. The
 critical gotcha: **TCC matches the resolved on-disk binary, not a symlink or a
 launcher**. A virtualenv `python` symlink, or a `cargo run` wrapper, will not
-inherit the grant — you must grant the real interpreter/binary path:
+inherit the grant, so you must grant the real interpreter/binary path:
 
 ```bash
 # resolve the real path first
@@ -122,8 +122,8 @@ grant_tcc "$(.venv/bin/python -c 'import sys; print(sys.executable)')"
 ```
 
 This also bites test runners that use content-addressed binary paths: macOS
-TCC grants "don't cope with cargo-hashed test-binary paths" — every rebuild
-produces a new hash and a new, ungranted binary.
+TCC grants "don't cope with cargo-hashed test-binary paths", because every
+rebuild produces a new hash and a new, ungranted binary.
 
 ### macOS: web content needs accessibility turned on per-process
 
@@ -137,14 +137,14 @@ be set on the web area before the DOM is reflected into the AX tree.
 ### macOS roles are open-ended strings, not an enum
 
 `AXRole` and `AXSubrole` are plain `CFString`s. `AXRoleConstants.h` lists ~50
-conventional roles, but **there is no closed enum** — apps and web content report
+conventional roles, but **there is no closed enum**, and apps and web content report
 arbitrary values. WebKit alone adds `"AXWebArea"`, `"AXLink"`, `"AXHeading"`, and
 many more that aren't in the SDK header. Any code that `switch`es over a fixed set
 of role strings will silently mishandle real-world content.
 
 ### Windows: every top-level window is a `Window`, dialogs included
 
-UIA maps **all** top-level windows — ordinary windows and modal dialogs alike —
+UIA maps **all** top-level windows, ordinary windows and modal dialogs alike,
 to `UIA_WindowControlTypeId`. To tell a dialog apart you must read
 `UIA_IsDialogPropertyId` (Windows 10 1703+). Native frameworks such as Qt set
 `IsDialog` on a `QDialog` *without* populating `AriaRole`, so the same dialog
@@ -152,12 +152,12 @@ reports as a dialog on macOS/Linux but as a plain window on Windows unless you
 check that property.
 
 `AriaRole`, conversely, is populated only by ARIA/web content (Electron,
-AccessKit) — never by native Win32/Qt/WPF apps — so you cannot rely on it for
+AccessKit) and never by native Win32/Qt/WPF apps, so you cannot rely on it for
 native role refinement.
 
 A nasty corollary: because *any* top-level window with `IsDialog=true` becomes a
-dialog, transient system popups — **UAC prompts, credential dialogs, Windows
-Update** — will flip a window's role out from under you. Desktop state is not
+dialog, transient system popups (**UAC prompts, credential dialogs, Windows
+Update**) will flip a window's role out from under you. Desktop state is not
 deterministic.
 
 ### Windows: `ControlType.Custom` often means "no control type at all"
@@ -165,8 +165,8 @@ deterministic.
 UIA's default value for the `ControlType` property is `Custom` (50025), so an
 element whose provider never publishes a control type is indistinguishable from
 a deliberately custom widget. WinForms hits this constantly: accessible objects
-that don't derive from `ControlAccessibleObject` — a `DataGridView`'s rows, for
-instance — implement only `LegacyIAccessible`, so UIA reports `Custom` even
+that don't derive from `ControlAccessibleObject`, a `DataGridView`'s rows for
+instance, expose only `LegacyIAccessible`, so UIA reports `Custom` even
 though MSAA still reports `ROLE_SYSTEM_ROW`.
 
 xa11y therefore reads `LegacyIAccessible.Role` for `Custom` elements and maps
@@ -179,9 +179,9 @@ remain visible.
 There is no single control type for "table cell" in a framework grid. The two
 Microsoft grids disagree:
 
-- **WinForms `DataGridView`** — `DataGridViewCell.DataGridViewCellAccessibleObject`
+- **WinForms `DataGridView`.** `DataGridViewCell.DataGridViewCellAccessibleObject`
   overrides `ControlTypePropertyId` to `DataItem` and supports `TableItem`.
-- **WPF `DataGrid`** — `DataGridCellItemAutomationPeer` reports
+- **WPF `DataGrid`.** `DataGridCellItemAutomationPeer` reports
   `AutomationControlType.Custom` and supports `TableItem` + `GridItem`.
 
 `DataItem` is also what UIA uses for a *row*, so neither the control type nor
@@ -194,7 +194,7 @@ AccessKit's.
 ### Windows: WinForms range controls have no `RangeValue` pattern
 
 A WinForms `TrackBar` reports `ControlType.Slider` and a `NumericUpDown`
-reports `ControlType.Spinner`, but neither implements `RangeValuePattern` —
+reports `ControlType.Spinner`, but neither supports `RangeValuePattern`, and
 `TrackBar.TrackBarAccessibleObject` advertises `Value` and `LegacyIAccessible`
 only, and `UpDownBase.UpDownBaseAccessibleObject` inherits the Invoke-only base
 set. The current value is readable as a *string* through `ValuePattern`; the
@@ -211,7 +211,7 @@ read its value?" are separate questions on Windows.
 
 `AtspiRole` is a C enum (131 values) sent as a `u32`. Examples:
 `PUSH_BUTTON` (43), `CHECK_BOX` (7), `ENTRY` (79), `TEXT` (61), `FRAME` (23).
-States are a separate 64-bit bitfield (`AtspiStateType`), not properties —
+States are a separate 64-bit bitfield (`AtspiStateType`) rather than properties:
 `ENABLED` (8), `FOCUSED` (12), `VISIBLE` (30), `EDITABLE` (7), `CHECKED` (4).
 
 ### Qt tabs: `tab` on Windows, `radio_button` on macOS
@@ -230,7 +230,7 @@ dialog.descendant("tab[name='Settings'], radio_button[name='Settings']").press()
 WebKitGTK **2.52** changed which AT-SPI role it reports for an HTML `<textarea>`,
 breaking any selector keyed on the old role after a routine `libwebkit2gtk-4.1`
 upgrade (`2.50.4` → `2.52.3`). The portable fix is to never trust the toolkit's
-text role directly — derive single-line vs multi-line from the `MULTI_LINE`
+text role directly. Derive single-line vs multi-line from the `MULTI_LINE`
 state bit, which is consistent across GTK (`GtkEntry`/`GtkTextView`),
 Qt (`QLineEdit`/`QPlainTextEdit`), and every WebKit version.
 
@@ -241,7 +241,7 @@ Qt (`QLineEdit`/`QPlainTextEdit`), and every WebKit version.
 A `QDialog` opened inside a host process (e.g. a Qt submitter dialog inside
 a C++ DCC application) can register with UIA as its **own top-level
 "application"**, sharing the host's PID but living outside the host app's
-element tree. Searching the host app for the dialog finds nothing — you
+element tree. Searching the host app for the dialog finds nothing, and you
 must attach to the dialog's own app. Predicate-based discovery handles this
 without hand-rolling an enumeration loop:
 
@@ -252,11 +252,11 @@ dialog_app = xa11y.App.find(
 )
 ```
 
-On macOS AX the same dialog is an ordinary child window of the host app —
+On macOS AX the same dialog is an ordinary child window of the host app, and
 so dialog discovery is one of the few places where platform-specific code
 is legitimately required.
 
-Two corollaries, both confirmed against live trees:
+Both of the following are confirmed against live trees:
 
 - **The dialog's accessible name is the `QApplication` display name, not
   `windowTitle()`.** Both the UIA "app" and the dialog window inside it
@@ -264,7 +264,7 @@ Two corollaries, both confirmed against live trees:
   name + version), so match on a name *prefix* rather than the window
   title you see in the title bar.
 - **Child popups may be hosted elsewhere.** A `QMessageBox` shown from such
-  a dialog can land in the *host* application's tree, not the dialog's UIA
+  a dialog can appear in the *host* application's tree, not the dialog's UIA
   app. When the owner is unpredictable, search from the system root
   (module-level `xa11y.locator(...)`) and wait for the popup's body text.
 
@@ -273,7 +273,7 @@ Two corollaries, both confirmed against live trees:
 `QFormLayout` does not propagate a row's label to the field's accessible
 name. In practice sibling widgets surface with the enclosing group's name
 (e.g. three spin boxes all named `"Job Properties"`) or with an empty name.
-Selectors can't disambiguate by name alone — pin the widget with
+Selectors can't disambiguate by name alone, so pin the widget with
 `.nth(n)` (1-based, tree order) or scope to a parent `group` first, and
 re-verify the indices when the form's layout changes.
 
@@ -288,36 +288,36 @@ elements in a single Chrome window) and `"showContextMenu"` (~230 elements). A
 client that looks for a hardcoded `"press"` will report `ActionNotSupported` on
 half the ecosystem unless it normalizes through an alias table.
 
-### Chromium on Linux exposes no `EditableText` interface — anywhere
+### Chromium on Linux exposes no `EditableText` interface, anywhere
 
-This is a big one for text input. **No Chromium element implements
+This is a big one for text input. **No Chromium element provides
 `org.a11y.atspi.EditableText` anywhere in its tree** (confirmed across 500+
 nodes). There is no accessibility path to set the value of a Chromium/Electron
-text field on Linux — attempts hit D-Bus `UnknownMethod` / `UnknownInterface`
+text field on Linux, and attempts hit D-Bus `UnknownMethod` / `UnknownInterface`
 errors. The only options are keyboard synthesis (xdotool / ydotool / uinput) or
 a fix upstream in Chromium.
 
 ### GTK menu buttons hide the real action on an inner widget
 
 `GtkMenuButton`, `AdwMenuButton`, and `AdwSplitButton` present an outer
-`push button` accessible that advertises `NActions = 0` — pressing it raises
-`ActionNotSupported` — wrapping an inner `toggle button` that carries the real
-`click` action. Every stock GNOME app ships these (Calculator, Text Editor,
+`push button` accessible that advertises `NActions = 0`, so pressing it raises
+`ActionNotSupported`. It wraps an inner `toggle button` that carries the real
+`click` action. Every stock GNOME app has them (Calculator, Text Editor,
 Characters, Baobab, Logs, Clocks), so "the button I can see has no press action"
 is a common, confusing result. The workaround is to walk a bounded slice of the
 outer widget's subtree (gated on `Application.ToolkitName == "GTK"`) and invoke
-the single actionable descendant.
+the single matching descendant.
 
 ### GTK4 `CheckButton` reports `NActions = 0`
 
 A GTK4 `CheckButton` can report zero actions via the `Action` interface even
-though it is toggleable, so `toggle()` via `DoAction` is unavailable — toggling
+though it is toggleable, so `toggle()` via `DoAction` is unavailable and toggling
 must go through the `press` path. AccessKit's AT-SPI bridge has the mirror-image
 quirk: it hardcodes the action name as **`"click"`, never `"toggle"`**.
 
-### macOS has no `AXToggle` — `AXPress` is the native toggle
+### macOS has no `AXToggle`, so `AXPress` is the native toggle
 
-There is no `AXToggle` action. `AXPress` *is* the platform's toggle for
+There is no `AXToggle` action. `AXPress` is the platform's toggle for
 checkboxes, switches, and radio buttons. Code expecting a dedicated toggle action
 on macOS will never find one.
 
@@ -325,39 +325,39 @@ on macOS will never find one.
 
 There is no AX action to scroll an element into view. On Linux this maps to
 `Component.ScrollTo`; on Windows to `ScrollItemPattern.ScrollIntoView`; on macOS
-it is a genuine no-op.
+it really is a no-op.
 
 ### Numeric vs text values diverge
 
 - **Linux:** the `org.a11y.atspi.Value` interface is **`f64`-only**. Text values
-  require `EditableText`; if neither is present you get a "not supported" result.
+  require `EditableText`. If neither is present you get a "not supported" result.
   WebKit sliders on Linux historically did not honor `Value.SetCurrentValue`.
 - **macOS:** `AXValue` is set directly for both text and numeric.
 - **Windows:** numeric goes through `RangeValuePattern`, text through
-  `ValuePattern` — and `type_text` is a non-atomic read-modify-write splice via
+  `ValuePattern`, and `type_text` is a non-atomic read-modify-write splice via
   `TextPattern.GetSelection()` + `ValuePattern.SetValue()`.
 
 ### Selection is reported through a different channel on every platform
 
-- **Windows:** `SelectionItemPattern.IsSelected` where the framework implements
+- **Windows:** `SelectionItemPattern.IsSelected` where the framework provides
   it, but frameworks that predate the pattern publish selection *only* as the
   MSAA `STATE_SYSTEM_SELECTED` bit on `LegacyIAccessible.State`. WinForms grid
   cells are the common case: their pattern set is
-  Legacy/Invoke/Value/TableItem/GridItem — no `SelectionItem`. xa11y reads both.
+  Legacy/Invoke/Value/TableItem/GridItem and no `SelectionItem`. xa11y reads both.
 - **macOS:** per-element `AXSelected` where it exists; Qt's Cocoa bridge
-  implements no per-cell `AXSelected` at all and exposes the selection only
+  provides no per-cell `AXSelected` at all and exposes the selection only
   through the *container's* `AXSelectedChildren`, so xa11y derives cell
   selection from the table.
 - **Linux:** the AT-SPI `SELECTED` state bit, set per element.
 
-### Qt spin boxes step — they don't set
+### Qt spin boxes step rather than set
 
 Setting a Qt `QSpinBox` / `QDoubleSpinBox` value through the accessibility
 API does not work on either Windows or macOS: depending on the platform and
 call, the set either raises or **reports success without changing the
 value**. The reliable cross-platform pattern is to *step* with
-`increment()` / `decrement()` and read the value back after each step —
-and don't trust a fixed step count, because a single `increment()` can
+`increment()` / `decrement()` and read the value back after each step.
+Don't trust a fixed step count, because a single `increment()` can
 occasionally advance the value by more than one:
 
 ```python
@@ -369,16 +369,16 @@ while current != target:
 ```
 
 (Bound the loop in real code so an out-of-range target can't spin forever.)
-Text fields and checkboxes are unaffected — `set_value()` and `toggle()`
+Text fields and checkboxes are unaffected, and `set_value()` and `toggle()`
 work on Qt as expected.
 
-## Element references go stale — constantly
+## Element references go stale, constantly
 
 ### All three backends mint a fresh handle on every read
 
 Windows/UIA, macOS/AX, and Linux/AT-SPI2 each **mint a brand-new handle every
 time you cache or re-read an element**. You cannot use a handle's identity to
-dedup or compare elements across two queries — the same on-screen element returns
+dedup or compare elements across two queries, because the same on-screen element returns
 disjoint handles, so naive identity-based dedup silently returns zero results.
 Key elements by a *stable* property instead: UIA `GetRuntimeId`, AT-SPI
 `(bus_name, object_path)`, or a structural tree path.
@@ -388,13 +388,13 @@ Key elements by a *stable* property instead: UIA `GetRuntimeId`, AT-SPI
 AccessKit's AT-SPI bridge **regenerates the entire subtree (and all accessible
 object paths) on a structural mutation**. A snapshot captured before an action is
 invalidated the moment that action rebuilds the tree, so a second operation on
-the old reference surfaces a stale-object platform error. The robust pattern is
+the old reference surfaces a stale-object platform error. The dependable pattern is
 to re-resolve the selector after every mutation rather than holding element
 handles.
 
 ### UIA tree updates are asynchronous
 
-After an action that changes structure (closing a dialog, navigating), the UIA
+After an action that changes structure (closing a dialog, moving to another view), the UIA
 tree can take **longer than 100 ms** to settle. During that window a perfectly
 valid selector is transiently un-findable:
 
@@ -419,8 +419,8 @@ EVENT_E_ALL_SUBSCRIBERS_FAILED (0x80040201)
 Qt propagates this back through the action call **even though the UI action
 itself completed successfully**. The same code can surface from
 `FindAllBuildCache` during a find. xa11y treats `0x80040201` as success on
-action calls (`press`/`toggle`/`select`), and on query calls — where a value is
-still needed — retries the call a few times before giving up.
+action calls (`press`/`toggle`/`select`). On query calls, where a value is
+still needed, it retries the call a few times before giving up.
 
 ### Windows: `FindAllBuildCache` silently drops fragment elements
 
@@ -438,19 +438,19 @@ target an always-enabled element to verify focus behavior.
 ### Windows: screenshots fail in Session 0 / disconnected RDP
 
 GDI `BitBlt` returns `ERROR_INVALID_HANDLE` in disconnected-RDP or Session-0
-contexts — there is no visible desktop to capture.
+contexts, because there is no visible desktop to capture.
 
 ## Threading and process model
 
 - **Windows UIA is COM, MTA-only.** Event handlers fire on a background MTA
   thread (`CoInitializeEx(NULL, COINIT_MULTITHREADED)`). Use per-handler
-  `RemoveXxxEventHandler` — `RemoveAllEventHandlers` nukes every concurrent
+  `RemoveXxxEventHandler`, since `RemoveAllEventHandlers` nukes every concurrent
   subscription in the process.
 - **macOS AXObserver is CFRunLoop-bound.** Callbacks deliver a *live*
-  `AXUIElementRef` valid **only during the callback** — capture what you need
+  `AXUIElementRef` valid **only during the callback**, so capture what you need
   synchronously.
 - **Linux AT-SPI is D-Bus.** A dedicated accessibility bus (separate from the
-  session bus) carries all traffic; the registry daemon tracks apps and routes
+  session bus) handles every message. The registry daemon tracks apps and routes
   events.
 
 ## Memory safety: AX values can throw through your FFI
@@ -468,18 +468,18 @@ client must wrap raw CoreFoundation / AX calls (`CFRetain`, `CFRelease`,
 Push-based accessibility events are richer than polling, but each platform omits
 things the others deliver:
 
-- **Linux AT-SPI2 has no menu-open/close signal at all** — `MenuOpened` /
+- **Linux AT-SPI2 has no menu-open/close signal at all.** `MenuOpened` /
   `MenuClosed` can never fire. Consumers must poll or watch structural changes.
 - **GTK4 sometimes skips `Focus:Focus`**, emitting only
   `Object:StateChanged(focused, true)`. Listen for both.
 - **`StateChanged{Enabled}`** arrives as either `StateChanged(enabled, _)` or
-  `StateChanged(sensitive, _)` — AT-SPI2 still exposes both names.
-- **WebKit2GTK and Electron often omit `Text:TextChanged`** — you may have to
+  `StateChanged(sensitive, _)`, since AT-SPI2 still exposes both names.
+- **WebKit2GTK and Electron often omit `Text:TextChanged`**, so you may have to
   fall back to `ValueChanged` on text roles.
-- **macOS `AXValueChanged` carries no position or delta** — only the element.
+- **macOS `AXValueChanged` carries no position or delta**, only the element.
   There is no `AXTextChanged`-with-position notification; diffing old vs new text
   is the only option.
-- **macOS scopes many notifications to element-level observers** — table
+- **macOS scopes many notifications to element-level observers**: table
   row/selection changes, `AXMenuItemSelected`, `AXCreated`/`AXMoved`/`AXResized`,
   `AXLayoutChanged` are not delivered to an app-level observer.
 - **Windows UIA has no first-class window-activated event.** Inferring it from
@@ -494,12 +494,12 @@ storm of IPC:
 
 | Platform | Per-node cost | Bulk subtree fetch? |
 | --- | --- | --- |
-| **Linux (AT-SPI2)** | 6–10 D-Bus round-trips per node | No — `GetChildren` returns references, you re-query each child. (`Cache.GetItems` exists but returns only a partial property set for the whole app.) |
-| **macOS (AX)** | 2–3 Mach IPC calls per node | No — but `AXUIElementCopyMultipleAttributeValues` batches one node's attributes into a single round-trip. |
-| **Windows (UIA)** | One call for a whole subtree | **Yes** — `IUIAutomationCacheRequest` + `FindAllBuildCache` fetches an entire subtree with chosen properties/patterns in one cross-process call. |
+| **Linux (AT-SPI2)** | 6-10 D-Bus round-trips per node | No. `GetChildren` returns references, and you re-query each child. (`Cache.GetItems` exists but returns only a partial property set for the whole app.) |
+| **macOS (AX)** | 2-3 Mach IPC calls per node | No, but `AXUIElementCopyMultipleAttributeValues` batches one node's attributes into a single round-trip. |
+| **Windows (UIA)** | One call for a whole subtree | **Yes.** `IUIAutomationCacheRequest` + `FindAllBuildCache` fetches an entire subtree with chosen properties/patterns in one cross-process call. |
 
-The practical consequence on Linux and macOS: a naive full-tree walk of a
-complex app is slow enough to feel hung. Prefer narrow, combinator-constrained
+On Linux and macOS, a naive full-tree walk of a complex app is slow enough to
+feel hung. Prefer narrow, combinator-constrained
 queries (`toolbar > button[name='Save']`) so the engine never descends subtrees
 it doesn't need.
 
@@ -507,9 +507,9 @@ it doesn't need.
 
 ### Bidi control characters leak into reported strings
 
-Platforms — notably macOS for some LTR app configurations, and RTL apps
-everywhere — embed Unicode **bidirectional format controls** into the strings
-they report (`name`, `value`, `description`). These are invisible but break naive
+Platforms embed Unicode **bidirectional format controls** into the strings
+they report (`name`, `value`, `description`); macOS does it for some LTR app
+configurations, and RTL apps do it everywhere. These are invisible but break naive
 equality:
 
 ```python
@@ -523,7 +523,7 @@ comparing; keep ZWJ/ZWNJ, which are legitimate content.
 ### at-spi2-core can drop names containing control characters
 
 Some `at-spi2-core` configurations drop an accessible's `Name` entirely when it
-contains non-printable control characters — so an element with a perfectly good
+contains non-printable control characters, so an element with a perfectly good
 visible label becomes undiscoverable by name. This is configuration-dependent
 (the same app can keep the name under a different at-spi2-core build), which makes
 it especially confusing.
@@ -534,12 +534,12 @@ Wayland has no standard accessibility-driven input path, and the architecturally
 "correct" route is not broadly available yet:
 
 - **`xdg-desktop-portal.RemoteDesktop` (libei)** is implemented today only by
-  `xdg-desktop-portal-gnome` and `-kde`, and needs a GDM/SDDM-managed session —
+  `xdg-desktop-portal-gnome` and `-kde`, and needs a GDM/SDDM-managed session,
   so there is **no working portal backend on wlroots compositors** (sway,
   Hyprland) or headless servers.
 - **`/dev/uinput`** is the compositor-agnostic fallback (the same mechanism
   `xdotool --using-uinput`, `ydotool`, `wtype`, Steam Input, and Wine use), but
-  it **requires `input` group membership**, which grants global input read/write —
+  it **requires `input` group membership**, which grants global input read/write,
   comparable to macOS Input Monitoring:
 
   ```bash
@@ -553,23 +553,23 @@ In containers, Docker's `/dev` tmpfs isolation hides host-created
 ## macOS focus and launch races
 
 - **`CGEventPost` (and OS focus) target whichever app is frontmost.** On a CI
-  runner an onboarding/background window — **Setup Assistant, Notification Center,
-  Software Update** — can hold the front slot and silently swallow every synthetic
+  runner an onboarding/background window (**Setup Assistant, Notification Center,
+  Software Update**) can hold the front slot and silently swallow every synthetic
   event, leaving an empty event log. Claim frontmost for your target app before
-  driving input; don't assume your window has focus just because it's visible.
+  driving input. A window can be visible without having focus.
 - **`open -a` has a `-600` quit-then-relaunch race.** Re-launching an app that is
-  mid-quit fails with error `-600`; and "the process exists" does not mean "its
-  accessibility tree is ready" — poll for the tree, not just the PID.
+  mid-quit fails with error `-600`. "The process exists" also does not mean
+  "its accessibility tree is ready", so poll for the tree, not just the PID.
 
 ## Coordinate systems
 
 - **macOS reports points, not pixels.** On a Retina display 1 point = 2 physical
-  pixels — hit-testing against a screenshot taken in pixels will be off by the
+  pixels, so hit-testing against a screenshot taken in pixels will be off by the
   scale factor.
 - **Windows and Linux report logical (device-independent) coordinates**, with
   `Screenshot.scale` bridging to physical pixels. On Linux the scale is exact
   where reliably detectable and falls back to `1.0` (coordinates then physical)
-  otherwise — see [platform details](/guides/platform-details/#coordinates-and-hidpi).
+  otherwise. See [platform details](/guides/platform-details/#coordinates-and-hidpi).
   Multi-monitor setups produce negative coordinates for displays positioned
   left of or above the primary.
 

--- a/docs/site/src/content/docs/guides/accessibility-quirks.mdx
+++ b/docs/site/src/content/docs/guides/accessibility-quirks.mdx
@@ -76,8 +76,8 @@ code         --force-renderer-accessibility   # VS Code
 cursor       --force-renderer-accessibility
 ```
 
-The environment variable `ACCESSIBILITY_ENABLED=1` has the same effect on some
-Chromium builds, though the launch flag is the reliable route.
+On some Chromium builds the environment variable `ACCESSIBILITY_ENABLED=1`
+has the same effect.
 
 Representative node counts on Ubuntu 24.04 + GNOME 46 (Wayland):
 

--- a/docs/site/src/content/docs/guides/ci.mdx
+++ b/docs/site/src/content/docs/guides/ci.mdx
@@ -1,41 +1,41 @@
 ---
 title: Testing in CI
-description: Run xa11y accessibility tests in CI across Linux, macOS, and Windows — a ready-made GitHub Actions setup plus the CI-agnostic steps it automates.
+description: Run xa11y accessibility tests in CI across Linux, macOS, and Windows, with a ready-made GitHub Actions setup plus the CI-agnostic steps it automates.
 ---
 
 xa11y drives the *real* accessibility tree of a running application, so the
-hard part of CI isn't xa11y — it's standing up an environment where an
+hard part of CI isn't xa11y. It's standing up an environment where an
 accessibility API is actually available. A bare CI runner usually has no
 display, no accessibility bus, and (on macOS) no permission to read other
 apps' trees. This guide covers what each platform needs.
 
-The requirements themselves — a display, a D-Bus session, the AT-SPI bridge,
-the macOS Accessibility permission — are **generic to any CI system** (GitLab
+The requirements themselves (a display, a D-Bus session, the AT-SPI bridge,
+the macOS Accessibility permission) are **generic to any CI system** (GitLab
 CI, CircleCI, Jenkins, a plain container, or your laptop). Only the
 [`setup-a11y` composite action](#the-setup-a11y-action-github-actions) and the
-YAML snippets are **GitHub Actions–specific**: they're a convenience wrapper
+YAML snippets are **specific to GitHub Actions**: they're a convenience wrapper
 so you don't have to wire the generic steps up by hand. If you're not on
 GitHub Actions, skip to [Doing it without the
 action](#doing-it-without-the-action-any-ci) for the same setup as plain
 shell commands.
 
 The examples below run tests with `pytest`, but xa11y exposes the same API
-from Python, JavaScript, Rust, and the `xa11y` CLI — substitute whichever test
-runner your suite uses. Nothing in the CI setup is tied to a particular
+from Python, JavaScript, Rust, and the `xa11y` CLI, so substitute whichever
+test runner your suite uses. Nothing in the CI setup is tied to a particular
 language.
 
 ## Why it's tricky
 
-This section is CI-agnostic — it describes the underlying platform
-requirements, not anything specific to GitHub Actions. Each platform exposes
+This section is CI-agnostic, describing the underlying platform
+requirements rather than anything specific to GitHub Actions. Each platform exposes
 accessibility differently, and each has a precondition that fails silently if
 you miss it:
 
 | Platform | API | What CI is missing by default |
 | --- | --- | --- |
-| **Linux** | AT-SPI2 (D-Bus) | No display, no D-Bus session, AT-SPI bridge not running/enabled |
+| **Linux** | AT-SPI2 (D-Bus) | A display, a D-Bus session, and the AT-SPI bridge all have to be started |
 | **macOS** | AXUIElement | The test process isn't granted the Accessibility (TCC) permission |
-| **Windows** | UI Automation | Nothing — UIA works on hosted runners out of the box |
+| **Windows** | UI Automation | Nothing. UIA works on hosted runners out of the box |
 
 The failure mode is the same on Linux and macOS: queries return an **empty
 tree** rather than an error, so it looks like your app has no UI. The
@@ -43,10 +43,10 @@ sections below show how to satisfy each precondition.
 
 ## The `setup-a11y` action (GitHub Actions)
 
-This section is **GitHub Actions–specific**. The quickest path on GitHub is
+This section is **specific to GitHub Actions**. The quickest path on GitHub is
 the [`xa11y/setup-a11y`](https://github.com/xa11y/setup-a11y) action. It
 installs the Linux system libraries, brings up a headless display + D-Bus +
-AT-SPI, and (on macOS) grants the Accessibility permission — then exports the
+AT-SPI, and (on macOS) grants the Accessibility permission, then exports the
 environment so every later step in the job inherits it.
 
 ```yaml title=".github/workflows/test.yml"
@@ -78,22 +78,22 @@ jobs:
 | `install-deps` | `true` | Set `false` to skip apt entirely. |
 | `setup-display` | `true` | Start Xvfb and export `DISPLAY` (Linux). |
 | `setup-atspi` | `true` | Start D-Bus + AT-SPI and export their env (Linux). |
-| `setup-window-manager` | `false` | Start fluxbox — needed by toolkits (e.g. egui) that only publish their tree once a window is mapped/focused. |
+| `setup-window-manager` | `false` | Start fluxbox, needed by toolkits (e.g. egui) that only publish their tree once a window is mapped/focused. |
 | `display` | `:99` | X display number for Xvfb. |
-| `macos-tcc-client` | `""` | Path to the binary to grant Accessibility (TCC) on macOS — e.g. your python interpreter. When empty, the action warns instead. |
+| `macos-tcc-client` | `""` | Path to the binary to grant Accessibility (TCC) on macOS, e.g. your python interpreter. When empty, the action warns instead. |
 
 The Linux package set is defined once, in
 [`apt-packages.txt`](https://github.com/xa11y/setup-a11y/blob/v1/apt-packages.txt),
 grouped by purpose. Pick the groups your test app's toolkit needs:
 
-- **base** — headless display + AT-SPI stack. Always include this.
-- **gtk** — GTK3/4 + WebKitGTK (GTK apps, Tauri).
-- **electron** — Chromium/Electron runtime libraries.
+- **base** covers the headless display and AT-SPI stack. Always include this.
+- **gtk** covers GTK3/4 and WebKitGTK (GTK apps, Tauri).
+- **electron** covers the Chromium/Electron runtime libraries.
 
 ## macOS
 
 macOS won't let one process read another's accessibility tree unless it holds
-the **Accessibility** TCC permission — this is a macOS requirement, not a
+the **Accessibility** TCC permission. That is a macOS requirement, not a
 GitHub Actions one. On a hosted runner you grant it to whichever process runs
 your tests: the Python or Node interpreter, the `xa11y` CLI binary, or your
 own test harness. The GitHub Actions example below grants it to the Python
@@ -119,7 +119,7 @@ takes effect immediately.
 
 ### Granting TCC without the action
 
-Outside GitHub Actions — a different CI system, or a local headless run — use
+Outside GitHub Actions, on a different CI system or a local headless run, use
 the standalone helper [`scripts/grant_macos_tcc.sh`](https://github.com/xa11y/xa11y/blob/main/scripts/grant_macos_tcc.sh).
 Pass it the **resolved** interpreter path (TCC matches the real on-disk
 binary, not a venv symlink):
@@ -132,21 +132,21 @@ scripts/grant_macos_tcc.sh "$(.venv/bin/python -c 'import sys; print(sys.executa
 The `setup-a11y` action (in its own [`xa11y/setup-a11y`](https://github.com/xa11y/setup-a11y)
 repo) carries its own inline copy of this sqlite write rather than calling the
 script. That's structural, not an oversight: a composite action consumed as
-`xa11y/setup-a11y@v1` only receives the action's own directory — it doesn't get
-a checkout of this repo, so it can't reach `scripts/`. The action must be
-self-contained to work for external consumers; the script serves the contexts
-the action can't (local dev, other CI). Keep the two in sync — each side says
-so in a comment.
+`xa11y/setup-a11y@v1` only receives the action's own directory, and it doesn't
+get a checkout of this repo, so it can't reach `scripts/`. The action must be
+self-contained to work for external consumers. The script serves the contexts
+the action can't (local dev, other CI). Keep the two in sync. Each side says so
+in a comment.
 :::
 
 ## Windows
 
-Nothing to set up — UI Automation is available on hosted `windows-latest`
-runners, which have an interactive desktop session. Just run your tests.
+UI Automation is available on hosted `windows-latest` runners, which have an
+interactive desktop session, so just run your tests.
 
 ## Doing it without the action (any CI)
 
-If you're not on GitHub Actions — or can't use the composite action — here's
+If you're not on GitHub Actions, or can't use the composite action, here's
 the underlying setup for Linux as plain shell commands. This is exactly what
 the action automates, and it works on any CI system or a local machine:
 

--- a/docs/site/src/content/docs/guides/cli.mdx
+++ b/docs/site/src/content/docs/guides/cli.mdx
@@ -1,11 +1,11 @@
 ---
 title: CLI
-description: Use the xa11y CLI to explore accessibility trees, find elements, and debug tests.
+description: Use the xa11y CLI to explore accessibility trees and debug failing tests.
 ---
 
 The `xa11y` command-line tool is for exploring and debugging. It mirrors the library API and is useful for inspecting an app before writing code, or figuring out why a selector isn't matching.
 
-If you're looking to build agents that control desktop applications, see [agent-desktop.dev](https://agent-desktop.dev) — a purpose-built tool for that, built on xa11y.
+If you're looking to build agents that control desktop applications, see [agent-desktop.dev](https://agent-desktop.dev), a purpose-built tool for that, built on xa11y.
 
 ## Install
 

--- a/docs/site/src/content/docs/guides/design.mdx
+++ b/docs/site/src/content/docs/guides/design.mdx
@@ -88,14 +88,18 @@ The matrix below summarises which apps are exercised on which platforms and what
 
 | Test app    | Frameworks tested            | Platforms in CI       | Suites that target it      | Features covered                         |
 |-------------|------------------------------|-----------------------|----------------------------|------------------------------------------|
-| AccessKit   | Rust + winit + AccessKit     | Linux, macOS, Windows | Rust core integ, JS integ  | compat, actions, events, screenshot      |
+| AccessKit   | Rust + winit + AccessKit     | Linux, Windows²       | Rust core integ, JS integ  | compat, actions, events, screenshot      |
 | Qt          | PySide6 (Qt 6)               | Linux, macOS, Windows | Python integ               | compat, actions, events                  |
 | GTK         | GTK 4 (PyGObject)            | Linux                 | Python integ               | compat, actions¹                         |
 | Cocoa       | AppKit (Swift)               | macOS                 | Python integ               | compat, actions, events                  |
-| Tauri       | Tauri (Rust + HTML)          | Linux, macOS, Windows | Python integ               | compat, actions, events, input_sim, screenshot |
+| Tauri       | Tauri (Rust + HTML)          | Linux, macOS³         | Python integ               | compat, actions, events, input_sim, screenshot |
 | Electron    | Chromium + Node              | Linux                 | JS integ                   | compat, actions, AccessibilityNotEnabled detection |
 
 ¹ GTK event subscription is exercised through the Rust integ suite via AT-SPI2 rather than duplicated in the per-app Python suite.
+
+² AccessKit on macOS runs locally rather than in CI, for the TCC reason described under the CI matrix below.
+
+³ No windows-latest cell for Tauri, which leaves the Windows `SendInput` path without end-to-end input-simulation coverage (`windows_input_sim` in `tests/matrix.yaml`).
 
 ### CI matrix
 

--- a/docs/site/src/content/docs/guides/design.mdx
+++ b/docs/site/src/content/docs/guides/design.mdx
@@ -3,30 +3,30 @@ title: Architecture & Design
 description: Internal architecture, design tenets, and testing strategy for xa11y.
 ---
 
-This page is for contributors and for consumers who want a clearer picture of what xa11y is built on, how design decisions are made, and how the library is hardened. If you are looking for usage docs, start at the [Overview](/guides/overview/). For how the library is verified — the test suites, the toolkit fleet, and CI — see [How xa11y Is Tested](/guides/testing/).
+This page is for contributors and for consumers who want a clearer picture of what xa11y is built on, how design decisions are made, and how the library is hardened. If you are looking for usage docs, start at the [Overview](/guides/overview/). For how the library is verified (the test suites, the toolkit fleet, and CI), see [How xa11y Is Tested](/guides/testing/).
 
 ## Architecture at a glance
 
-xa11y is a Rust workspace organised into a platform-independent core, three platform backends, and language bindings.
+xa11y is a Rust workspace with a platform-independent core, three platform backends, and the language bindings on top of them.
 
-- **`xa11y-core`** — platform-independent types, traits, and the selector engine. Anything that does not need OS-specific FFI lives here.
-- **`xa11y-linux`** — AT-SPI2 backend over `zbus`, plus a `libxkbcommon` + `uinput` input backend.
-- **`xa11y-macos`** — `AXUIElement` backend with an ObjC exception-safety layer (`exception_safe.m`).
-- **`xa11y-windows`** — UI Automation backend.
-- **`xa11y`** — umbrella crate that picks the right backend at compile time and exposes the public Rust API.
-- **`xa11y-python`** (PyO3 / maturin) and **`xa11y-js`** (napi-rs) — language bindings layered on top of the umbrella crate.
+- **`xa11y-core`** holds platform-independent types, traits, and the selector engine. Anything that does not need OS-specific FFI lives here.
+- **`xa11y-linux`** is the AT-SPI2 backend over `zbus`, plus a `libxkbcommon` + `uinput` input backend.
+- **`xa11y-macos`** is the `AXUIElement` backend with an ObjC exception-safety layer (`exception_safe.m`).
+- **`xa11y-windows`** is the UI Automation backend.
+- **`xa11y`** is the umbrella crate that picks the right backend at compile time and exposes the public Rust API.
+- **`xa11y-python`** (PyO3 / maturin) and **`xa11y-js`** (napi-rs) are the language bindings layered on top of the umbrella crate.
 
-The public surface — `App`, `Element`, `Locator`, `Subscription`, `Selector` — is platform-agnostic. Each backend implements a small set of provider traits, and `xa11y-core` is responsible for everything that *can* be cross-platform: the selector parser, the locator engine, retry/wait loops, error mapping, and screenshot encoding.
+The public surface (`App`, `Element`, `Locator`, `Subscription`, `Selector`) is platform-agnostic. Each backend fills in a small set of provider traits, and `xa11y-core` is responsible for everything that *can* be cross-platform: the selector parser, the locator engine, retry/wait loops, error mapping, and screenshot encoding.
 
-Actions (`press`, `set_value`, `type_text`, …) are exposed on both `Locator` and `Element`. `Locator` is the auto-waiting wrapper: it re-resolves its selector and waits for visible+enabled before dispatching. `Element` calls go straight through to the provider handle captured at fetch time — no re-resolution, no wait — and surface `ElementStale` if the handle is gone. Both shapes share a single underlying provider call, so action fidelity (tenet 3) is enforced in one place.
+Actions (`press`, `set_value`, `type_text`, …) are exposed on both `Locator` and `Element`. `Locator` is the auto-waiting wrapper: it re-resolves its selector and waits for visible+enabled before dispatching. `Element` calls go straight through to the provider handle captured at fetch time, skipping re-resolution and the wait, and surface `ElementStale` if the handle is gone. Both shapes share a single underlying provider call, so action fidelity (tenet 3) is enforced in one place.
 
 ## Design tenets
 
-These four tenets are the firm defaults for every new piece of provider or binding code. They are restated verbatim in `CLAUDE.md` so reviewers and AI agents apply them consistently.
+The tenets below are the firm defaults for every new piece of provider or binding code. They are restated verbatim in `CLAUDE.md` so reviewers and AI agents apply them consistently.
 
 ### 1. No silent fallbacks
 
-If an operation fails, return the error — don't silently try a different mechanism. Fallbacks hide bugs and make behaviour unpredictable for consumers. Surface failures clearly so callers can handle them.
+If an operation fails, return the error rather than silently trying a different mechanism. Fallbacks hide bugs and make behaviour unpredictable for consumers. Surface failures clearly so callers can handle them.
 
 Anti-patterns this rules out:
 
@@ -35,32 +35,32 @@ Anti-patterns this rules out:
 - `if let Ok(x) = ... { ... }` that treats a real error as "no match".
 - Try-A-then-B-then-C fallback chains where each step hides the original failure.
 
-If multiple mechanisms genuinely need to be tried, do it explicitly with logged reasoning, not silent fall-through.
+If multiple mechanisms really do need to be tried, do it explicitly with logged reasoning, not silent fall-through.
 
 ### 2. Only expose what accessibility APIs support
 
-If a platform has no accessibility interface for an operation, don't paper over it with input simulation — leave the action out of the element's `actions` list. Input simulation lives in its own surface (`InputSim`) and is never reached from `locator.press()` automatically.
+If a platform has no accessibility interface for an operation, don't paper over it with input simulation. Leave the action out of the element's `actions` list. Input simulation lives in its own surface (`InputSim`) and is never reached from `locator.press()` automatically.
 
 ### 3. Action fidelity
 
-If an element advertises an action name in its `actions` list, calling that action must invoke the original platform action — not a substitute. The verbs `press`, `toggle`, `focus`, `select`, `expand`, `collapse` are *semantic* and may legitimately dispatch to different platform APIs (e.g. `press` on Windows can resolve to UIA Invoke, Toggle, SelectionItem.Select, or ExpandCollapse based on the element's primary-activation pattern). What is forbidden is advertising one verb and calling something that does not implement it semantically (e.g. simulating a click instead of invoking the API).
+If an element advertises an action name in its `actions` list, calling that action must invoke the original platform action, never a substitute. The verbs `press`, `toggle`, `focus`, `select`, `expand`, `collapse` are *semantic* and may legitimately dispatch to different platform APIs (e.g. `press` on Windows can resolve to UIA Invoke, Toggle, SelectionItem.Select, or ExpandCollapse based on the element's primary-activation pattern). What is forbidden is advertising one verb and calling something that does not carry out its semantics (e.g. simulating a click instead of calling the API).
 
 ### 4. Fail surfaceably, not fatally
 
 Prefer `Result` over `.unwrap()` / `.expect()` in provider and binding code.
 
-- **Locks**: `.lock().unwrap()` on caches becomes `.lock().unwrap_or_else(|e| e.into_inner())` — poisoning in a memoization cache is recoverable.
+- **Locks**: `.lock().unwrap()` on caches becomes `.lock().unwrap_or_else(|e| e.into_inner())`, because poisoning in a memoization cache is recoverable.
 - **Platform FFI returns**: never `.unwrap()` a CF / AX / UIA / AT-SPI2 return. Map to `Error::Platform`.
 - **Tests** may use `.expect("...")` with a descriptive message when the failure indicates a broken fixture.
 - Any new `.unwrap()` must have an invariant one line above that proves it can't panic.
 
 ### Breaking a tenet
 
-These are firm defaults, not absolutes. Genuine exceptions:
+These are firm defaults. A real exception has to clear three bars:
 
-1. Need explicit human approval — agents must pause and ask.
-2. Are documented at the call site with a `// TENET-BREAK(<N>):` comment explaining why the break is justified and what the alternative would cost.
-3. Are greppable (`rg 'TENET-BREAK'`), so the full set of exceptions stays visible and reviewable.
+1. It needs explicit human approval, so agents must pause and ask.
+2. It is documented at the call site with a `// TENET-BREAK(<N>):` comment explaining why the break is justified and what the alternative would cost.
+3. It is greppable (`rg 'TENET-BREAK'`), so the full set of exceptions stays visible and reviewable.
 
 ## Testing strategy
 
@@ -68,23 +68,23 @@ The testing philosophy has two pillars: **integration tests against real, live a
 
 ### Layers
 
-- **Unit tests** (`cargo xtask test`) — selector parsing, locator/wait loops, error mapping, and per-backend logic that doesn't need a live AX tree. Run on every push on Linux, macOS, and Windows.
-- **Rust core integration suite** (`xa11y/tests/integ/`, run via `cargo xtask test-integ`) — the fast-path validation suite for the core API surface. All tests are `#[ignore]` and target the AccessKit + winit test app. Event subscription is split per-platform (`events_linux.rs`, `events_macos.rs`, `events_windows.rs`).
-- **Per-app compatibility suites** (`tests/<framework>/`) — Python integration tests that drive each major UI framework end-to-end through xa11y. They confirm that real-world AX trees, roles, and actions behave correctly with frameworks other than AccessKit. JS suites add a partial second-binding check.
-- **Fuzz targets** (`xa11y/fuzz/` for libFuzzer; `xa11y-fuzz/` for live-app stress) — randomised stress over the public API, the selector engine, tree operations, and serde round-trips.
-- **Linux Wayland uinput e2e** — drives `LinuxInputProvider` through its public API on the runner and reads events back via `libevdev`, verifying wire-level codes/values for the input-simulation surface.
+- **Unit tests** (`cargo xtask test`) cover selector parsing, locator/wait loops, error mapping, and per-backend logic that doesn't need a live AX tree. Run on every push on Linux, macOS, and Windows.
+- **Rust core integration suite** (`xa11y/tests/integ/`, run via `cargo xtask test-integ`) is the fast-path validation suite for the core API surface. All tests are `#[ignore]` and target the AccessKit + winit test app. Event subscription is split per-platform (`events_linux.rs`, `events_macos.rs`, `events_windows.rs`).
+- **Per-app compatibility suites** (`tests/<framework>/`) are Python integration tests that drive each major UI framework end-to-end through xa11y. They confirm that real-world AX trees, roles, and actions behave correctly with frameworks other than AccessKit. JS suites add a partial second-binding check.
+- **Fuzz targets** (`xa11y/fuzz/` for libFuzzer; `xa11y-fuzz/` for live-app stress) put randomised stress on the public API, the selector engine, tree operations, and serde round-trips.
+- **Linux Wayland uinput e2e** drives `LinuxInputProvider` through its public API on the runner and reads events back via `libevdev`, verifying wire-level codes/values for the input-simulation surface.
 
 ### Cross-cutting choices
 
-- **Live targets only** — every integration test runs against a real running application, never a recorded fixture. Live tests catch backend bugs that recorded ones miss.
+- **Live targets only.** Every integration test runs against a real running application, never a recorded fixture. Live tests catch backend bugs that recorded ones miss.
 - **One coverage vehicle per concern.** Input simulation and screenshot capture exercise platform input/screenshot APIs, not AX-framework compatibility, so they are tested *once per platform* (against the Tauri app, which runs on all three) rather than against every framework.
 - **Test-app-first.** When an integration test needs a widget the test app doesn't expose, the test app gets the widget *before* the test is added. This keeps tests deterministic and prevents the suite from drifting away from a stable target surface.
-- **Coverage matrix as a CI gate.** `tests/matrix.yaml` is machine-readable; `tests/matrix_check.py` runs in CI and fails the build when a row drifts away from what's documented. Gaps must be declared, not silently introduced.
+- **Coverage matrix as a CI gate.** `tests/matrix.yaml` is machine-readable. `tests/matrix_check.py` runs in CI and fails the build when a row drifts away from what's documented. Gaps must be declared, not silently introduced.
 - **Bindings parity check.** `cargo xtask check-bindings-parity` keeps the Rust, Python, and JS public surfaces aligned so a feature added to one binding cannot quietly miss the others.
 
 ### Test-suite map
 
-The matrix below summarises which apps are exercised on which platforms and what each suite covers. `compat` = tree structure and widget discovery; `actions` = press/toggle/focus/type/expand-collapse; `events` = subscription and state-change detection; `input_sim` and `screenshot` = the platform-input and screenshot surfaces.
+The matrix below summarises which apps are exercised on which platforms and what each suite covers. `compat` = tree structure and widget discovery. `actions` = press/toggle/focus/type/expand-collapse. `events` = subscription and state-change detection. `input_sim` and `screenshot` = the platform-input and screenshot surfaces.
 
 | Test app    | Frameworks tested            | Platforms in CI       | Suites that target it      | Features covered                         |
 |-------------|------------------------------|-----------------------|----------------------------|------------------------------------------|
@@ -99,13 +99,13 @@ The matrix below summarises which apps are exercised on which platforms and what
 
 ### CI matrix
 
-CI runs every push and pull request, with `RUSTFLAGS: -Dwarnings` so warnings fail the build. The notable jobs:
+CI runs every push and pull request, with `RUSTFLAGS: -Dwarnings` so warnings fail the build. The main jobs:
 
 | Job                     | Runner            | What it does                                                            |
 |-------------------------|-------------------|-------------------------------------------------------------------------|
 | Linux                   | `ubuntu-latest`   | Workspace unit tests + AccessKit Rust integ suite under Xvfb + dbus.    |
 | Linux Wayland (uinput)  | `ubuntu-latest`   | uinput e2e for the Wayland input backend; reads back via libevdev.      |
-| macOS                   | `macos-latest`    | Workspace unit tests. (TCC-bound integ tests run locally; see below.)   |
+| macOS                   | `macos-latest`    | Workspace unit tests. (TCC-bound integ tests run locally. See below.)   |
 | Windows                 | `windows-latest`  | Workspace unit tests + AccessKit Rust integ suite via UIA.              |
 | Integ (per app × OS)    | matrix            | One app × one OS × Python+JS+CLI suites via `tests/harness/launch.py`.  |
 | Lint & Format           | `ubuntu-latest`   | `cargo fmt`, `clippy -Dwarnings`, README sync, bindings parity, matrix check. |
@@ -120,7 +120,7 @@ macOS Rust integ tests for the AccessKit app are not wired into CI: they require
 
 ### Pre-PR checklist
 
-Before opening a PR, run `cargo xtask check`. It chains formatting (`fmt --check`), lint (clippy + ruff + Python Rust check), unit tests, and Python bindings. For provider or test-app changes, also run `cargo xtask test-integ`. The same checks run in CI; fixing them locally first keeps review tight.
+Before opening a PR, run `cargo xtask check`. It chains formatting (`fmt --check`), lint (clippy + ruff + Python Rust check), unit tests, and Python bindings. For provider or test-app changes, also run `cargo xtask test-integ`. The same checks run in CI, so fixing them locally first keeps review tight.
 
 ## Platform notes
 
@@ -130,7 +130,7 @@ All raw CoreFoundation / AX FFI calls in `xa11y-macos/src/ax.rs` go through wrap
 
 ### Linux: input subsystem
 
-Wayland input simulation goes through `uinput`. The Wayland uinput e2e tests run *directly on the runner* rather than in a container — Docker's `/dev` tmpfs isolation hides the udev-minted `/dev/input/eventN` node for the virtual device, even with `--device /dev/uinput` and a bind mount. The container path is still useful for non-Linux developer hosts.
+Wayland input simulation goes through `uinput`. The Wayland uinput e2e tests run *directly on the runner* rather than in a container, because Docker's `/dev` tmpfs isolation hides the udev-minted `/dev/input/eventN` node for the virtual device, even with `--device /dev/uinput` and a bind mount. The container path is still useful for non-Linux developer hosts.
 
 ### Windows: UI Automation
 

--- a/docs/site/src/content/docs/guides/desktop-testing.mdx
+++ b/docs/site/src/content/docs/guides/desktop-testing.mdx
@@ -9,23 +9,23 @@ import jsExample from "../../../../../../examples/js/end_to_end.mjs?raw";
 import rustExample from "../../../../../../examples/rust/src/main.rs?raw";
 import cliExample from "../../../../../../examples/cli/end_to_end.sh?raw";
 
-xa11y's Locator pattern makes it natural to write integration tests for desktop apps — find elements, interact with them, wait for changes, and assert on the result. If you've used Playwright for web testing, the workflow is familiar.
+xa11y's Locator pattern makes it natural to write integration tests for desktop apps. Find elements, act on them, wait for the UI to settle, and assert on the result. If you've used Playwright for web testing, the workflow is familiar.
 
 ## Waits
 
 Desktop UIs update asynchronously. After pressing a button, the result might not appear for a few frames. Locator `wait_*()` methods poll until a condition is met or a timeout expires:
 
-- `wait_visible()` / `wait_hidden()` — element appears or disappears
-- `wait_enabled()` / `wait_disabled()` — element becomes interactive or not
-- `wait_attached()` / `wait_detached()` — element exists in the tree or not
-- `wait_focused()` / `wait_unfocused()` — element gains or loses focus
-- `wait_until(predicate)` — arbitrary condition on the resolved element
+- `wait_visible()` / `wait_hidden()` for an element appearing or disappearing
+- `wait_enabled()` / `wait_disabled()` for an element becoming interactive
+- `wait_attached()` / `wait_detached()` for an element entering or leaving the tree
+- `wait_focused()` / `wait_unfocused()` for an element gaining or losing focus
+- `wait_until(predicate)` for an arbitrary condition on the resolved element
 
-Always use waits instead of sleeping — they're faster (resolve as soon as the condition is met) and more reliable (won't flake on slow machines).
+Always use waits instead of sleeping. They resolve as soon as the condition is met, and they won't flake on a slow machine.
 
 ### The default timeout
 
-Auto-waiting action methods (`press()`, `set_value()`, …), the `wait_*()` family, and app lookup (`App.by_name` / `App.by_pid`) all share one process-wide default timeout: **5 seconds**. When that's too tight — cold CI runners are the classic case — raise it once instead of threading `timeout=` through every call site:
+Auto-waiting action methods (`press()`, `set_value()`, …), the `wait_*()` family, and app lookup (`App.by_name` / `App.by_pid`) all share one process-wide default timeout: **5 seconds**. When that's too tight (cold CI runners are the classic case), raise it once instead of threading `timeout=` through every call site:
 
 ```python
 xa11y.set_default_timeout(30.0)        # Python (seconds)
@@ -39,24 +39,24 @@ setDefaultTimeout(30);                 // JavaScript (seconds)
 xa11y::set_default_timeout(Duration::from_secs(30));   // Rust
 ```
 
-Or set the `XA11Y_DEFAULT_TIMEOUT` environment variable (seconds, read once at startup). Resolution order: an explicit per-call `timeout=` always wins, then the programmatic `set_default_timeout()` value, then the environment variable, then the built-in 5 seconds. A timeout of `0` means a single attempt with no polling.
+Or set the `XA11Y_DEFAULT_TIMEOUT` environment variable (seconds, read once at startup). Resolution order runs from most to least specific. An explicit per-call `timeout=` always wins. After that comes the programmatic `set_default_timeout()` value, the environment variable, and finally the built-in 5 seconds. A timeout of `0` means a single attempt with no polling.
 
-Because Locator *actions* (`press()`, `set_value()`, `toggle()`, …) already auto-wait for the target to be visible and enabled, a short `wait_visible()` immediately before an action is redundant — pass a per-call `timeout=` when one step needs a longer window, or raise the default once when the whole suite does.
+Because Locator *actions* (`press()`, `set_value()`, `toggle()`, …) already auto-wait for the target to be visible and enabled, a short `wait_visible()` immediately before an action is redundant. Pass a per-call `timeout=` when one step needs a longer window, or raise the default once when the whole suite does.
 
-The same rule applies to *finding* things: every entry point that can race app startup has a polling form built in, so a hand-rolled `while`/`sleep` loop is never needed. Built-in polling also releases the host language's runtime lock while it waits (Python threads keep running during a 60s `wait_visible`) and produces a structured diagnosis on timeout — what it waited for, what it last observed, and near-miss candidates (see [Errors & Diagnosis](/guides/errors/)). A manual loop gets none of that.
+The same rule applies to *finding* things: every entry point that can race app startup has a polling form built in, so a hand-rolled `while`/`sleep` loop is never needed. Built-in polling also releases the host language's runtime lock while it waits (Python threads keep running during a 60s `wait_visible`) and produces a structured diagnosis on timeout, covering what it waited for, what it last observed, and near-miss candidates (see [Errors & Diagnosis](/guides/errors/)). A manual loop gets none of that.
 
 ## Attaching to the app under test
 
-The usual test flow is: launch the app as a subprocess, then attach by PID — `App.by_pid` polls until the OS registers the process with the accessibility API:
+The usual test flow launches the app as a subprocess, then attaches by PID. `App.by_pid` polls until the OS registers the process with the accessibility API:
 
 ```python
 proc = subprocess.Popen([app_path])
 app = xa11y.App.by_pid(proc.pid, timeout=60.0)
 ```
 
-Two situations need more than a PID:
+A PID is not always enough on its own.
 
-- **The UI registers as more than one accessibility app.** Some toolkits register top-level windows as *separate* accessibility applications sharing the host PID — on Windows UIA, a Qt dialog can appear as its own app rather than under the main window's tree (see [Accessibility API Quirks](/guides/accessibility-quirks/)). Match it with a predicate instead of polling `App.list()` by hand:
+- **The UI may register as more than one accessibility app.** Some toolkits register top-level windows as *separate* accessibility applications sharing the host PID. On Windows UIA, a Qt dialog can appear as its own app rather than under the main window's tree (see [Accessibility API Quirks](/guides/accessibility-quirks/)). Match it with a predicate instead of polling `App.list()` by hand:
 
   ```python
   dialog_app = xa11y.App.find(
@@ -65,7 +65,7 @@ Two situations need more than a PID:
   )
   ```
 
-- **The element belongs to an app you can't predict.** Message boxes and system popups are sometimes hosted by a different app than the one showing them. A locator created with the module-level `xa11y.locator()` searches from the system root — every running app — so you can wait for the popup without knowing its owner:
+- **The element belongs to an app you can't predict.** Message boxes and system popups are sometimes hosted by a different app than the one showing them. A locator created with the module-level `xa11y.locator()` searches from the system root, across every running app, so you can wait for the popup without knowing its owner:
 
   ```python
   popup_text = xa11y.locator("static_text[name^='Saved the submission']")
@@ -174,17 +174,17 @@ This test opens Calculator, performs `7 × 8`, and asserts the result is `56`.
 
 ## Full runnable example
 
-The repo ships an end-to-end example for each binding that drives the in-tree
+The repo carries an end-to-end example for each binding that drives the in-tree
 AccessKit test app (`test-apps/accesskit`) from launch to teardown. CI runs
 all four files on Linux against the AccessKit test app, so they can't rot.
-(The library itself ships on macOS and Windows too — separate Rust
-integration tests cover those platforms; the published examples just lock in
-their Linux behavior automatically.)
+(The library supports macOS and Windows too. Separate Rust integration tests
+cover those platforms, and the published examples lock in their Linux
+behavior automatically.)
 
-Each file covers the same flow: launch a subprocess, poll the accessibility
-API until the OS registers it, dump the tree to discover selectors, exercise
-the locator + wait + action surface, subscribe to events, and tear the
-subprocess down cleanly.
+Each file covers the same flow. It launches a subprocess and polls the
+accessibility API until the OS registers it. It dumps the tree to discover
+selectors, exercises the locator, wait, and action surface, subscribes to
+events, then tears the subprocess down cleanly.
 
 To run from a fresh checkout:
 
@@ -238,7 +238,7 @@ See the [Overview](/guides/overview/#cli) for the full CLI reference.
 
 ## Tips
 
-- **Be specific with selectors.** `button[name='7']` is better than `button` — it won't break when the UI adds more buttons.
+- **Be specific with selectors.** `button[name='7']` is better than `button`, because it won't break when the UI adds more buttons.
 - **Use locators, not elements, for interactions.** Locators re-resolve their selector on every operation, making them resilient to UI changes.
-- **Prefer `wait_until` for complex assertions.** Instead of sleeping then asserting, combine the wait and the condition — the test passes as soon as the UI is ready.
-- **Keep timeouts generous in CI.** CI machines are slower. Use 5–10 seconds for waits even if your local machine resolves in milliseconds — or raise the process-wide default once with `set_default_timeout()` / `XA11Y_DEFAULT_TIMEOUT` instead of touching every call site.
+- **Prefer `wait_until` for complex assertions.** Combine the wait and the condition instead of sleeping then asserting, and the test passes as soon as the UI is ready.
+- **Keep timeouts generous in CI.** CI machines are slower. Use 5 to 10 seconds for waits even if your local machine resolves in milliseconds, or raise the process-wide default once with `set_default_timeout()` / `XA11Y_DEFAULT_TIMEOUT` instead of touching every call site.

--- a/docs/site/src/content/docs/guides/errors.mdx
+++ b/docs/site/src/content/docs/guides/errors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Errors & Diagnosis
-description: xa11y errors carry their own diagnosis — selectors, wait conditions, last observations, and bounded scope snapshots.
+description: xa11y errors carry their own diagnosis, including selectors, wait conditions, last observations, and bounded scope snapshots.
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
@@ -10,10 +10,10 @@ logging to understand it. A timeout tells you *what it was waiting for* and
 *what it last saw*; a selector miss tells you *what was actually there*. The
 same information is available two ways:
 
-- **Rendered into the message** — the exception text alone is enough to
+- **Rendered into the message.** The exception text alone is enough to
   diagnose a CI failure from the log.
-- **As structured fields** — exception attributes in Python, error
-  properties in JavaScript, and the [`Diagnosis`] struct in Rust — so
+- **As structured fields.** Exception attributes in Python, error
+  properties in JavaScript, and the [`Diagnosis`] struct in Rust, so
   harnesses can act on them programmatically instead of parsing prose.
 
 ## Anatomy of a timeout
@@ -32,24 +32,25 @@ application "Finder" (pid=512)
 
 Reading it back:
 
-- **`waiting for`** — the wait condition: `visible`, `attached`,
-  `enabled`, … for the `wait_*` methods; `press target actionable
-  (visible && enabled)` for an auto-waiting action; `event matching
-  predicate` for event waits; `custom predicate` for `wait_until`.
-- **`selector`** — the full selector the locator was resolving.
-- **`last observed`** — the final poll's observation. This is the key
-  distinction when debugging:
-  - `selector never matched` — the element was never there (wrong selector,
-    wrong window, app not ready).
+- **`waiting for`** names the wait condition. The `wait_*` methods report
+  `visible`, `attached`, `enabled`, and so on. An auto-waiting action
+  reports `press target actionable (visible && enabled)`, an event wait
+  reports `event matching predicate`, and `wait_until` reports
+  `custom predicate`.
+- **`selector`** is the full selector the locator was resolving.
+- **`last observed`** is the final poll's observation, which is what
+  separates the two failure modes when debugging:
+  - `selector never matched` means the element was never there (wrong
+    selector, wrong window, app not ready).
   - `matched button "Export" (visible=false, enabled=true, focused=false)`
-    — the element *was* there, but in the wrong state. No candidate or
-    scope sweep is attached in this case; the states tell the story.
-  - `selector matched 2 element(s); nth(5) requested` — an `nth()` index
-    out of range.
-- **`candidates`** — near-misses: elements with the selector's target role
-  but different attributes. A typo like `button[name="Exprot"]` lists
+    means the element was there in the wrong state. No candidate or scope
+    sweep is attached in this case. The states already tell the story.
+  - `selector matched 2 element(s); nth(5) requested` means an `nth()`
+    index out of range.
+- **`candidates`** lists near-misses: elements with the selector's target
+  role but different attributes. A typo like `button[name="Exprot"]` lists
   `button "Export"` right in the error.
-- **`search scope (bounded)`** — a depth-limited, line-capped snapshot of
+- **`search scope (bounded)`** is a depth-limited, line-capped snapshot of
   where the search happened: a tree dump for scoped locators, the running
   application list for rootless ones and app lookups. This replaces the
   `print(app.dump())` wrapper you'd otherwise write around the failing call.
@@ -122,7 +123,7 @@ already failed.
 
 ## App lookups
 
-`App.by_pid` / `App.by_name` / `App.find` timeouts list what *is* running,
+`App.by_pid` / `App.by_name` / `App.find` timeouts list every running app,
 so an attach failure on an opaque CI runner is diagnosable from the message:
 
 ```text
@@ -147,7 +148,7 @@ events will arrive
 
 This behavior is governed by design tenet 6 (*errors carry their own
 diagnosis*) in `AGENTS.md`. The structured carrier is the `Diagnosis`
-struct in `xa11y-core/src/error.rs`; its module docs describe the pattern —
+struct in `xa11y-core/src/error.rs`. Its module docs describe the pattern:
 enrich at the terminal failure site, keep poll-loop retry signals cheap,
 bound every payload, and never let diagnosis collection mask the original
 error. New failure paths should attach a `Diagnosis` rather than

--- a/docs/site/src/content/docs/guides/errors.mdx
+++ b/docs/site/src/content/docs/guides/errors.mdx
@@ -123,8 +123,9 @@ already failed.
 
 ## App lookups
 
-`App.by_pid` / `App.by_name` / `App.find` timeouts list every running app,
-so an attach failure on an opaque CI runner is diagnosable from the message:
+`App.by_pid` / `App.by_name` / `App.find` timeouts report a bounded list of
+the apps that were running, so an attach failure on an opaque CI runner is
+diagnosable from the message:
 
 ```text
 xa11y.SelectorNotMatchedError: No element matched selector:

--- a/docs/site/src/content/docs/guides/input.mdx
+++ b/docs/site/src/content/docs/guides/input.mdx
@@ -7,12 +7,12 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 xa11y can drive a target application in two distinct ways:
 
-- **Accessibility actions** — `locator.press()`, `locator.type_text()`, `locator.toggle()`, etc. These call the platform accessibility API directly. They work even when the target window is not focused, are deterministic, and are the preferred way to drive a UI.
-- **Input simulation** — `InputSim` generates OS-level pointer and keyboard events at the system event layer (CGEvent on macOS, SendInput on Windows, XTest on X11).
+- **Accessibility actions** are `locator.press()`, `locator.type_text()`, `locator.toggle()`, and the rest. These call the platform accessibility API directly. They are deterministic and work even when the target window is not focused, which makes them the preferred way to drive a UI.
+- **Input simulation** is `InputSim`, which generates OS-level pointer and keyboard events at the system event layer (CGEvent on macOS, SendInput on Windows, XTest on X11).
 
 **Prefer accessibility actions wherever possible.** Reach for input simulation only for gestures that have no accessibility equivalent: drag-and-drop, scroll wheels, global shortcuts, or tests that must exercise the event loop itself.
 
-The two mechanisms are not bridged. A failed accessibility action never falls back to input simulation, and input simulation never inspects the accessibility tree for you. If you want to click an element with synthesised input, you compute its bounds via the a11y API and hand a point or `Element` to `InputSim`.
+The mechanisms are not bridged. A failed accessibility action never falls back to input simulation, and input simulation never inspects the accessibility tree for you. If you want to click an element with synthesised input, you compute its bounds via the a11y API and hand a point or `Element` to `InputSim`.
 
 ## When to use which
 
@@ -32,11 +32,11 @@ The two mechanisms are not bridged. A failed accessibility action never falls ba
 | macOS | Accessibility + Input Monitoring for the terminal/IDE running your code |
 | Windows | None for normal user sessions |
 | Linux (X11) | `XTest` extension enabled on the X server. Zero setup. |
-| Linux (Wayland / headless) | Membership in the `input` group (`sudo usermod -aG input $USER` then re-login). xa11y opens `/dev/uinput` and registers a virtual evdev keyboard+pointer — same mechanism used by `xdotool --using-uinput`, `ydotool`, `wtype`, Steam Input, and Wine. **The privilege grants global input read/write access** — comparable to macOS Input Monitoring. |
+| Linux (Wayland / headless) | Membership in the `input` group (`sudo usermod -aG input $USER` then re-login). xa11y opens `/dev/uinput` and registers a virtual evdev keyboard+pointer, the same mechanism used by `xdotool --using-uinput`, `ydotool`, `wtype`, Steam Input, and Wine. **The privilege grants global input read/write access**, comparable to macOS Input Monitoring. |
 
 On macOS, input simulation usually also requires the target window to be foregrounded. Activate the window explicitly before synthesising input.
 
-xa11y picks the Linux backend at runtime: if `DISPLAY` is set we drive XTest; otherwise we fall through to uinput. There is no compile-time feature flag — both backends are always built into `xa11y-linux`. The uinput path is compositor-agnostic, so it works on every Wayland desktop (GNOME, KDE Plasma, sway, Hyprland, Cosmic, weston) and also on headless Linux servers. Errors from a missing `input` group surface as `PermissionDenied` with an actionable message; a missing `uinput` kernel module surfaces as `Unsupported`.
+xa11y picks the Linux backend at runtime: if `DISPLAY` is set we drive XTest, and otherwise we use uinput. There is no compile-time feature flag, and both backends are always built into `xa11y-linux`. The uinput path is compositor-agnostic, so it works on every Wayland desktop (GNOME, KDE Plasma, sway, Hyprland, Cosmic, weston) and also on headless Linux servers. Errors from a missing `input` group surface as `PermissionDenied` with a message saying what to do about it. A missing `uinput` kernel module surfaces as `Unsupported`.
 
 ## Basic usage
 
@@ -114,8 +114,8 @@ xa11y picks the Linux backend at runtime: if `DISPLAY` is set we drive XTest; ot
 
 Every pointer method accepts either a screen-space point or an `Element`:
 
-- **Point** — absolute screen coordinates in logical (device-independent) units: points on macOS, DIPs on Windows, and logical pixels on Linux (physical where the HiDPI scale can't be read reliably — see [platform details](/guides/platform-details/#coordinates-and-hidpi)). Origin is the top-left of the primary display; negative values are valid on multi-monitor setups.
-- **Element** — uses the centre of the element's `bounds` at the time of the call. `InputSim` does not re-read the accessibility tree for you — re-fetch via a locator first if the UI may have moved.
+- **Point** is absolute screen coordinates in logical (device-independent) units. That means points on macOS and DIPs on Windows. On Linux it means logical pixels, or physical pixels where the HiDPI scale can't be read reliably (see [platform details](/guides/platform-details/#coordinates-and-hidpi)). Origin is the top-left of the primary display, and negative values are valid on multi-monitor setups.
+- **Element** uses the centre of the element's `bounds` at the time of the call. `InputSim` does not re-read the accessibility tree for you, so re-fetch via a locator first if the UI may have moved.
 
 In Rust, additional anchors are available via `ClickOptions.anchor` (`Anchor::TopLeft`, `Anchor::Offset { dx, dy }`, etc.).
 
@@ -177,11 +177,11 @@ In Rust, additional anchors are available via `ClickOptions.anchor` (`Anchor::To
   </TabItem>
 </Tabs>
 
-Scroll: positive `dx` scrolls right, positive `dy` scrolls content down (moves the viewport up), in platform "ticks" (typically one notch of a physical scroll wheel).
+Scroll units are platform "ticks", typically one notch of a physical scroll wheel. Positive `dx` scrolls right. Positive `dy` scrolls content down, which moves the viewport up.
 
 ## Keyboard
 
-Modifier keys (`Shift`, `Ctrl`, `Alt`, `Meta`) are ordinary keys — pass them alongside character keys. `Meta` is the platform's "command" modifier: Cmd on macOS, Win on Windows, Super on Linux.
+Modifier keys (`Shift`, `Ctrl`, `Alt`, `Meta`) are ordinary keys, so pass them alongside character keys. `Meta` is the platform's "command" modifier, spelled Cmd on macOS, Win on Windows, and Super on Linux.
 
 <Tabs syncKey="lang">
   <TabItem label="Rust">
@@ -290,6 +290,6 @@ Drag-and-drop has no accessibility equivalent on most platforms. Resolve both en
 | --- | --- |
 | `PermissionDenied` | OS denied the synthesis permission (macOS Input Monitoring, etc.) |
 | `Unsupported` | Platform has no backend for the operation (e.g. Linux session with neither `DISPLAY` nor `WAYLAND_DISPLAY` set) |
-| `NoElementBounds` | Target `Element` has no bounds — re-fetch it or anchor on a point |
+| `NoElementBounds` | Target `Element` has no bounds. Re-fetch it or anchor on a point |
 | `InvalidActionData` | Uppercase `Char` key, malformed key name, or bad target tuple |
 | `Platform` | Raw OS failure (FFI return code etc.) |

--- a/docs/site/src/content/docs/guides/overview.mdx
+++ b/docs/site/src/content/docs/guides/overview.mdx
@@ -5,11 +5,11 @@ description: What xa11y is, how it works, and how it compares to other tools.
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-**xa11y** is a cross-platform library for reading accessibility trees, taking actions, listening to accessibility event streams, synthesising low-level input, and capturing screenshots.
+**xa11y** is a cross-platform library for reading accessibility trees and acting on them. It also subscribes to accessibility event streams, and can synthesise low-level input or capture screenshots.
 
 ## What is desktop accessibility?
 
-Most desktop applications expose an **accessibility tree** — a structured representation of their UI intended for screen readers and other assistive technology. Each platform has its own API for this (macOS AXUIElement, Windows UI Automation, Linux AT-SPI2), but the underlying concepts are the same. xa11y provides a single API that works with all of them.
+Most desktop applications expose an **accessibility tree**, a structured representation of their UI intended for screen readers and other assistive technology. Each platform has its own API for this (macOS AXUIElement, Windows UI Automation, Linux AT-SPI2), but the underlying concepts are the same. xa11y provides a single API that works with all of them.
 
 ### Trees
 
@@ -29,7 +29,7 @@ An accessibility tree mirrors the visual hierarchy of an application. Here's wha
       ...
 ```
 
-Every element in the tree has properties. For example, here's the full data for `button "+"`:
+Every element in the tree has properties. Here's the full data for `button "+"`:
 
 ```
 role:    button
@@ -42,19 +42,19 @@ actions: press, focus
 
 ### Actions
 
-Accessibility APIs let you interact with elements: press buttons, type into fields, toggle checkboxes, expand menus, scroll, and more. xa11y exposes all of these through a unified action API.
+Accessibility APIs expose the operations an element supports, from pressing a button or typing into a field to expanding a menu and scrolling a pane. xa11y offers all of these through a unified action API.
 
 ### Input simulation
 
-For the small set of gestures with no accessibility equivalent — drag-and-drop, scroll wheels, global shortcuts — xa11y also ships an [`InputSim`](/guides/input/) façade that synthesises OS-level pointer and keyboard events. Input simulation lives in its own surface (`xa11y::input_sim()` / `xa11y.input_sim()` / `inputSim()`) and never falls back from an accessibility action automatically — prefer `locator.press()` and `locator.type_text()` whenever they work.
+For the small set of gestures with no accessibility equivalent (drag-and-drop, scroll wheels, global shortcuts) xa11y also offers an [`InputSim`](/guides/input/) façade that synthesises OS-level pointer and keyboard events. Input simulation lives in its own surface (`xa11y::input_sim()` / `xa11y.input_sim()` / `inputSim()`) and never falls back from an accessibility action automatically. Prefer `locator.press()` and `locator.type_text()` whenever they work.
 
 ### Screenshots
 
-xa11y can capture pixel-level snapshots of the full screen, a region, or the pixels under an accessibility element. Useful for attaching visual evidence to test failures or feeding vision-language models the same frame the agent is reasoning about. See the [Screenshots guide](/guides/screenshots/).
+xa11y captures pixel-level snapshots of the full screen, an explicit region, or the area behind an accessibility element. This is useful for attaching visual evidence to test failures or feeding vision-language models the same frame the agent is reasoning about. See the [Screenshots guide](/guides/screenshots/).
 
 ### Events
 
-Accessibility APIs also emit events when the UI changes — elements appearing or disappearing, focus moving, names or values updating. For example, clicking a text field might emit:
+Accessibility APIs also emit events when the UI changes: elements appearing or disappearing, focus moving, names or values updating. Clicking a text field might emit:
 
 ```
 FocusChanged  app="Calculator"  target=text_field "Display"
@@ -64,21 +64,21 @@ xa11y supports subscribing to these event streams per-app via `app.subscribe()`.
 
 ## How does xa11y compare to other tools?
 
-xa11y reads accessibility trees from the outside, across all three desktop platforms, through one API. That distinguishes it from single-platform libraries like pywinauto and FlaUI, from pixel-matching tools like SikuliX, and from [AccessKit](https://accesskit.dev/), which *publishes* a tree rather than consuming one.
+xa11y reads accessibility trees from the outside, across all three desktop platforms, through one API. That distinguishes it from single-platform libraries such as pywinauto and FlaUI, and from pixel-matching tools such as SikuliX. It also differs from [AccessKit](https://accesskit.dev/), which *publishes* a tree rather than consuming one.
 
 See the [comparison page](/compare/) for the full landscape, capability tables, and when to choose something else.
 
 ## Concepts
 
-<img src="/concepts.svg" alt="Diagram showing xa11y's three concepts: Read (App → .children() → Element → .children()/.parent()), Act (App → .locator() → Locator → Actions/Waits/.element()/.elements()), and Listen (App → .subscribe() → Subscription → recv()/wait_for()/iter())" style="width:100%;max-width:720px;margin:1rem auto;display:block" />
+<img src="/concepts.svg" alt="Diagram of the Read, Act, and Listen paths through xa11y. Read goes App to .children() to Element. Act goes App to .locator() to Locator, then on to actions, waits, and .elements(). Listen goes App to .subscribe() to Subscription, then on to recv(), wait_for(), and iter()" style="width:100%;max-width:720px;margin:1rem auto;display:block" />
 
 xa11y is built around three core types:
 
-- **App** — entry point for interacting with an application. Construct via `App::by_name()`, `App::by_pid()`, `App::find()` (predicate-based discovery), or `App::list()`. An App provides three paths: `app.children()` for navigating the tree, `app.locator(selector)` for actions and waits, and `app.subscribe()` for event streams.
-- **Element** — a live handle to a node in the accessibility tree. Navigate with `children()` and `parent()` — each call queries the platform lazily. Read properties like `role`, `name`, `value`, `states`, `bounds`. Capture the subtree as a structured snapshot with `tree(max_depth)` or as an indented string with `dump(max_depth)`. Actions (`press()`, `set_value()`, etc.) are available too, acting on the captured handle without re-resolution or auto-wait.
-- **Locator** — a lazy selector that re-resolves on every operation. Use for actions (`press()`, `set_value()`, and others), waits (`wait_visible()`, and others), and querying (`element()`, `elements()`). Auto-waits for visible+enabled before acting and is the recommended path for most code. Inspired by [Playwright's Locator pattern](https://playwright.dev/docs/locators).
-- **Subscription** — live event stream from an app. Created via `app.subscribe()`. Pull events with `try_recv()`, `recv(timeout)`, `wait_for(predicate, timeout)`, or iterate with `iter()`. Drop to unsubscribe.
-- **Selector** — CSS-like query syntax used by Locator. Supports role matching, attribute filters, combinators, and nth selection.
+- **App** is the entry point for driving an application. Construct via `App::by_name()`, `App::by_pid()`, `App::find()` (predicate-based discovery), or `App::list()`. An App offers `app.children()` for tree navigation, `app.locator(selector)` for actions and waits, and `app.subscribe()` for event streams.
+- **Element** is a live handle to a node in the accessibility tree. Navigate with `children()` and `parent()`, where each call queries the platform lazily. Read properties like `role`, `name`, `value`, `states`, `bounds`. Capture the subtree as a structured snapshot with `tree(max_depth)` or as an indented string with `dump(max_depth)`. Actions (`press()`, `set_value()`, etc.) are available too, acting on the captured handle without re-resolution or auto-wait.
+- **Locator** is a lazy selector that re-resolves on every operation. Use for actions (`press()`, `set_value()`, and others), waits (`wait_visible()`, and others), and querying (`element()`, `elements()`). Auto-waits for visible+enabled before acting and is the recommended path for most code. Inspired by [Playwright's Locator pattern](https://playwright.dev/docs/locators).
+- **Subscription** is a live event stream from an app. Created via `app.subscribe()`. Pull events with `try_recv()`, `recv(timeout)`, `wait_for(predicate, timeout)`, or iterate with `iter()`. Drop to unsubscribe.
+- **Selector** is the CSS-like query syntax used by Locator. Supports role matching, attribute filters, combinators, and nth selection.
 
 ## Connecting to an app
 
@@ -152,7 +152,7 @@ xa11y is built around three core types:
 
 ### Lazy navigation
 
-`app.children()` returns the top-level elements (typically windows). Each `Element` supports `children()` and `parent()` for further navigation — every call queries the platform lazily, so you always see the current state of the UI.
+`app.children()` returns the top-level elements (typically windows). Each `Element` supports `children()` and `parent()` for further navigation. Every call queries the platform lazily, so you always see the current state of the UI.
 
 <Tabs syncKey="lang">
   <TabItem label="Rust">
@@ -201,7 +201,7 @@ Element navigation and snapshots: `children()`, `parent()`, `tree(max_depth)`, `
 
 ### Elements are live
 
-Every call to `children()` or `parent()` queries the platform. There are no cached snapshots — you always see the latest tree state.
+Every call to `children()` or `parent()` queries the platform. There are no cached snapshots, so you always see the latest tree state.
 
 <Tabs syncKey="lang">
   <TabItem label="Rust">
@@ -233,11 +233,11 @@ Every call to `children()` or `parent()` queries the platform. There are no cach
   </TabItem>
 </Tabs>
 
-To find specific elements, use a Locator (below) — it uses CSS-like selectors to find elements efficiently.
+To find specific elements, use a Locator (below), which uses CSS-like selectors to find elements efficiently.
 
 ### Subtree snapshots
 
-`element.tree(max_depth)` captures the subtree rooted at an element as a recursive data structure (`role`, `name`, `value`, `children`). `element.dump(max_depth)` formats the same snapshot as an indented string — useful for debugging and test diagnostics. Both accept an optional `max_depth` argument: `0` returns only the root node, `1` includes its direct children, and so on. Omit for the full subtree.
+`element.tree(max_depth)` captures the subtree rooted at an element as a recursive data structure (`role`, `name`, `value`, `children`). `element.dump(max_depth)` formats the same snapshot as an indented string, which is useful for debugging and test diagnostics. Both accept an optional `max_depth` argument: `0` returns only the root node, `1` includes its direct children, and so on. Omit for the full subtree.
 
 <Tabs syncKey="lang">
   <TabItem label="Rust">
@@ -347,7 +347,7 @@ A `Locator` holds a selector and **re-resolves on every operation**. Create one 
   </TabItem>
 </Tabs>
 
-**Best practice:** make selectors specific so they stay stable as the UI evolves. Don't select `button` — select `button[name='Cancel']` inside a specific group or window. A vague selector like `button` can become unreliable when new elements are added — it may match the wrong element or start returning multiple matches unexpectedly.
+**Best practice:** make selectors specific so they stay stable as the UI evolves. Instead of `button`, select `button[name='Cancel']` inside a specific group or window. A vague selector like `button` can become unreliable when new elements are added, matching the wrong element or returning several matches unexpectedly.
 
 **Actions:** `press()`, `focus()`, `blur()`, `toggle()`, `select()`, `expand()`, `collapse()`, `set_value()`, `set_numeric_value()`, `type_text()`, `select_text()`, `increment()`, `decrement()`, `show_menu()`, `scroll_into_view()`.
 
@@ -357,13 +357,13 @@ A `Locator` holds a selector and **re-resolves on every operation**. Create one 
 
 **Chaining:** `nth(n)`, `first()`, `child(selector)`, `descendant(selector)`.
 
-Locator re-resolves its selector on every operation, making it resilient to UI changes between calls. To inspect element properties or traverse the subtree, call `.element()` first — `tree()` and `dump()` live on `Element`, not `Locator`.
+Locator re-resolves its selector on every operation, making it resilient to UI changes between calls. To inspect element properties or traverse the subtree, call `.element()` first, because `tree()` and `dump()` live on `Element` rather than `Locator`.
 
 ### Element actions
 
 The same action verbs are also available directly on `Element`. A `Locator` re-resolves its selector and auto-waits for the element to be visible and enabled before acting; an `Element` acts on the snapshot you already captured, with no re-resolution and no auto-wait. If the underlying element has been destroyed since you fetched it, the call returns an `ElementStale` error.
 
-Reach for `Element` actions when you've already inspected an element — typically after `.dump()` or reading `.actions` — and want to act on that same instance. For everything else, use a `Locator`: it stays correct across UI changes and is the path most code should take.
+Reach for `Element` actions when you've already inspected an element, typically after `.dump()` or reading `.actions`, and want to act on that same instance. For everything else, use a `Locator`, which stays correct across UI changes and is the path most code should take.
 
 <Tabs syncKey="lang">
   <TabItem label="Rust">
@@ -404,7 +404,7 @@ Reach for `Element` actions when you've already inspected an element — typical
   </TabItem>
 </Tabs>
 
-**Recommended path: Locator.** Auto-wait and selector re-resolution make Locator resilient to tree changes between operations. Use `Element` actions only when you already hold the element and want to act on that exact instance.
+**Reach for Locator first.** Auto-wait and selector re-resolution make Locator resilient to tree changes between operations. Use `Element` actions only when you already hold the element and want to act on that exact instance.
 
 ## Selectors
 
@@ -419,16 +419,16 @@ button[name$='Cancel']              # ends-with (case-insensitive)
 group > button                      # direct child combinator
 window button[name='OK']            # descendant (any depth)
 button:nth(2)                       # 2nd match (1-based)
-button[name='Play'], button[name='Pause']  # alternation — see below
+button[name='Play'], button[name='Pause']  # alternation (see below)
 ```
 
 **Supported attributes:** `name`, `value`, `description`, `role`.
 
-**Operators:** `=` (exact, case-sensitive), `*=` (contains), `^=` (starts-with), `$=` (ends-with). Substring operators are case-insensitive.
+**Operators:** `=` (exact, case-sensitive), `*=` (contains), `^=` (starts-with), `$=` (ends-with). The substring operators are case-insensitive.
 
 **Roles use `snake_case`:** `button`, `text_field`, `check_box`, `radio_button`, `menu_item`, `tab_group`, `static_text`, `combo_box`, `list_item`, `table_row`, `table_cell`, `scroll_bar`, `progress_bar`, `tree_item`, `web_area`, `split_group`, `spin_button`, etc.
 
-**Selector groups (alternation):** A top-level comma separates alternation clauses, just like CSS selector lists. The result is the union of each clause's matches, deduplicated by element identity and returned in document order. Each clause is parsed independently, so combinators apply per clause: `window button, dialog button` means "buttons under a window *or* buttons under a dialog." Chained `descendant()` / `child()` calls on a group locator distribute over every clause — `locator("toolbar, dialog").descendant("button")` is equivalent to `locator("toolbar button, dialog button")`. Commas inside quoted attribute values (`[name='a,b']`) are not separators.
+**Selector groups (alternation).** A top-level comma separates alternation clauses, just like CSS selector lists. The result is the union of each clause's matches, deduplicated by element identity and returned in document order. Each clause is parsed independently, so combinators apply per clause: `window button, dialog button` means "buttons under a window, plus buttons under a dialog." Chained `descendant()` / `child()` calls on a group locator distribute over every clause, so `locator("toolbar, dialog").descendant("button")` is equivalent to `locator("toolbar button, dialog button")`. Commas inside quoted attribute values (`[name='a,b']`) are not separators.
 
 ## Events
 
@@ -436,7 +436,7 @@ Subscribe to accessibility events from an app with `app.subscribe()`.
 
 <Tabs syncKey="lang">
   <TabItem label="Rust">
-    The returned `Subscription` is a pull-based event stream — no filters or selectors, just all events for the app.
+    The returned `Subscription` is a pull-based event stream carrying every event for the app, with no filters or selectors.
 
     ```rust
     let calc = App::by_name("Calculator", Duration::from_secs(5))?;
@@ -511,7 +511,7 @@ Subscribe to accessibility events from an app with `app.subscribe()`.
 
 ## CLI
 
-xa11y ships a command-line tool for exploring accessibility trees, finding elements, performing actions, and streaming events. It mirrors the library API and is useful for debugging tests or inspecting an app before writing code.
+xa11y includes a command-line tool for exploring accessibility trees and driving them from the shell, including actions and live event streams. It mirrors the library API and is useful for debugging tests or inspecting an app before writing code.
 
 Install via Rust or Python:
 

--- a/docs/site/src/content/docs/guides/platform-details.mdx
+++ b/docs/site/src/content/docs/guides/platform-details.mdx
@@ -67,77 +67,77 @@ Roles not recognized by a platform map to `Unknown`.
 | `Increment` | AXIncrement | increment *(or Value +step)* | RangeValuePattern *(+step)* |
 | `Decrement` | AXDecrement | decrement *(or Value -step)* | RangeValuePattern *(-step)* |
 | `ShowMenu` | AXShowMenu | menu, showmenu, popup | ExpandCollapsePattern |
-| `ScrollIntoView` | *(no-op — no AX equivalent)* | Component.ScrollTo | ScrollItemPattern |
+| `ScrollIntoView` | *(no-op, no AX equivalent)* | Component.ScrollTo | ScrollItemPattern |
 
 ## Platform caveats
 
 ### ScrollIntoView
 
-No direct equivalent on macOS — this action is a **no-op**. On Linux it uses `Component.ScrollTo` with top-edge alignment. On Windows it uses `ScrollItemPattern.ScrollIntoView`.
+macOS has no direct equivalent, so this action is a **no-op**. On Linux it uses `Component.ScrollTo` with top-edge alignment. On Windows it uses `ScrollItemPattern.ScrollIntoView`.
 
 ### SetValue: text vs numeric
 
-- **macOS:** Sets the `AXValue` attribute directly — works for both text and numeric values.
-- **Linux:** The `Value` D-Bus interface only supports `f64`. Text values require `EditableText.ReplaceText`. If neither interface is available, returns `TextValueNotSupported`.
-- **Windows:** Tries `RangeValuePattern` for numeric values, falls back to `ValuePattern.SetValue` for text.
+- **macOS** sets the `AXValue` attribute directly, which works for both text and numeric values.
+- **Linux** has a `Value` D-Bus interface that only supports `f64`, so text values require `EditableText.ReplaceText`. If neither interface is available, the call returns `TextValueNotSupported`.
+- **Windows** tries `RangeValuePattern` for numeric values and falls back to `ValuePattern.SetValue` for text.
 
 ### TypeText
 
-Inserts text via the accessibility API — never simulates keyboard events.
+Text is inserted through the accessibility API. Keyboard events are never simulated.
 
-- **macOS:** Sets `AXSelectedText` (replaces selection or inserts at cursor).
-- **Linux:** Calls `EditableText.InsertText` at the current caret offset.
-- **Windows:** Reads current value via `ValuePattern`, splices in the new text, then calls `SetValue`.
+- **macOS** sets `AXSelectedText`, replacing the selection or inserting at the cursor.
+- **Linux** calls `EditableText.InsertText` at the current caret offset.
+- **Windows** reads the current value via `ValuePattern`. It then splices in the new text and calls `SetValue`.
 
 ### Blur
 
-- **macOS:** Sets `AXFocused` to false on the element.
-- **Linux / Windows:** No direct API equivalent. The action is not supported.
+- **macOS** sets `AXFocused` to false on the element.
+- **Linux and Windows** have no direct API equivalent, so the action is unsupported.
 
 ### Coordinates
 
 All platforms report bounds as logical (device-independent) screen coordinates with origin at the top-left of the primary display, and `Screenshot.scale` carries the physical-to-logical ratio for mapping bounds onto captured pixels. Note:
 
-- **macOS** reports in points — its native logical unit. On Retina displays, 1 point = 2 physical pixels.
-- **Windows** reports device-independent pixels (DIPs); `scale` is the display's DPI scaling (e.g. `1.5` at 150%).
-- **Linux** reports logical pixels where the HiDPI scale is reliably detectable, and falls back to physical at scale `1.0` otherwise — see [Coordinates and HiDPI](/guides/platform-details/#coordinates-and-hidpi) for exactly when.
+- **macOS** reports in points, its native logical unit. On Retina displays, 1 point = 2 physical pixels.
+- **Windows** reports device-independent pixels (DIPs), and `scale` is the display's DPI scaling (e.g. `1.5` at 150%).
+- **Linux** reports logical pixels where the HiDPI scale is reliably detectable, and falls back to physical at scale `1.0` otherwise. See [Coordinates and HiDPI](/guides/platform-details/#coordinates-and-hidpi) for exactly when.
 - Multi-monitor setups can produce negative coordinates for displays positioned left of or above the primary.
 
 ### Name resolution
 
 Platforms use different attributes to determine an element's `name`:
 
-- **macOS:** AXTitle, then AXDescription, then AXValue (for text elements).
-- **Linux:** Accessible.Name, then Description. For `StaticText` with no name, the first portion of the value is used.
-- **Windows:** CurrentName property.
+- **macOS** uses AXTitle, then AXDescription, then AXValue (for text elements).
+- **Linux** uses Accessible.Name, then Description. For `StaticText` with no name, the first portion of the value is used.
+- **Windows** uses the CurrentName property.
 
 ### Checked state
 
 The tri-state checked value (`Off` / `On` / `Mixed`) is derived differently:
 
-- **macOS:** Parses the `AXValue` attribute — `"0"` = Off, `"1"` = On, `"2"` = Mixed.
-- **Linux:** Uses AT-SPI state bits — `Checked` (0x10) and `Mixed` (0x2000).
-- **Windows:** Reads `TogglePattern.CurrentToggleState` — 0 = Off, 1 = On, 2 = Indeterminate.
+- **macOS** parses the `AXValue` attribute, where `"0"` = Off, `"1"` = On, `"2"` = Mixed.
+- **Linux** uses the AT-SPI state bits `Checked` (0x10) and `Mixed` (0x2000).
+- **Windows** reads `TogglePattern.CurrentToggleState`, where 0 = Off, 1 = On, 2 = Indeterminate.
 
 ### Selected state
 
 Per-item selection (`selected` on rows, cells, list items) is read differently:
 
-- **macOS:** The per-element `AXSelected` attribute when present. Some bridges — notably Qt's — implement no per-element `AXSelected` and expose selection only through the container's `AXSelectedChildren`; for `table_cell` / `table_row` / `list_item` elements whose `AXSelected` attribute is absent, xa11y resolves `selected` by membership in the nearest ancestor's `AXSelectedChildren` (at most two hops: cell → row → table). Derived values appear in `states.selected` only — `raw` never gains a synthetic `AXSelected` key.
-- **Linux:** The AT-SPI `Selected` state bit.
-- **Windows:** `SelectionItemPattern.CurrentIsSelected`.
+- **macOS** uses the per-element `AXSelected` attribute when present. Some bridges (Qt's among them) provide no per-element `AXSelected` and expose selection only through the container's `AXSelectedChildren`. For `table_cell` / `table_row` / `list_item` elements whose `AXSelected` attribute is absent, xa11y resolves `selected` by membership in the nearest ancestor's `AXSelectedChildren` (at most two hops: cell → row → table). Derived values appear in `states.selected` alone, and `raw` never gains a synthetic `AXSelected` key.
+- **Linux** uses the AT-SPI `Selected` state bit.
+- **Windows** uses `SelectionItemPattern.CurrentIsSelected`.
 
 ### Table headers
 
-Header exposure varies by toolkit as well as platform. Windows surfaces header cells as `HeaderItem` elements and per-cell header relationships via the `TableItem` pattern; AT-SPI exposes `column header` / `row header` roles; AppKit tables expose a header group whose sort buttons carry the column titles. One known toolkit gap: **Qt tables on macOS expose no header objects at all** — Qt's Cocoa bridge synthesizes `AXRow`/`AXColumn` children only and implements no `AXHeader` attribute, so column titles are absent from the AX tree and xa11y cannot surface them. This is an upstream Qt limitation; use the platform-consistent `table table_cell` selectors for data, and avoid depending on header names for Qt apps on macOS.
+Header exposure varies by toolkit as well as platform. Windows surfaces header cells as `HeaderItem` elements and per-cell header relationships via the `TableItem` pattern. AT-SPI exposes `column header` / `row header` roles. AppKit tables expose a header group whose sort buttons carry the column titles. One known toolkit gap: **Qt tables on macOS expose no header objects at all**. Qt's Cocoa bridge synthesizes `AXRow`/`AXColumn` children only and provides no `AXHeader` attribute, so column titles are absent from the AX tree and xa11y cannot surface them. This is an upstream Qt limitation. Use the platform-consistent `table table_cell` selectors for data, and avoid depending on header names for Qt apps on macOS.
 
 ### Linux: X11 vs Wayland
 
-xa11y supports both X11 and Wayland Linux sessions. Backends are selected at runtime — there is no compile-time feature flag.
+xa11y supports both X11 and Wayland Linux sessions. Backends are selected at runtime, with no compile-time feature flag.
 
 | Capability | X11 | Wayland |
 | --- | --- | --- |
-| Accessibility (AT-SPI2) | D-Bus — no display-server dependency | D-Bus — no display-server dependency |
+| Accessibility (AT-SPI2) | D-Bus, no display-server dependency | D-Bus, no display-server dependency |
 | Input simulation | `XTest` extension (no setup) | `/dev/uinput` virtual evdev device (requires `input` group) |
 | Screen capture | `GetImage` on the root window | PNG URI from `org.freedesktop.portal.Screenshot` |
 
@@ -149,9 +149,9 @@ The selection rule:
 
 #### Why uinput instead of libei + portal RemoteDesktop?
 
-`org.freedesktop.portal.RemoteDesktop` (libei) is the architecturally "correct" Wayland input-sim path and the future of structured input injection on Linux, but today it covers a strict subset of the ecosystem: only `xdg-desktop-portal-gnome` and `xdg-desktop-portal-kde` implement it, and neither has a usable headless mode without a session manager (GDM / SDDM). uinput goes through the kernel and is compositor-agnostic — it works on every Wayland desktop (GNOME, KDE Plasma, sway, Hyprland, Cosmic, weston) and on headless Linux servers, with the same code path. It is the same mechanism `xdotool --using-uinput`, `ydotool`, `wtype`, Steam Input, and Wine all use.
+`org.freedesktop.portal.RemoteDesktop` (libei) is the architecturally "correct" Wayland input-sim path and the future of structured input injection on Linux, but today it covers a strict subset of the ecosystem: only `xdg-desktop-portal-gnome` and `xdg-desktop-portal-kde` support it, and neither has a usable headless mode without a session manager (GDM / SDDM). uinput goes through the kernel and is compositor-agnostic, so it works on every Wayland desktop (GNOME, KDE Plasma, sway, Hyprland, Cosmic, weston) and on headless Linux servers, with the same code path. It is the same mechanism `xdotool --using-uinput`, `ydotool`, `wtype`, Steam Input, and Wine all use.
 
-The trade-off is that uinput requires the user to be in the `input` group, which grants global input read/write — comparable to macOS Input Monitoring. The portal model is more granular (per-app consent) but isn't broadly available yet. xa11y may add a libei backend later as an opt-in upgrade once the portal landscape stabilises.
+The trade-off is that uinput requires the user to be in the `input` group, which grants global input read/write, comparable to macOS Input Monitoring. The portal model is finer-grained (per-app consent) but isn't broadly available yet. xa11y may add a libei backend later as an opt-in upgrade once the portal landscape stabilises.
 
 #### Wayland screenshot portal consent
 
@@ -161,31 +161,31 @@ The Screenshot portal usually auto-approves for non-interactive callers (`intera
 
 `Element.bounds` and input `Point`s are logical (device-independent) coordinates, matching the cross-platform contract, and `Screenshot.scale` reports the physical-to-logical ratio. The scale is detected best-effort and is exact where it can be read reliably:
 
-- **Pure X11, integer scaling** — read from `Xft.dpi` in the X `RESOURCE_MANAGER` (the same signal GTK/Qt use). AT-SPI extents and `XTest` are physical, so bounds are divided and input points multiplied by it.
-- **Single-output Wayland, integer or fractional** — the exact ratio `physical_mode / logical_size` from `xdg-output` (e.g. `1920 / 1280 = 1.5`), not the rounded `wl_output.scale`.
+- **Pure X11, integer scaling.** Read from `Xft.dpi` in the X `RESOURCE_MANAGER` (the same signal GTK/Qt use). AT-SPI extents and `XTest` are physical, so bounds are divided and input points multiplied by it.
+- **Single-output Wayland, integer or fractional.** The exact ratio `physical_mode / logical_size` from `xdg-output` (e.g. `1920 / 1280 = 1.5`), rather than the rounded `wl_output.scale`.
 
-Every other configuration fails closed to `1.0` — never wrong data. There, bounds stay physical and the scale is not upscaled, but capture and input round-trips remain correct because bounds and pixels stay in the same space:
+Every other configuration fails closed to `1.0`, so the data is never wrong. There, bounds stay physical and the scale is not upscaled, but capture and input round-trips remain correct because bounds and pixels stay in the same space:
 
-- **Fractional X11** — GTK's X11 window scale is integer-only, so a fractional `Xft.dpi` scales fonts, not the coordinate space.
-- **Multi-monitor mixed-DPI Wayland** — a single scalar can't represent per-monitor scales, so it falls back to the largest integer `wl_output.scale` (the Windows backend has the same limitation).
-- **XWayland** (both `DISPLAY` and `WAYLAND_DISPLAY` set) — capture runs through the X11 backend, so the reported scale follows the X11 source and stays `1.0`, consistent with that backend.
+- **Fractional X11.** GTK's X11 window scale is integer-only, so a fractional `Xft.dpi` scales fonts, not the coordinate space.
+- **Multi-monitor mixed-DPI Wayland.** A single scalar can't represent per-monitor scales, so it falls back to the largest integer `wl_output.scale` (the Windows backend has the same limitation).
+- **XWayland** (both `DISPLAY` and `WAYLAND_DISPLAY` set) runs capture through the X11 backend, so the reported scale follows the X11 source and stays `1.0`, consistent with that backend.
 
 `Point` arguments to input simulation, after the logical→physical conversion, are mapped onto the uinput virtual coordinate range. Override the assumed screen size (default 1920×1080) with `XA11Y_SCREEN_WIDTH` / `XA11Y_SCREEN_HEIGHT` env vars if your setup differs.
 
 ### GTK press fallback (Linux)
 
-GTK 4 menu-button widgets (`GtkMenuButton`, `AdwMenuButton`, `AdwSplitButton`) present as an outer `push button` accessible that advertises `NActions = 0` wrapping an inner `toggle button` that carries the real `click` action. Calling `press()` on the outer would normally raise `ActionNotSupported`. When the owning application identifies itself as GTK via `Application.ToolkitName == "GTK"`, xa11y-linux instead walks a bounded slice of the outer's subtree (BFS, depth 3, actionable roles only, name must match) and invokes the single actionable descendant it finds. The fallback is strictly scoped: it only runs inside GTK apps, only when the widget's own Action interface is empty, and only when exactly one candidate matches — ambiguous subtrees still surface the original error.
+GTK 4 menu-button widgets (`GtkMenuButton`, `AdwMenuButton`, `AdwSplitButton`) present as an outer `push button` accessible that advertises `NActions = 0` wrapping an inner `toggle button` that carries the real `click` action. Calling `press()` on the outer would normally raise `ActionNotSupported`. When the owning application identifies itself as GTK via `Application.ToolkitName == "GTK"`, xa11y-linux instead walks a bounded slice of the outer's subtree (BFS, depth 3, restricted to roles that carry a click action, name must match) and invokes the single matching descendant it finds. Scoping is strict. It only runs inside GTK apps, only when the widget's own Action interface is empty, and only when exactly one candidate matches. Ambiguous subtrees still surface the original error.
 
 ### WebKitGTK tables
 
 Two WebKitGTK behaviors affect `<table>` content (verified against WebKitGTK 2.52; both are engine behaviors, not xa11y ones):
 
-- **`<th>` cells can destabilize the whole page's tree.** With a window manager present, a table containing `<th>` header cells can send WebKit's accessibility tree into continuous invalidation churn — every content accessible goes defunct moments after being exposed, and the page effectively vanishes from AT-SPI. If a WebKitGTK-based app's tree keeps coming back empty or `unknown`, check for this (xa11y marks dead objects with `raw["atspi_defunct"]`).
-- **Layout-table heuristic.** A `<table>` without headers or a `<caption>` is judged decorative and dropped from the accessibility tree entirely. Cell text is exposed through the AT-SPI Text interface (surfaced as the cell's `value`), not as the accessible name — use `table_cell[value*="..."]` selectors for WebKitGTK content.
+- **`<th>` cells can destabilize the whole page's tree.** With a window manager present, a table containing `<th>` header cells can send WebKit's accessibility tree into continuous invalidation churn. Every content accessible goes defunct moments after being exposed, and the page effectively vanishes from AT-SPI. If a WebKitGTK-based app's tree keeps coming back empty or `unknown`, check for this (xa11y marks dead objects with `raw["atspi_defunct"]`).
+- **Layout-table heuristic.** A `<table>` without headers or a `<caption>` is judged decorative and dropped from the accessibility tree entirely. Cell text is exposed through the AT-SPI Text interface (surfaced as the cell's `value`) rather than as the accessible name, so use `table_cell[value*="..."]` selectors for WebKitGTK content.
 
 ### Linux Electron and Chromium apps
 
-On Linux, Electron and Chromium-based apps ship with their AT-SPI2 bridge disabled by default for performance. xa11y will connect to the app but its tree will contain only the top-level window — `App.by_name("…").locator("button").count()` returns 0 even though buttons are visible on screen.
+On Linux, Electron and Chromium-based apps have their AT-SPI2 bridge disabled by default for performance. xa11y will connect to the app but its tree will contain only the top-level window, so `App.by_name("…").locator("button").count()` returns 0 even though buttons are visible on screen.
 
 To expose the full tree, launch the app with `--force-renderer-accessibility`:
 
@@ -208,7 +208,7 @@ Representative node counts on Ubuntu 24.04 + GNOME 46 (Wayland):
 | Cursor    | 1            | 116       |
 | Chrome    | 1            | 210       |
 
-Native GTK apps (Nautilus, gnome-terminal, GNOME Calculator, gnome-text-editor) don't need the flag — their AT-SPI2 bridge is enabled by default.
+Native GTK apps (Nautilus, gnome-terminal, GNOME Calculator, gnome-text-editor) don't need the flag, because their AT-SPI2 bridge is enabled by default.
 
 Firefox exposes its tree when launched with `MOZ_ACCESSIBILITY_ATK2=1` set in the environment.
 

--- a/docs/site/src/content/docs/guides/quick-start.mdx
+++ b/docs/site/src/content/docs/guides/quick-start.mdx
@@ -32,22 +32,22 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## Platform setup
 
-**macOS** — Two permissions are required:
+**macOS** needs two permissions:
 
-1. **Accessibility** — System Settings → Privacy & Security → Accessibility. Grant permission to your terminal (or IDE).
-2. **Screen & System Audio Recording** (macOS 26+) — System Settings → Privacy & Security → Screen & System Audio Recording. Grant permission to your terminal. Without this, the accessibility API only exposes menu bars — window content (buttons, text fields, etc.) is invisible.
+1. **Accessibility**, under System Settings → Privacy & Security → Accessibility. Grant permission to your terminal (or IDE).
+2. **Screen & System Audio Recording** (macOS 26+), under System Settings → Privacy & Security → Screen & System Audio Recording. Grant permission to your terminal. Without it, the accessibility API exposes menu bars alone. Window content such as buttons and text fields stays invisible.
 
 After changing permissions, restart your terminal for them to take effect. `App::by_name()` (Rust) or `xa11y.App.by_name()` (Python) will return a `PermissionDenied` error with setup instructions if either permission is missing.
 
-**Linux** — Ensure AT-SPI2 is running (default on GNOME and most desktop environments). No special permissions needed. Electron and Chromium-based apps (VS Code, Cursor, Chrome) require an additional launch flag to expose their accessibility tree — see [Platform Details](/guides/platform-details/#linux-electron-and-chromium-apps).
+**Linux** needs AT-SPI2 running (the default on GNOME and most desktop environments), and nothing else to grant. Electron and Chromium-based apps (VS Code, Cursor, Chrome) require an additional launch flag to expose their accessibility tree. See [Platform Details](/guides/platform-details/#linux-electron-and-chromium-apps).
 
-**Windows** — No special permissions needed.
+**Windows** works as installed.
 
 ## Discover the tree first
 
 Before writing selectors, dump the app's accessibility tree so you know the exact roles and names to target. Accessibility labels are often different from what's painted on screen, so don't guess.
 
-The fastest way is the CLI — it dumps the whole app in one command and works the same regardless of language:
+The fastest way is the CLI, which dumps the whole app in one command and works the same regardless of language:
 
 ```bash
 xa11y apps                      # list running apps with PIDs
@@ -242,13 +242,13 @@ From code, `dump()` and `tree()` are available on `App`, `Locator`, and `Element
 | `group > button`                           | Buttons that are direct children of a group |
 | `window button[name='OK']`                 | Button named "OK" anywhere inside a window |
 | `button:nth(2)`                            | The 2nd button match             |
-| `button[name='All Clear'], button[name='Clear']` | Either button — see *Selector groups* below |
+| `button[name='All Clear'], button[name='Clear']` | Either button (see *Selector groups* below) |
 
 ### Selector groups (alternation)
 
 A top-level comma separates *alternation clauses*: the result is the union
 of each clause's matches, deduplicated by element identity and returned in
-document order — the same semantics CSS uses for selector lists. This is
+document order, the same semantics CSS uses for selector lists. This is
 useful when the label of an element changes with state and you want one
 locator that handles every variant:
 
@@ -273,6 +273,6 @@ Commas inside quoted attribute values (`[name='a,b']`) are not separators.
 
 ## Next steps
 
-- [Overview](/guides/overview/) — concepts, architecture, and how xa11y compares to other tools
-- [Rust API Reference](https://docs.rs/xa11y/) — full Rust API documentation on docs.rs
-- [Python API Reference](/api/python/) — full Python API documentation
+- [Overview](/guides/overview/) covers concepts, architecture, and how xa11y compares to other tools
+- [Rust API Reference](https://docs.rs/xa11y/) is the full Rust API documentation on docs.rs
+- [Python API Reference](/api/python/) is the full Python API documentation

--- a/docs/site/src/content/docs/guides/screenshots.mdx
+++ b/docs/site/src/content/docs/guides/screenshots.mdx
@@ -1,19 +1,19 @@
 ---
 title: Screenshots
-description: Capture the screen, a region, or the pixels under an accessibility element.
+description: Capture the screen, a region, or the pixels behind any accessibility element.
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 xa11y can capture pixel-level snapshots of the screen alongside its accessibility APIs. This is useful for attaching screenshots to test failures, feeding vision-language models with the same frame the agent is reasoning about, or visually diffing a region around a specific control.
 
-Three entry points:
+The entry points are:
 
-- **Full screen** — capture the entire primary display.
-- **Region** — capture an explicit rectangle in logical screen coordinates.
-- **Element** — capture the pixels under an accessibility element's current bounds.
+- **Full screen** captures the entire primary display.
+- **Region** captures an explicit rectangle in logical screen coordinates.
+- **Element** captures the pixels under an accessibility element's current bounds.
 
-Screenshots are decoupled from the accessibility and input layers. The target window is **not** raised or activated before capture — whatever pixels are at the requested coordinates are returned, including any occluding windows. Bring the target to the foreground yourself if you need a clean capture.
+Screenshots are decoupled from the accessibility and input layers. Capture never raises or activates the target window. Whatever pixels sit at the requested coordinates are returned, including any occluding windows. Bring the target to the foreground yourself if you need a clean capture.
 
 ## Permissions
 
@@ -96,7 +96,7 @@ Screenshots are decoupled from the accessibility and input layers. The target wi
 
 ## Working with the pixel buffer
 
-A `Screenshot` carries raw RGBA8 pixels along with dimensions and a scale factor. `width` and `height` are **physical** (device) pixels — the same resolution the compositor renders at — so on HiDPI displays they exceed the logical bounds passed in. `scale` records the physical-to-logical ratio (1.0 on standard displays, 2.0 on typical Retina, 1.5 / 1.75 / 2.0 on common Windows and Linux HiDPI configurations). `pixels.len()` equals `width * height * 4`.
+A `Screenshot` carries raw RGBA8 pixels along with dimensions and a scale factor. `width` and `height` are **physical** (device) pixels, the same resolution the compositor renders at, so on HiDPI displays they exceed the logical bounds passed in. `scale` records the physical-to-logical ratio (1.0 on standard displays, 2.0 on typical Retina, 1.5 / 1.75 / 2.0 on common Windows and Linux HiDPI configurations). `pixels.len()` equals `width * height * 4`.
 
 <Tabs syncKey="lang">
   <TabItem label="Rust">

--- a/docs/site/src/content/docs/guides/testing.mdx
+++ b/docs/site/src/content/docs/guides/testing.mdx
@@ -1,13 +1,13 @@
 ---
 title: How xa11y Is Tested
-description: The xa11y test suite — 700+ automated tests run against real GUI toolkits on Linux, macOS, and Windows, plus fuzzing and a set of enforced correctness tenets.
+description: The xa11y test suite, with 700+ automated tests run against real GUI toolkits on Linux, macOS, and Windows, plus fuzzing and a set of enforced correctness tenets.
 ---
 
 xa11y drives the *real* accessibility tree of a running application. There is
 no way to mock that meaningfully, so the library is verified the same way it is
-used: by launching real GUI apps built on real toolkits and asserting against
-the trees their platform accessibility APIs actually expose. This page is a map
-of that test suite — what runs, against what, and where.
+used. Real GUI apps built on real toolkits are launched, and the tests assert
+against the trees their platform accessibility APIs actually expose. This page
+maps that test suite: what runs, and against what.
 
 If you are deciding whether to depend on xa11y, this is the page that answers
 "how do I know it works?"
@@ -21,21 +21,21 @@ JavaScript, and the CLI. Roughly:
 | --- | --- | --- | --- |
 | Rust unit | ~60 | `xa11y/tests/unit_test.rs` | Selector engine, locators, roles, state sets, error mapping, serialization (against an in-memory mock provider) |
 | Rust integration | ~150 | `xa11y/tests/integ/` | Live tree reads, action dispatch, events, screenshots against a running app |
-| Python binding unit | ~240 | `xa11y-python/tests/` | The PyO3 surface — types, actions, exceptions, GIL release, subscriptions |
+| Python binding unit | ~240 | `xa11y-python/tests/` | The PyO3 surface: types, actions, exceptions, GIL release, subscriptions |
 | Python integration | ~100 | `tests/suites/python/` | Per-app compat, actions, events, errors, input simulation, screenshots |
 | CLI integration | ~30 | `tests/suites/cli/` | The `xa11y` CLI end-to-end against running apps |
 | JavaScript unit | ~115 | `xa11y-js/__test__/unit/` | The napi-rs binding surface |
 | JavaScript integration | ~40 | `tests/suites/js/` | Per-app compat, actions, input simulation, screenshots |
 
-Counts are approximate and grow over time; the figures above are meant to
-convey shape, not a frozen total. The authoritative coverage index — which app
-is tested in which language for which feature — lives in
+Counts are approximate and grow over time, so read the figures above as a rough
+shape. The authoritative coverage index, recording which app is tested in which
+language for which feature, lives in
 [`tests/matrix.yaml`](https://github.com/xa11y/xa11y/blob/main/tests/matrix.yaml).
 
 ## Tested against real toolkits, not stubs
 
 The integration suites run against a fleet of small test apps, each built on a
-genuinely different GUI toolkit, and each launched as a real process whose
+different GUI toolkit, and each launched as a real process whose
 accessibility tree xa11y reads through the platform API. This is the part that
 matters: a passing test means xa11y handled a real AT-SPI2, AXUIElement, or
 UI Automation tree, not a fixture shaped to match the code.
@@ -44,31 +44,33 @@ UI Automation tree, not a fixture shaped to match the code.
 | --- | --- | :---: | :---: | :---: |
 | `accesskit` | Rust + winit (AccessKit) | ✓ | ✓ | ✓ |
 | `qt` | PySide6 (Qt) | ✓ | ✓ | ✓ |
-| `gtk` | GTK4 (PyGObject) | ✓ | — | — |
-| `cocoa` | Swift / AppKit | — | ✓ | — |
+| `gtk` | GTK4 (PyGObject) | ✓ | ○ | ○ |
+| `cocoa` | Swift / AppKit | ○ | ✓ | ○ |
 | `tauri` | Rust + WebView | ✓ | ✓ | ✓ |
-| `electron` | Chromium / Node | ✓ | — | — |
+| `electron` | Chromium / Node | ✓ | ○ | ○ |
 | `egui` | Rust immediate-mode (eframe) | ✓ | ✓ | ✓ |
-| `winforms` | .NET Windows Forms | — | — | ✓ |
-| `wpf` | .NET WPF | — | — | ✓ |
+| `winforms` | .NET Windows Forms | ○ | ○ | ✓ |
+| `wpf` | .NET WPF | ○ | ○ | ✓ |
+
+A hollow circle means the combination is not run in CI.
 
 Across those rows, xa11y is exercised against all three platform accessibility
-backends — **AT-SPI2** on Linux, **AXUIElement** on macOS, and **UI
-Automation** on Windows — and against toolkits that report their trees in
-meaningfully different ways (retained-mode native widgets, immediate-mode
-GUIs, two distinct web renderers, and — with Windows Forms and WPF — two
-first-party Microsoft UIA providers rather than third-party bridges). The
+backends (**AT-SPI2** on Linux, **AXUIElement** on macOS, **UI Automation** on
+Windows) and against toolkits that report their trees in meaningfully different
+ways: retained-mode native widgets, immediate-mode GUIs, two distinct web
+renderers, and two first-party Microsoft UIA providers rather than third-party
+bridges, by way of Windows Forms and WPF. The
 toolkit-specific quirks this surfaces are documented in
 [Accessibility Quirks](/guides/accessibility-quirks/).
 
 ## One suite, every binding
 
 The per-app integration tests aren't duplicated per language. Python, JavaScript,
-and the CLI run the *same* feature suites — compat, actions, events, errors,
-input simulation, screenshots — against the *same* running app, driven by a
-shared harness (`tests/harness/launch.py`). That means binding parity isn't
-asserted by hand; it's proven by every binding passing identical scenarios
-against an identical target.
+and the CLI run the *same* feature suites (compat, actions, events, errors,
+input simulation, screenshots) against the *same* running app, driven by a
+shared harness (`tests/harness/launch.py`). Binding parity is proven by every
+binding passing identical scenarios against an identical target, rather than
+asserted by hand.
 
 ## The CI matrix
 
@@ -94,7 +96,7 @@ the provider interface against a running app with randomized action sequences.
 ## Correctness is a stated discipline
 
 The breadth above is backed by a small set of firm engineering tenets that
-every new piece of provider or binding code is held to — **no silent
+every new piece of provider or binding code is held to: **no silent
 fallbacks**, **action fidelity** (an advertised action invokes the real
 platform action, never a substitute), **errors that carry their own
 diagnosis**, and **blocking calls that release the host runtime's lock**. These
@@ -107,9 +109,9 @@ identically.
 
 The test-app fleet is deliberately chosen so that each app covers an
 accessibility surface the others don't. If you work with a common UI framework
-that's **meaningfully different** from everything in the table above — a
-different accessibility implementation, a renderer family not yet represented,
-a platform combination we don't exercise — that's a coverage gap worth closing.
+that's **meaningfully different** from everything in the table above, that's a
+coverage gap worth closing. A different accessibility backend, a renderer family
+not yet represented, or a platform combination we don't exercise all qualify.
 Please [open an issue](https://github.com/xa11y/xa11y/issues/new) describing the
-framework and how its accessibility tree differs; new test-app coverage is very
+framework and how its accessibility tree differs. New test-app coverage is very
 welcome.

--- a/docs/site/src/content/docs/guides/testing.mdx
+++ b/docs/site/src/content/docs/guides/testing.mdx
@@ -42,17 +42,25 @@ UI Automation tree, not a fixture shaped to match the code.
 
 | Test app | Toolkit | Linux | macOS | Windows |
 | --- | --- | :---: | :---: | :---: |
-| `accesskit` | Rust + winit (AccessKit) | ✓ | ✓ | ✓ |
+| `accesskit` | Rust + winit (AccessKit) | ✓ | ✓&nbsp;† | ✓ |
 | `qt` | PySide6 (Qt) | ✓ | ✓ | ✓ |
 | `gtk` | GTK4 (PyGObject) | ✓ | ○ | ○ |
 | `cocoa` | Swift / AppKit | ○ | ✓ | ○ |
-| `tauri` | Rust + WebView | ✓ | ✓ | ✓ |
+| `tauri` | Rust + WebView | ✓ | ✓ | ○ |
 | `electron` | Chromium / Node | ✓ | ○ | ○ |
 | `egui` | Rust immediate-mode (eframe) | ✓ | ✓ | ✓ |
 | `winforms` | .NET Windows Forms | ○ | ○ | ✓ |
 | `wpf` | .NET WPF | ○ | ○ | ✓ |
 
-A hollow circle means the combination is not run in CI.
+A hollow circle means the combination is not run in CI. † AccessKit on macOS
+runs locally through `./scripts/run_integ_tests_macos.sh` rather than in CI,
+because the Rust integ suite needs an Accessibility (TCC) grant that hosted
+macOS runners cannot hold against a cargo-hashed binary path.
+
+Tauri has no Windows cell, and since it is the only app carrying the
+input-simulation suite, the Windows `SendInput` path has no end-to-end
+coverage. That gap is declared as `windows_input_sim` in
+[`tests/matrix.yaml`](https://github.com/xa11y/xa11y/blob/main/tests/matrix.yaml).
 
 Across those rows, xa11y is exercised against all three platform accessibility
 backends (**AT-SPI2** on Linux, **AXUIElement** on macOS, **UI Automation** on

--- a/docs/site/src/content/docs/index.mdx
+++ b/docs/site/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ template: splash
 hero:
   tagline: A unified API for accessibility trees across macOS, Windows, and Linux. Test desktop apps, power AI agents, or build assistive tools.
   image:
-    html: '<img src="/hero.svg" alt="Animated demo showing xa11y querying a Slack accessibility tree, pressing buttons, typing text, and running assertions" width="600" height="520" />'
+    html: '<img src="/hero.svg" alt="Animated demo of xa11y querying a Slack accessibility tree, then pressing buttons and typing text, then running assertions" width="600" height="520" />'
   actions:
     - text: Get Started
       link: /guides/quick-start/
@@ -20,11 +20,11 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 
 <CardGrid stagger>
   <Card title="Read the tree" icon="open-book">
-    Lazy, live navigation of the accessibility tree. CSS-like selectors
-    — `button[name='Submit']`, `textfield[name^='Search']`, `group > button`.
+    Lazy, live navigation of the accessibility tree. CSS-like selectors:
+    `button[name='Submit']`, `textfield[name^='Search']`, `group > button`.
   </Card>
   <Card title="Drive the UI" icon="rocket">
-    Invoke accessibility actions directly — `press`, `toggle`, `type_text`,
+    Invoke accessibility actions directly: `press`, `toggle`, `type_text`,
     `set_value`. Plus a separate `InputSim` for drag-and-drop, scroll wheels,
     and global shortcuts.
   </Card>
@@ -37,8 +37,8 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     (AT-SPI2). Write once, query anywhere.
   </Card>
   <Card title="Proven, not vibes" icon="approve-check">
-    700+ automated tests run against real GUI toolkits — Qt, GTK, Cocoa,
-    Tauri, Electron, egui, Windows Forms, WPF — on Linux, macOS, and Windows. See
+    700+ automated tests run against real GUI toolkits (Qt, GTK, Cocoa,
+    Tauri, Electron, egui, Windows Forms, WPF) on Linux, macOS, and Windows. See
     [How xa11y Is Tested](/guides/testing/).
   </Card>
 </CardGrid>

--- a/tests/matrix.yaml
+++ b/tests/matrix.yaml
@@ -24,11 +24,14 @@ apps:
     platforms: [macos]
 
   tauri:
-    platforms: [linux, macos, windows]
+    platforms: [linux, macos]
     notes: >
       Primary vehicle for input_sim and screenshot coverage (one-per-platform strategy).
       Uses a dedicated event-log page that captures synthesised pointer and keyboard
       events, enabling end-to-end assertions rather than smoke tests.
+      No windows-latest cell: WebView2 has never been wired into the integ
+      matrix. Since tauri is the only app carrying input_sim, that leaves
+      Windows input simulation uncovered — tracked as windows_input_sim below.
 
   electron:
     platforms: [linux]
@@ -49,8 +52,8 @@ apps:
     platforms: [windows]
     notes: >
       The only Microsoft UI framework in the matrix. Every other Windows cell
-      reaches UIA through a third-party bridge (Qt, AccessKit, Chromium,
-      WebView2), so the WinForms provider — and in particular the
+      reaches UIA through a third-party bridge (Qt via qt, AccessKit via
+      egui), so the WinForms provider — and in particular the
       DataGridView, whose cells are ControlType.DataItem + the TableItem
       pattern — is what exercises the row-vs-cell disambiguation in
       xa11y-windows against a framework grid. Built with `dotnet build`
@@ -92,7 +95,10 @@ features:
     per_app: false
     tested_on: [tauri, electron]
     notes: >
-      Tests platform input APIs, not a11y compatibility. Covered once per platform.
+      Tests platform input APIs, not a11y compatibility. Covered once per
+      platform on Linux and macOS, and not at all on Windows: both vehicles
+      (tauri, electron) stop short of a windows-latest cell, so the SendInput
+      path has no integration coverage. See the windows_input_sim gap.
       Python: Tauri app (end-to-end with event log). JS: Tauri + Electron apps
       (smoke tests; see the app gate in tests/suites/js/03_input_sim.test.js).
 
@@ -101,7 +107,9 @@ features:
     per_app: false
     tested_on: [tauri, electron]
     notes: >
-      Tests platform screenshot APIs. Covered once per platform.
+      Tests platform screenshot APIs. Covered once per platform. On Windows
+      that cover comes from rust_core alone, since neither per-app vehicle
+      (tauri, electron) has a windows-latest cell.
       Python: Tauri app. JS: Tauri + Electron apps. Rust: AccessKit app
       (rust_core).
 
@@ -181,6 +189,22 @@ gaps:
     affects:
       apps: [accesskit]
       language: python
+
+  - id: windows_input_sim
+    description: >
+      Input simulation has no integration coverage on Windows. input_sim is
+      carried by the tauri and electron apps only, and neither has a
+      windows-latest cell in the integ matrix (tauri: linux + macos;
+      electron: linux). The Linux Wayland uinput e2e job covers the Linux
+      backend at wire level and the macOS CGEvent path is covered through
+      tauri, so xa11y-windows' SendInput path is the one input backend no
+      test drives end-to-end. Closing it means adding
+      `- { os: windows-latest, app: tauri }` to the integ matrix.
+    severity: medium
+    workaround: "Unit tests only; no end-to-end assertion of the Windows SendInput path"
+    affects:
+      apps: [tauri]
+      features: [input_sim]
 
   - id: js_input_sim_per_app
     description: >

--- a/xa11y-python/README.md
+++ b/xa11y-python/README.md
@@ -37,15 +37,15 @@ pip install xa11y
 
 Requires Python 3.9+. Pre-built wheels available for Linux, macOS, and Windows.
 
-> **macOS:** Grant your terminal **two** permissions in **System Settings > Privacy & Security**:
-> 1. **Accessibility** — required for all accessibility API access.
-> 2. **Screen & System Audio Recording** (macOS 26+) — required to read window content. Without this, only menu bars are visible.
+> On **macOS**, grant your terminal **two** permissions in **System Settings > Privacy & Security**:
+> 1. **Accessibility**, required for all accessibility API access.
+> 2. **Screen & System Audio Recording** (macOS 26+), required to read window content. Without it, only menu bars are visible.
 >
 > Restart your terminal after changing permissions.
 >
-> **Linux:** AT-SPI2 must be running (default on GNOME/most DEs). No special permissions needed.
+> On **Linux**, AT-SPI2 must be running (the default on GNOME and most desktop environments). Nothing else to grant.
 >
-> **Windows:** No special permissions needed.
+> **Windows** works as installed.
 
 ## Selector Syntax
 

--- a/xa11y/README.md
+++ b/xa11y/README.md
@@ -42,15 +42,15 @@ fn main() -> Result<()> {
 xa11y = "0.4"
 ```
 
-> **macOS:** Grant your terminal **two** permissions in **System Settings > Privacy & Security**:
-> 1. **Accessibility** — required for all accessibility API access.
-> 2. **Screen & System Audio Recording** (macOS 26+) — required to read window content. Without this, only menu bars are visible.
+> On **macOS**, grant your terminal **two** permissions in **System Settings > Privacy & Security**:
+> 1. **Accessibility**, required for all accessibility API access.
+> 2. **Screen & System Audio Recording** (macOS 26+), required to read window content. Without it, only menu bars are visible.
 >
 > Restart your terminal after changing permissions.
 >
-> **Linux:** AT-SPI2 must be running (default on GNOME/most DEs). No special permissions needed.
+> On **Linux**, AT-SPI2 must be running (the default on GNOME and most desktop environments). Nothing else to grant.
 >
-> **Windows:** No special permissions needed.
+> **Windows** works as installed.
 
 ## Selector Syntax
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -38,6 +38,7 @@ COMMANDS:
     test-matrix-check   Validate the tests/matrix.yaml coverage index
     test-harness        Unit-test the shared integ harness (tests/harness/)
     docs                Build documentation
+    lint-docs           Lint README + docs prose with Vale (requires the `vale` binary)
     coverage            Generate code coverage report
     fuzz [ARGS..]       Run provider fuzzer (pass-through args)
     sync-readmes [--check]  Generate crates.io/PyPI READMEs from root README.md
@@ -77,6 +78,7 @@ fn main() -> ExitCode {
         "test-matrix-check" => do_test_matrix_check(),
         "test-harness" => do_test_harness(),
         "docs" => do_docs(),
+        "lint-docs" => do_lint_docs(),
         "coverage" => do_coverage(),
         "fuzz" => do_fuzz(rest),
         "sync-readmes" => do_sync_readmes(rest),
@@ -522,6 +524,39 @@ fn do_test_harness() -> bool {
     heading("Integ harness self-tests");
     let root = project_root();
     run_in("python", &["-m", "pytest", "tests/harness", "-v"], &root)
+}
+
+/// Paths the prose linter covers: the root README and every hand-written
+/// page of the docs site. Generated API reference pages live under
+/// `docs/site/src/content/docs/api/` and are excluded by `.vale.ini`.
+const VALE_TARGETS: &[&str] = &["README.md", "docs/site/src/content/docs"];
+
+/// Lint README and docs prose with Vale (`.vale.ini` at the repo root).
+///
+/// Vale is a Go binary rather than a Cargo dependency, so this reports a
+/// missing install as a failure with instructions rather than skipping the
+/// check: a doc-lint that quietly passes when the linter is absent is worse
+/// than no check at all.
+fn do_lint_docs() -> bool {
+    heading("Lint docs prose (vale)");
+    let root = project_root();
+
+    if Command::new("vale").arg("--version").output().is_err() {
+        eprintln!("`vale` was not found on PATH.");
+        eprintln!("Install it from https://vale.sh/docs/install, then re-run.");
+        eprintln!("  macOS:  brew install vale");
+        eprintln!("  Linux:  download the release tarball for your arch");
+        return false;
+    }
+
+    // Downloads the pinned `ai-tells` package into .github/styles/. A no-op
+    // once the styles are present, so it is safe to run on every invocation.
+    if !run_in("vale", &["sync"], &root) {
+        eprintln!("`vale sync` failed: could not fetch the styles named in .vale.ini.");
+        return false;
+    }
+
+    run_in("vale", VALE_TARGETS, &root)
 }
 
 fn do_docs() -> bool {


### PR DESCRIPTION
Adds a Vale config at the repo root covering `README.md` and the
hand-written pages of the docs site, with two style sets:

- `Vale`, the built-in style that ships with the binary (spelling,
  repetition).
- `ai-tells` (github.com/tbhb/vale-ai-tells), which flags the prose
  patterns that read as machine-written: em-dash asides, three-item verb
  series, "not X but Y" contrasts, hedges, filler adverbs.

Both are pinned (the package release in `.vale.ini`, the Vale binary in
the workflow) so an upstream rule addition can't turn CI red without a
commit here.

Running it surfaced 250+ findings, all fixed in this change. The bulk
were em-dash asides rewritten as commas, parentheses, or separate
sentences; the rest were verb tricolons, semicolon splices, capitalised
words after colons, and filler vocabulary ("genuinely", "notable",
"actionable", "robust"). Two coverage tables used an em-dash as the
not-tested marker; those now use a hollow circle with a stated legend.

Spelling false positives are handled by a project vocabulary at
`.github/styles/config/vocabularies/xa11y/accept.txt` rather than by
rewording around the checker. The downloaded rule files are gitignored;
the config and the vocabulary are committed.

Two parser limitations needed explicit handling in `.vale.ini`, both
commented there: a fenced code block indented inside a JSX element is not
recognised as a fence, and YAML frontmatter is linted as prose (the keys
are dropped so `description` values still get checked).

Tooling:

- `cargo xtask lint-docs` runs the check locally. A missing `vale` binary
  is reported as a failure with install instructions rather than skipped,
  since a doc lint that passes when the linter is absent is worse than no
  check.
- A `Docs Lint` workflow runs it in CI, path-filtered to `README.md`, the
  docs content directory, `.vale.ini`, and the vocabulary.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012DRa2M37L6PAFZoD4ptvk8