### PR TITLE
fix(python): release the GIL in App.find (tenet 5)

### DIFF
--- a/tests/suites/python/test_gil_release.py
+++ b/tests/suites/python/test_gil_release.py
@@ -1,0 +1,92 @@
+"""Tenet 5 enforcement for the entry points that need a real provider.
+
+``xa11y-python/tests/test_gil_release.py`` is the main home for these tests,
+but everything it covers runs against the mock provider. ``App.find`` cannot:
+it resolves the platform provider through ``xa11y::provider()``, so proving it
+releases the GIL needs a live accessibility bus, which is what this suite has.
+
+The shape is the same as the unit-test file's: a background Python thread
+increments a counter while the main thread blocks in a native call. If the
+call held the GIL, the counter would stay near zero.
+
+Regression test for issue #358, where ``App.find`` held the GIL for its whole
+poll loop — including the sleeps between polls — freezing every other thread
+in the consumer's process for the full timeout.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+import xa11y
+
+# A 1-second native wait. With the GIL released the 1 ms spin loop gets
+# hundreds of iterations; with it held it gets approximately zero.
+_WAIT_S = 1.0
+_MIN_TICKS = 50
+
+
+def _ticks_during(blocked_call) -> int:
+    """Spin a background thread while ``blocked_call`` blocks the main one."""
+    ticks = {"n": 0}
+    started = threading.Event()
+    stop = threading.Event()
+
+    def spin():
+        started.set()
+        while not stop.is_set():
+            ticks["n"] += 1
+            time.sleep(0.001)
+
+    thread = threading.Thread(target=spin, daemon=True)
+    thread.start()
+    if not started.wait(timeout=5):
+        raise AssertionError("spin thread failed to start")
+    ticks["n"] = 0  # discount any pre-wait iterations
+    try:
+        blocked_call()
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+    return ticks["n"]
+
+
+def test_app_find_releases_gil_between_predicate_calls(app):
+    """``App.find`` calls back into Python, so it must hold the GIL only for
+    each predicate call — not across the sleeps between polls."""
+
+    def blocked():
+        with pytest.raises((xa11y.TimeoutError, xa11y.SelectorNotMatchedError)):
+            xa11y.App.find(lambda candidate: False, timeout=_WAIT_S)
+
+    ticks = _ticks_during(blocked)
+    assert ticks >= _MIN_TICKS, (
+        f"background thread made only {ticks} iterations during a {_WAIT_S}s "
+        f"App.find — the poll loop is holding the GIL (tenet 5, issue #358)"
+    )
+
+
+def test_app_find_still_propagates_a_predicate_exception(app):
+    """Releasing the GIL must not change how a raising predicate surfaces.
+
+    The predicate's exception is stashed across the ``allow_threads`` boundary
+    and re-raised; a regression here would show up as a misleading "no match"
+    timeout instead of the caller's own error.
+    """
+
+    class Sentinel(Exception):
+        pass
+
+    def boom(candidate):
+        raise Sentinel("predicate blew up")
+
+    with pytest.raises(Sentinel, match="predicate blew up"):
+        xa11y.App.find(boom, timeout=_WAIT_S)
+
+
+def test_app_find_still_matches(app):
+    """The happy path, so the GIL change cannot silently break discovery."""
+    found = xa11y.App.find(lambda candidate: candidate.pid == app.pid, timeout=5.0)
+    assert found.pid == app.pid

--- a/xa11y-python/src/lib.rs
+++ b/xa11y-python/src/lib.rs
@@ -1316,39 +1316,55 @@ impl App {
     /// ```
     #[staticmethod]
     #[pyo3(signature = (predicate, *, timeout=None))]
-    fn find(predicate: PyObject, timeout: Option<f64>) -> PyResult<Self> {
+    fn find(py: Python<'_>, predicate: PyObject, timeout: Option<f64>) -> PyResult<Self> {
         let timeout = effective_timeout(timeout)?;
         let provider = get_provider()?;
-        // The predicate is Python, so the poll loop must hold the GIL to call
-        // it (mirrors `Locator.wait_until`). We route through `try_find_with`
-        // so a raised exception fails fast: stash the real `PyErr` here and
-        // return an error from the closure (which `poll_lookup` short-circuits
-        // on), then re-raise the original Python exception below rather than
-        // coercing it to a misleading "no match".
-        let pred_err: std::cell::RefCell<Option<PyErr>> = std::cell::RefCell::new(None);
-        let result = xa11y::App::try_find_with(provider.clone(), timeout, |data| {
-            Python::with_gil(|py| -> xa11y::Result<bool> {
-                let outcome: PyResult<bool> = (|| {
-                    let app = Py::new(py, App::from_data(data, provider.clone()))?;
-                    predicate.call1(py, (app,))?.bind(py).is_truthy()
-                })();
-                match outcome {
-                    Ok(matched) => Ok(matched),
-                    Err(e) => {
-                        *pred_err.borrow_mut() = Some(e);
-                        Err(xa11y::Error::Platform {
-                            code: -1,
-                            message: "find() predicate raised".to_string(),
-                        })
+        // The poll loop runs with the GIL released (tenet 5); the predicate
+        // closure reacquires it per call. This mirrors `Locator.wait_until`.
+        // Holding the GIL for the loop would freeze every other thread in the
+        // consumer's process for the full timeout — and the loop *sleeps*
+        // between polls (`poll_lookup` in xa11y-core), so it is not even doing
+        // useful work while it blocks them.
+        //
+        // We route through `try_find_with` so a raised exception fails fast:
+        // stash the real `PyErr` here and return an error from the closure
+        // (which `poll_lookup` short-circuits on), then re-raise the original
+        // Python exception below rather than coercing it to a misleading
+        // "no match".
+        //
+        // A `Mutex` rather than a `RefCell`: the closure crosses
+        // `allow_threads`, which requires it to be `Send`, and `&RefCell` is
+        // not. There is no contention — the predicate runs on this thread —
+        // so the lock costs nothing.
+        let pred_err: std::sync::Mutex<Option<PyErr>> = std::sync::Mutex::new(None);
+        let result = py.allow_threads(|| {
+            xa11y::App::try_find_with(provider.clone(), timeout, |data| {
+                Python::with_gil(|py| -> xa11y::Result<bool> {
+                    let outcome: PyResult<bool> = (|| {
+                        let app = Py::new(py, App::from_data(data, provider.clone()))?;
+                        predicate.call1(py, (app,))?.bind(py).is_truthy()
+                    })();
+                    match outcome {
+                        Ok(matched) => Ok(matched),
+                        Err(e) => {
+                            // Poisoning cannot lose anything that matters here:
+                            // the stashed error is write-once and read once.
+                            *pred_err.lock().unwrap_or_else(|p| p.into_inner()) = Some(e);
+                            Err(xa11y::Error::Platform {
+                                code: -1,
+                                message: "find() predicate raised".to_string(),
+                            })
+                        }
                     }
-                }
+                })
             })
         });
+        let stashed = pred_err.into_inner().unwrap_or_else(|p| p.into_inner());
         match result {
             Ok(app) => Ok(Self::from_core(app)),
             // A stashed predicate error takes precedence — re-raise the exact
             // Python exception the predicate threw.
-            Err(e) => Err(pred_err.into_inner().unwrap_or_else(|| to_py_err(e))),
+            Err(e) => Err(stashed.unwrap_or_else(|| to_py_err(e))),
         }
     }
 

--- a/xa11y-python/tests/test_gil_release.py
+++ b/xa11y-python/tests/test_gil_release.py
@@ -5,6 +5,12 @@ tight loop while the main thread blocks inside a native xa11y wait. If the
 wait held the GIL, the background thread could not be scheduled and the
 counter would stay near zero for the duration of the wait.
 
+Everything here runs against the mock provider. ``App.find`` cannot: it
+resolves the platform provider through ``xa11y::provider()``, so its tenet-5
+coverage lives in ``tests/suites/python/test_gil_release.py``, where a live
+accessibility bus exists. Issue #358 went unnoticed because that gap was not
+recorded anywhere.
+
 Referenced from AGENTS.md (Design Tenets, tenet 5) — keep the file name
 stable.
 """


