### PR TITLE
feat(selector): support the `*` universal selector

### DIFF
--- a/docs/site/src/content/docs/reference/cli.mdx
+++ b/docs/site/src/content/docs/reference/cli.mdx
@@ -210,8 +210,7 @@ input-simulation and screenshot commands take neither flag.
 
 `xa11y find` and `xa11y action` take the same selector syntax as the library.
 See [Selectors](/reference/selectors/) for operators, combinators, and
-attributes. Note that the syntax has no `*` wildcard, so "any element with this
-state" is written as an attribute-only selector:
+attributes.
 
 ```bash
 xa11y find "[focusable='true']" --app Slack

--- a/docs/site/src/content/docs/reference/selectors.mdx
+++ b/docs/site/src/content/docs/reference/selectors.mdx
@@ -25,6 +25,8 @@ text_field[name^='Search']          # starts-with (case-insensitive)
 text_field[name*='email']           # contains (case-insensitive)
 button[name$='Cancel']              # ends-with (case-insensitive)
 [focusable='true']                  # attribute only, any role
+*                                   # universal selector, any element
+group > *                           # every direct child, whatever its role
 group > button                      # direct child combinator
 window button[name='OK']            # descendant (any depth)
 button:nth(2)                       # 2nd match (1-based)
@@ -59,9 +61,46 @@ role names containing a space (AT-SPI's `push button`) cannot be written this
 way, because a role token accepts only the characters `[A-Za-z0-9_]`.
 
 The role may be omitted entirely, in which case the selector matches any role:
-`[name='Submit']` matches an element with that name whatever its role. There is
-no `*` wildcard. Writing `*` is a syntax error, so use an attribute-only
-selector for "any role".
+`[name='Submit']` matches an element with that name whatever its role.
+
+## The universal selector
+
+`*` matches any element. It means the same thing as omitting the role, so
+`*[name='Submit']` and `[name='Submit']` are the same query. Write it where a
+role cannot simply be left out:
+
+| Selector | Matches |
+| --- | --- |
+| `*` | Every element in scope |
+| `dialog > *` | Every direct child of a dialog, whatever its role |
+| `window *` | Every descendant of a window |
+| `group > * > button` | Buttons exactly two levels below a group |
+
+The last row is the case with no other spelling: it skips exactly one
+generation without naming the role in between. For the two middle rows,
+[`children()` and `tree()`](/reference/locator/#navigation-and-snapshots)
+answer the same question imperatively when you already hold the parent
+element.
+
+`*` binds as a whole segment, so it cannot be combined with a role name.
+`*button`, `button*`, and `**` are all syntax errors.
+
+### Cost
+
+A selector scoped to an application walks that application's subtree. `*`
+retains every node of that walk instead of the few that match a role, so it
+materializes every element's attributes:
+
+- On Windows the walk already materializes every node in one batched
+  `FindAllBuildCache` call, so `*` costs nothing extra.
+- On macOS and Linux the walk fetches only the attributes a selector asks
+  about, so `*` shifts the cost from "probe every node, build the matches" to
+  "build every node."
+
+A bare `*` with no application scope repeats that across every running
+application. That is the same order of work as calling `App.dump()` on
+everything on the desktop. It is a reasonable thing to ask for when exploring,
+but prefer to scope the search or pass a limit in code that runs often.
 
 ## Attribute filters
 

--- a/xa11y-core/src/selector.rs
+++ b/xa11y-core/src/selector.rs
@@ -6,7 +6,7 @@
 //! selector      := simple_selector (combinator simple_selector)*
 //! combinator    := " "          // descendant (any depth)
 //!                | " > "       // direct child
-//! simple_selector := role_name? attr_filter* pseudo?
+//! simple_selector := (role_name | "*")? attr_filter* pseudo?
 //! role_name     := [a-z_]+     // snake_case role name
 //! attr_filter   := "[" attr_name op value "]"
 //! attr_name     := "name" | "value" | "description" | "role"
@@ -19,6 +19,17 @@
 //! A top-level comma separates an *alternation group*: the result is the
 //! union of each clause's matches, deduplicated by element identity and
 //! returned in document order. See [`SelectorGroup`].
+//!
+//! `*` is the universal selector and matches any element. It is equivalent to
+//! omitting the role, so `*[name="OK"]` and `[name="OK"]` are the same query;
+//! it exists for the positions where a role cannot simply be left out —
+//! `dialog > *` (any direct child), `window *` (any descendant), and
+//! `group > * > button` (skip exactly one generation).
+//!
+//! A bare `*` searched from the system root matches every element of every
+//! running application. That is a proportionate amount of work for what was
+//! asked, but it is not cheap: see the "Cost" section of the selector
+//! reference in the docs site.
 
 use std::collections::HashSet;
 
@@ -195,19 +206,34 @@ impl Selector {
         let mut filters = Vec::new();
         let mut nth = None;
 
-        // Try to parse role name. Normalized roles are snake_case (e.g., `button`).
-        // Platform roles may include uppercase (e.g., `AXButton`, `PUSH_BUTTON`).
-        let start = pos;
-        while pos < chars.len() && (chars[pos].is_ascii_alphanumeric() || chars[pos] == '_') {
+        // `*` is the universal selector: it imposes no role constraint, which
+        // is exactly `role: None`. It carries no field of its own — it only
+        // suppresses the "empty simple selector" guard below, so that a
+        // segment consisting of nothing but `*` is legal where a segment
+        // consisting of nothing at all is not.
+        //
+        // A role name and `*` are alternatives, never a sequence: consuming
+        // `*` skips the role parse entirely, so `*button` falls out of this
+        // function at the `*` and is rejected by the caller's combinator
+        // check rather than silently parsing as `button`.
+        let wildcard = chars.get(pos) == Some(&'*');
+        if wildcard {
             pos += 1;
-        }
-        if pos > start {
-            let role_str: String = chars[start..pos].iter().collect();
-            match Role::from_snake_case(&role_str) {
-                Some(r) => role = Some(RoleMatch::Normalized(r)),
-                None => {
-                    // Not a normalized role — treat as a platform role name.
-                    role = Some(RoleMatch::Platform(role_str));
+        } else {
+            // Try to parse role name. Normalized roles are snake_case (e.g., `button`).
+            // Platform roles may include uppercase (e.g., `AXButton`, `PUSH_BUTTON`).
+            let start = pos;
+            while pos < chars.len() && (chars[pos].is_ascii_alphanumeric() || chars[pos] == '_') {
+                pos += 1;
+            }
+            if pos > start {
+                let role_str: String = chars[start..pos].iter().collect();
+                match Role::from_snake_case(&role_str) {
+                    Some(r) => role = Some(RoleMatch::Normalized(r)),
+                    None => {
+                        // Not a normalized role — treat as a platform role name.
+                        role = Some(RoleMatch::Platform(role_str));
+                    }
                 }
             }
         }
@@ -261,7 +287,7 @@ impl Selector {
             }
         }
 
-        if role.is_none() && filters.is_empty() && nth.is_none() {
+        if !wildcard && role.is_none() && filters.is_empty() && nth.is_none() {
             return Err(Error::InvalidSelector {
                 selector: input.to_string(),
                 message: "empty simple selector".to_string(),
@@ -1138,28 +1164,26 @@ mod tests {
         assert_eq!(sel.segments[0].simple.filters[0].value, "addr");
     }
 
-    #[test]
-    fn nth_on_non_last_segment_filters_during_traversal() {
-        // Regression: `:nth(N)` on a non-last segment used to be treated as a
-        // pool limit on phase-1 (so up to N candidates were collected and
-        // *all* of their children expanded). The expected behaviour is that
-        // `:nth(N)` collapses the candidate set to just the N-th match
-        // before descending.
-        //
-        // Tree:
-        //   root (application)
-        //     ├── toolbar "A" → button "A1", button "A2"
-        //     └── toolbar "B" → button "B1", button "B2"
-        //
-        // `toolbar:nth(2) > button` must return only [B1, B2], not
-        // [A1, A2, B1, B2].
-        struct Row {
-            handle: u64,
-            role: Role,
-            name: &'static str,
-            parent: Option<u64>,
-        }
-        let tree: Vec<Row> = vec![
+    /// One row of [`fixture_tree`] — a flat parent-pointer encoding of a
+    /// small tree, which `fixture_children` turns into a `get_children_fn`.
+    struct Row {
+        handle: u64,
+        role: Role,
+        name: &'static str,
+        parent: Option<u64>,
+    }
+
+    /// A fixed two-level tree shared by the traversal tests:
+    ///
+    /// ```text
+    /// root (application)
+    ///   ├── toolbar "A" → button "A1", button "A2"
+    ///   └── toolbar "B" → button "B1", button "B2"
+    /// ```
+    ///
+    /// Document order is `root, A, A1, A2, B, B1, B2`.
+    fn fixture_tree() -> Vec<Row> {
+        vec![
             Row {
                 handle: 0,
                 role: Role::Application,
@@ -1202,35 +1226,63 @@ mod tests {
                 name: "B2",
                 parent: Some(2),
             },
-        ];
-        let make_data = |row: &Row| ElementData {
-            role: row.role,
-            name: Some(row.name.to_string()),
-            value: None,
-            description: None,
-            bounds: None,
-            actions: vec![],
-            states: crate::element::StateSet::default(),
-            numeric_value: None,
-            min_value: None,
-            max_value: None,
-            stable_id: None,
-            pid: Some(1),
-            raw: std::collections::HashMap::new(),
-            handle: row.handle,
-        };
-        let tree_ref = &tree;
-        let get_children = move |parent: Option<&ElementData>| -> Result<Vec<ElementData>> {
+        ]
+    }
+
+    /// Build a `get_children_fn` over a [`fixture_tree`], resolving children
+    /// by parent handle. Returned by reference so one fixture can serve
+    /// several `find_elements_in_tree` calls in a single test.
+    fn fixture_children(
+        tree: &[Row],
+    ) -> impl Fn(Option<&ElementData>) -> Result<Vec<ElementData>> + '_ {
+        fn make_data(row: &Row) -> ElementData {
+            ElementData {
+                role: row.role,
+                name: Some(row.name.to_string()),
+                value: None,
+                description: None,
+                bounds: None,
+                actions: vec![],
+                states: crate::element::StateSet::default(),
+                numeric_value: None,
+                min_value: None,
+                max_value: None,
+                stable_id: None,
+                pid: Some(1),
+                raw: std::collections::HashMap::new(),
+                handle: row.handle,
+            }
+        }
+        move |parent: Option<&ElementData>| -> Result<Vec<ElementData>> {
             let parent_handle = parent.map(|e| e.handle);
-            Ok(tree_ref
+            Ok(tree
                 .iter()
                 .filter(|row| row.parent == parent_handle)
                 .map(make_data)
                 .collect())
-        };
+        }
+    }
+
+    #[test]
+    fn nth_on_non_last_segment_filters_during_traversal() {
+        // Regression: `:nth(N)` on a non-last segment used to be treated as a
+        // pool limit on phase-1 (so up to N candidates were collected and
+        // *all* of their children expanded). The expected behaviour is that
+        // `:nth(N)` collapses the candidate set to just the N-th match
+        // before descending.
+        //
+        // Tree:
+        //   root (application)
+        //     ├── toolbar "A" → button "A1", button "A2"
+        //     └── toolbar "B" → button "B1", button "B2"
+        //
+        // `toolbar:nth(2) > button` must return only [B1, B2], not
+        // [A1, A2, B1, B2].
+        let tree = fixture_tree();
+        let get_children = fixture_children(&tree);
 
         let sel = Selector::parse("toolbar:nth(2) > button").unwrap();
-        let results = find_elements_in_tree(get_children, None, &sel, None, None).unwrap();
+        let results = find_elements_in_tree(&get_children, None, &sel, None, None).unwrap();
         let names: Vec<_> = results.iter().map(|e| e.name.clone().unwrap()).collect();
         assert_eq!(
             names,
@@ -1245,6 +1297,169 @@ mod tests {
         // parse as Ok but produce a Root-combinator segment in a non-first
         // position, causing an unreachable!() panic in find_elements_in_tree.
         assert!(Selector::parse("button:nth(1):nth(2)").is_err());
+    }
+
+    // ── universal selector (`*`) ────────────────────────────────────────────
+
+    #[test]
+    fn parse_bare_wildcard() {
+        let sel = Selector::parse("*").unwrap();
+        assert_eq!(sel.segments.len(), 1);
+        let simple = &sel.segments[0].simple;
+        // `*` is spelled as "no constraint at all" — it adds no field of its
+        // own, so the matcher needs no wildcard-specific branch.
+        assert!(simple.role.is_none());
+        assert!(simple.filters.is_empty());
+        assert!(simple.nth.is_none());
+    }
+
+    #[test]
+    fn parse_wildcard_as_combinator_target() {
+        let sel = Selector::parse("dialog > *").unwrap();
+        assert_eq!(sel.segments.len(), 2);
+        assert_eq!(sel.segments[1].combinator, Combinator::Child);
+        assert!(sel.segments[1].simple.role.is_none());
+
+        let sel = Selector::parse("window *").unwrap();
+        assert_eq!(sel.segments.len(), 2);
+        assert_eq!(sel.segments[1].combinator, Combinator::Descendant);
+        assert!(sel.segments[1].simple.role.is_none());
+    }
+
+    #[test]
+    fn parse_wildcard_as_intermediate_segment() {
+        // The case with no workaround before `*`: skip exactly one generation.
+        let sel = Selector::parse("group > * > button").unwrap();
+        assert_eq!(sel.segments.len(), 3);
+        assert!(sel.segments[1].simple.role.is_none());
+        assert_eq!(sel.segments[1].combinator, Combinator::Child);
+        assert!(matches!(
+            sel.segments[2].simple.role,
+            Some(RoleMatch::Normalized(Role::Button))
+        ));
+    }
+
+    #[test]
+    fn parse_wildcard_with_filters_and_nth() {
+        // `*[name="OK"]` must parse to exactly what `[name="OK"]` parses to.
+        let starred = Selector::parse(r#"*[name="OK"]"#).unwrap();
+        let bare = Selector::parse(r#"[name="OK"]"#).unwrap();
+        assert!(starred.segments[0].simple.role.is_none());
+        assert_eq!(
+            starred.segments[0].simple.filters.len(),
+            bare.segments[0].simple.filters.len()
+        );
+        assert_eq!(starred.segments[0].simple.filters[0].attr, "name");
+        assert_eq!(starred.segments[0].simple.filters[0].value, "OK");
+
+        let sel = Selector::parse("*:nth(3)").unwrap();
+        assert!(sel.segments[0].simple.role.is_none());
+        assert_eq!(sel.segments[0].simple.nth, Some(3));
+    }
+
+    #[test]
+    fn parse_wildcard_in_alternation_group() {
+        let group = SelectorGroup::parse("button, *").unwrap();
+        assert_eq!(group.clauses.len(), 2);
+        assert!(group.clauses[1].segments[0].simple.role.is_none());
+    }
+
+    #[test]
+    fn parse_wildcard_glued_to_role_is_error() {
+        // `*` and a role name are alternatives, not a sequence. Both orders
+        // must fail rather than silently dropping one of the two tokens.
+        assert!(Selector::parse("*button").is_err());
+        assert!(Selector::parse("button*").is_err());
+        assert!(Selector::parse("**").is_err());
+    }
+
+    #[test]
+    fn wildcard_matches_any_element() {
+        let sel = Selector::parse("*").unwrap();
+        let simple = &sel.segments[0].simple;
+
+        let mut el = element_default();
+        el.role = Role::Button;
+        assert!(matches_simple(&el, simple));
+
+        // Including roles that carry no name and no platform data at all —
+        // `*` must not accidentally depend on an attribute being present.
+        let el = element_default();
+        assert!(matches_simple(&el, simple));
+
+        let mut el = element_default();
+        el.role = Role::Unknown;
+        el.name = None;
+        assert!(matches_simple(&el, simple));
+    }
+
+    #[test]
+    fn wildcard_child_returns_all_children_of_anchor() {
+        // `toolbar > *` must return every child of the toolbar regardless of
+        // role, and must not reach past one generation.
+        let tree = fixture_tree();
+        let get_children = fixture_children(&tree);
+
+        let sel = Selector::parse("toolbar:nth(1) > *").unwrap();
+        let results = find_elements_in_tree(&get_children, None, &sel, None, None).unwrap();
+        let names: Vec<_> = results.iter().map(|e| e.name.clone().unwrap()).collect();
+        assert_eq!(names, vec!["A1".to_string(), "A2".to_string()]);
+    }
+
+    #[test]
+    fn wildcard_intermediate_segment_skips_one_generation() {
+        // `application > * > button` must find buttons that are exactly
+        // grandchildren of the root — i.e. it descends through the toolbars
+        // without naming them.
+        let tree = fixture_tree();
+        let get_children = fixture_children(&tree);
+
+        let sel = Selector::parse("application > * > button").unwrap();
+        let results = find_elements_in_tree(&get_children, None, &sel, None, None).unwrap();
+        let names: Vec<_> = results.iter().map(|e| e.name.clone().unwrap()).collect();
+        assert_eq!(names, vec!["A1", "A2", "B1", "B2"]);
+    }
+
+    #[test]
+    fn bare_wildcard_matches_every_node() {
+        let tree = fixture_tree();
+        let get_children = fixture_children(&tree);
+
+        let sel = Selector::parse("*").unwrap();
+        let results = find_elements_in_tree(&get_children, None, &sel, None, None).unwrap();
+        // Every node in the fixture, in document order.
+        let names: Vec<_> = results.iter().map(|e| e.name.clone().unwrap()).collect();
+        assert_eq!(names, vec!["root", "A", "A1", "A2", "B", "B1", "B2"]);
+    }
+
+    #[test]
+    fn wildcard_in_group_dedups_against_overlapping_clause() {
+        // `*` subsumes every other clause, so the union must not emit the
+        // buttons twice. This exercises the path-identity dedup in
+        // `find_elements_in_tree_group` against a clause that matches
+        // everything.
+        let tree = fixture_tree();
+        let get_children = fixture_children(&tree);
+
+        let group = SelectorGroup::parse("button, *").unwrap();
+        let results = find_elements_in_tree_group(&get_children, None, &group, None, None).unwrap();
+        let names: Vec<_> = results.iter().map(|e| e.name.clone().unwrap()).collect();
+        assert_eq!(
+            names,
+            vec!["root", "A", "A1", "A2", "B", "B1", "B2"],
+            "`button, *` must return each node once, in document order"
+        );
+    }
+
+    #[test]
+    fn bare_wildcard_respects_limit() {
+        let tree = fixture_tree();
+        let get_children = fixture_children(&tree);
+
+        let sel = Selector::parse("*").unwrap();
+        let results = find_elements_in_tree(&get_children, None, &sel, Some(3), None).unwrap();
+        let names: Vec<_> = results.iter().map(|e| e.name.clone().unwrap()).collect();
+        assert_eq!(names, vec!["root", "A", "A1"]);
     }
 
     /// Helper: build an ElementData with a given `raw` map for matcher tests.

--- a/xa11y/tests/integ/tree.rs
+++ b/xa11y/tests/integ/tree.rs
@@ -702,6 +702,118 @@ mod tests {
         );
     }
 
+    // ── universal selector (`*`) ────────────────────────────────────────
+
+    #[test]
+    #[ignore]
+    fn wildcard_is_superset_of_every_role_query() {
+        // `*` imposes no constraint, so on a real backend it must match at
+        // least every element any role-specific query finds. This is the
+        // end-to-end check that each provider's per-node probe treats an
+        // unconstrained SimpleSelector as a match rather than skipping it
+        // (the probe paths short-circuit on role, so "no role" is the branch
+        // most likely to be mishandled).
+        let app = h::app_root();
+        let all = app.locator("*").count().unwrap();
+        let buttons = app.locator("button").count().unwrap();
+        let text_fields = app.locator("text_field").count().unwrap();
+
+        assert!(buttons > 0, "fixture must have buttons. App: {}", app);
+        assert!(
+            all >= buttons + text_fields,
+            "`*` must match at least every button and text_field: \
+             all={all} buttons={buttons} text_fields={text_fields}",
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn wildcard_with_filter_equals_bare_attribute_selector() {
+        // `*[x]` and `[x]` are the same query by construction — the parser
+        // produces an identical SimpleSelector. Assert it on a real provider
+        // so a backend that special-cases "no role" can't diverge them.
+        let app = h::app_root();
+        let starred = app.locator(r#"*[role="button"]"#).count().unwrap();
+        let bare = app.locator(r#"[role="button"]"#).count().unwrap();
+        assert_eq!(
+            starred, bare,
+            "`*[role=\"button\"]` must equal `[role=\"button\"]`",
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn wildcard_child_returns_exactly_the_direct_children() {
+        // `window > *` must return each window's direct children and stop
+        // there. Compare against `Element::children()`, which is the same
+        // question asked through a different provider entry point.
+        let app = h::app_root();
+        let windows = app.locator("window").elements().unwrap();
+        assert!(!windows.is_empty(), "fixture must have a window");
+
+        let via_wildcard = app.locator("window").child("*").count().unwrap();
+        let via_children: usize = windows
+            .iter()
+            .map(|w| w.children().expect("children() must succeed").len())
+            .sum();
+
+        assert_eq!(
+            via_wildcard, via_children,
+            "`window > *` must equal the direct children of every window. App: {}",
+            app,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn wildcard_descendant_is_superset_of_wildcard_child() {
+        // `window *` (any depth) must be a superset of `window > *` (one
+        // level). Holds on any tree shape, so it's the portable check that
+        // the two combinators are wired to the wildcard segment correctly.
+        let app = h::app_root();
+        let child = app.locator("window").child("*").count().unwrap();
+        let descendant = app.locator("window").descendant("*").count().unwrap();
+
+        assert!(child > 0, "fixture window must have children. App: {}", app);
+        assert!(
+            descendant >= child,
+            "`window *` must be a superset of `window > *`: \
+             descendant={descendant} child={child}",
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn wildcard_intermediate_segment_stays_within_button_set() {
+        // `window > * > button` skips exactly one generation — the case with
+        // no imperative workaround. Whatever it finds must be a subset of
+        // all buttons; asserting a subset rather than a count keeps this
+        // portable across the three backends' differing tree depths.
+        let app = h::app_root();
+        let all_buttons: std::collections::HashSet<String> = app
+            .locator("button")
+            .elements()
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| e.data().name.clone())
+            .collect();
+        let nested: Vec<String> = app
+            .locator("window > * > button")
+            .elements()
+            .unwrap()
+            .into_iter()
+            .filter_map(|e| e.data().name.clone())
+            .collect();
+
+        for name in &nested {
+            assert!(
+                all_buttons.contains(name),
+                "`window > * > button` matched {name:?}, which `button` did not. App: {}",
+                app,
+            );
+        }
+    }
+
     #[test]
     #[ignore]
     fn selector_group_doc_order_interleaves_clauses() {


### PR DESCRIPTION
## What

Adds the CSS universal selector `*`. Previously it was a parse error in every position, and the error (`empty simple selector`) named neither the wildcard nor the alternative — a bad landing for the most reflexive thing to type in a CSS-like syntax.

```
*                     # every element in scope
dialog > *            # every direct child of a dialog
window *              # every descendant of a window
group > * > button    # buttons exactly two levels below a group
```

## How

`*` means "no role constraint", which is what a selector with no role already means. It parses to `role: None` and carries **no new field** — so `matches_simple` and all three backends' per-node probes already handled it correctly. The change is confined to `Selector::parse_simple`: accept `*` in the role position, and skip the "empty simple selector" guard when it's present.

Consequences that follow from that choice:

- `*[name='OK']` and `[name='OK']` parse to identical selectors, asserted directly in `parse_wildcard_with_filters_and_nth`.
- `*` and a role name are alternatives, not a sequence — consuming `*` skips the role parse, so `*button`, `button*` and `**` all remain errors rather than silently dropping a token.
- No public type changed, so `check-bindings-parity` needed no new classification, and both bindings pick the wildcard up for free (selectors cross the boundary as strings).

The only genuinely new capability is `group > * > button` — skipping exactly one generation. The `dialog > *` / `window *` shapes were already reachable imperatively via `Element::children()` / `Element::tree()`; the wildcard makes them expressible in a selector string, including through `Locator::child()` / `descendant()`.

## Cost

Worth stating plainly, since "`*` will walk the whole desktop" is the obvious objection:

- The tree walk was **already unbounded** for any rootless selector. `locator("button").all()` enumerates every node of every app today — `resolve_group` passes no limit down to the per-app call (`locator.rs:314`), and the walk recurses into every child regardless of match. `*` adds no new traversal.
- Each backend's per-node probe fetches only the attributes a selector names, so `*` probes **less** per node than `button` (zero attribute reads vs. one role read).
- What `*` does add is materialization: every visited node is retained rather than the few matching a role. On Windows that is free — `FindAllBuildCache(TreeScope_Subtree)` already builds every node in one batched call. On macOS and Linux it shifts the cost to `build_element_data` per node.

Net: a bare rootless `*` is the same order of work as `App.dump()` on every app on the desktop. Expensive, proportional to what was asked, and not a new class of hazard. The selector reference has a "Cost" section saying so and pointing at scoping or a limit for hot paths.

## Tests

12 unit tests in `xa11y-core/src/selector.rs` covering parse (all positions, the glued-token errors, alternation) and traversal (child, descendant, intermediate segment, bare-`*` document order, limit, and group dedup where `*` overlaps another clause).

5 integration tests in `xa11y/tests/integ/tree.rs` against a real provider — the backends' probe paths short-circuit on role, so "no role" is the branch most likely to be mishandled natively:

- `wildcard_is_superset_of_every_role_query`
- `wildcard_with_filter_equals_bare_attribute_selector`
- `wildcard_child_returns_exactly_the_direct_children` — cross-checks `window > *` against `Element::children()`
- `wildcard_descendant_is_superset_of_wildcard_child`
- `wildcard_intermediate_segment_stays_within_button_set`

`cargo xtask check` passes. `cargo xtask test-integ` is 138/138 on Linux; macOS and Windows land in CI here.

## Docs

- `reference/selectors.mdx` — new "The universal selector" section (table of the four shapes, the binding rule, the cost note), plus two lines in the at-a-glance block.
- `reference/cli.mdx` — dropped the "syntax has no `*` wildcard" aside, leaving the link to the selector reference as the single home for the syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqVFpynk1jznKsij4RS7Yt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqVFpynk1jznKsij4RS7Yt)_