### PR DESCRIPTION
Fixes the Python half of #358.

## The bug

`App.find` never released the GIL. It could not: the `#[pyfunction]` took no `py: Python` token, and there was no `allow_threads` anywhere in its body. The whole poll loop ran with the GIL held — including the sleep between polls inside `poll_lookup` — so every other thread in the consumer's process froze for up to the full timeout, while `find` did nothing but sleep.

The comment claimed this was necessary:

```rust
// The predicate is Python, so the poll loop must hold the GIL to call
// it (mirrors `Locator.wait_until`).
```

`wait_until` does the opposite, and says so at `lib.rs:848`: *"The poll loop runs with the GIL released (tenet 5); the predicate closure reacquires it per call."* That is what tenet 5 prescribes, and it is what `find` now does.

## The change

`find` takes a `py: Python` token and wraps `try_find_with` in `py.allow_threads`. The existing `Python::with_gil` inside the predicate closure already reacquires per callback, so the callback path is unchanged.

The stash for a raising predicate becomes a `Mutex` rather than a `RefCell`: the closure now crosses `allow_threads` and must therefore be `Send`, and `&RefCell` is not. There is no contention — the predicate runs on the calling thread — so the lock costs nothing. Poisoning is handled with `unwrap_or_else(|p| p.into_inner())` per tenet 4; the stash is write-once, read-once, so there is nothing a poisoned lock could lose.

## Audit

I swept every method in `xa11y-python/src/lib.rs` for the same mistake, checking each definition for a `py` token and for `allow_threads` in its body. **`App.find` was the only case.** Every other method that can block already takes the token and releases; `try_recv` holds the GIL by design, since it returns immediately rather than blocking.

The JS side of #358's audit is not addressed here, nor is the tenet-6 point about poll loops discarding expensive diagnoses. Both remain open on the issue.

## Tests

`App.find` was the one blocking entry point with no tenet-5 test, which is why this survived as long as it did. It cannot be covered where the others are: `xa11y-python/tests/test_gil_release.py` runs against the mock provider, and `find` resolves the *platform* provider through `xa11y::provider()`. So the test goes in the integration suite, where a live accessibility bus exists, and the unit-test file now records that split rather than leaving it as an unexplained gap.

`tests/suites/python/test_gil_release.py` adds three tests:

- the tenet-5 assertion itself — a background thread must keep making progress during a 1-second `App.find`;
- that a predicate's exception still propagates as *itself* across the `allow_threads` boundary, rather than degrading into a misleading "no match" timeout;
- that discovery still matches, so the change cannot silently break `find`.

The last two pin the behaviour this change could plausibly break.

## Verification

- `cargo check` on `xa11y-python` passes. The `Send` bound on the `allow_threads` closure is compiler-enforced, so a successful build is itself evidence the captured state is sound.
- Built with `maturin develop` and ran the full binding suite: **274 passed**, including the three existing tenet-5 tests.
- I could **not** run the new integration tests locally — this container has no AT-SPI registry, so `App.find` fails fast on provider resolution instead of polling. They will run in the `integ` matrix cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NooViB2BR9pAYrtbgog4ha

---
_Generated by [Claude Code](https://claude.ai/code/session_01NooViB2BR9pAYrtbgog4ha)_