### PR TITLE
fix(tests): close the foreground/gate race in the foreground suites

### DIFF
--- a/tests/suites/js/05_foreground.test.js
+++ b/tests/suites/js/05_foreground.test.js
@@ -6,6 +6,11 @@
 // read `isForeground` flag for the app's pid. When the OS reports our app as
 // frontmost we assert the strong invariants; otherwise we fall back to the
 // app-agnostic ones (types, uniqueness) so the suite degrades gracefully.
+//
+// The gate is read either side of the observation it gates, and honoured only
+// when the two agree — see `observeWithStableForeground`. Reading it once,
+// afterwards, made the gate and the observation two views of a desktop that
+// had moved in between.
 
 'use strict';
 
@@ -27,23 +32,59 @@ async function freshForegroundFlag(app) {
   return me ? Boolean(me.isForeground) : null;
 }
 
+/**
+ * Run `observe()` sandwiched between two reads of the app's frontmost flag,
+ * and report the flag only when it did not change across the observation.
+ *
+ * The gate and the thing it gates are two separate reads of mutable global
+ * desktop state, so taking them one after the other is a race: if the
+ * foreground moves to our app *between* `App.foreground()` resolving someone
+ * else and the gate being read, the gate opens on a fact that was not true
+ * when the observation was taken, and the strong assertion compares two
+ * moments that never coexisted. That is a real CI failure, not a bug in the
+ * binding:
+ *
+ *     our app (pid=7764) reports isForeground but
+ *     App.foreground() resolved a different pid=1704
+ *
+ * Reading the flag either side and requiring agreement means the strong
+ * invariants are asserted only against an observation the desktop held still
+ * for. A few retries cover a desktop that is merely settling; one that keeps
+ * changing hands reports `frontmost: null`, and the caller degrades to the
+ * app-agnostic assertions exactly as it already does when the app is not
+ * frontmost at all.
+ */
+async function observeWithStableForeground(app, observe, attempts = 5) {
+  let value;
+  for (let i = 0; i < attempts; i += 1) {
+    const before = await freshForegroundFlag(app);
+    value = await observe();
+    const after = await freshForegroundFlag(app);
+    if (before === after) return { value, frontmost: before };
+  }
+  return { value, frontmost: null };
+}
+
 // ── App.foreground() ────────────────────────────────────────────────────────
 
 test('App.foreground() resolves to a foreground app', async () => {
   const app = await getApp();
-  let fg;
+  let reading;
   try {
-    fg = await App.foreground({ timeout: 5000 });
+    reading = await observeWithStableForeground(app, () =>
+      App.foreground({ timeout: 5000 }),
+    );
   } catch (err) {
     if (err instanceof SelectorNotMatchedError) return; // nothing holds focus
     throw err;
   }
+  const { value: fg, frontmost } = reading;
 
   assert.ok(typeof fg.pid === 'number' && fg.pid > 0);
   // Whatever App.foreground() returns is, by definition, the foreground app.
   assert.equal(fg.isForeground, true);
 
-  if (await freshForegroundFlag(app)) {
+  if (frontmost) {
     assert.equal(
       fg.pid,
       app.pid,
@@ -88,7 +129,12 @@ test('App.isForeground is a plain boolean', async () => {
 
 test('active window reports active; descendants do not', async () => {
   const app = await getApp();
-  const windows = await app.locator('window').elements();
+  // Same race as above: the window snapshot and the frontmost gate are two
+  // reads of moving state, so take the snapshot inside the sandwich.
+  const { value: windows, frontmost } = await observeWithStableForeground(
+    app,
+    () => app.locator('window').elements(),
+  );
   if (windows.length === 0) return; // no separate window node (e.g. UIA app-as-window)
 
   const activeWindows = windows.filter((w) => w.active);
@@ -99,7 +145,6 @@ test('active window reports active; descendants do not', async () => {
     `expected at most one active window, found ${activeWindows.length}`,
   );
 
-  const frontmost = await freshForegroundFlag(app);
   if (frontmost) {
     assert.equal(
       activeWindows.length,

--- a/tests/suites/python/test_foreground.py
+++ b/tests/suites/python/test_foreground.py
@@ -19,6 +19,11 @@ The gate itself is the freshly-read ``is_foreground`` flag for the app's pid
 — when the OS says our app is frontmost we assert the strong invariants;
 otherwise we fall back to the app-agnostic ones (types, bounds, uniqueness)
 so the suite degrades gracefully rather than flaking.
+
+The gate is read either side of the observation it gates, and honoured only
+when the two agree — see ``_observe_with_stable_foreground``. Reading it once,
+afterwards, made the gate and the observation two views of a desktop that had
+moved in between.
 """
 
 from __future__ import annotations
@@ -41,6 +46,40 @@ def _fresh_foreground_flag(app: xa11y.App) -> bool | None:
     return None
 
 
+def _observe_with_stable_foreground(app, observe, attempts: int = 5):
+    """Run ``observe()`` between two reads of the frontmost flag.
+
+    Returns ``(value, frontmost)``, where ``frontmost`` is the flag only if it
+    did not change across the observation, and ``None`` otherwise.
+
+    The gate and the thing it gates are two separate reads of mutable global
+    desktop state, so taking them one after the other is a race: if the
+    foreground moves to our app *between* ``App.foreground()`` resolving
+    someone else and the gate being read, the gate opens on a fact that was not
+    true when the observation was taken, and the strong assertion compares two
+    moments that never coexisted. That is a real CI failure, not a binding bug
+    — the JS mirror of this file hit it on ``windows-latest``::
+
+        our app (pid=7764) reports isForeground but
+        App.foreground() resolved a different pid=1704
+
+    Reading the flag either side and requiring agreement means the strong
+    invariants are asserted only against an observation the desktop held still
+    for. A few retries cover a desktop that is merely settling; one that keeps
+    changing hands yields ``None``, and the caller degrades to the
+    app-agnostic assertions exactly as it already does when the app is not
+    frontmost at all.
+    """
+    value = None
+    for _ in range(attempts):
+        before = _fresh_foreground_flag(app)
+        value = observe()
+        after = _fresh_foreground_flag(app)
+        if before == after:
+            return value, before
+    return value, None
+
+
 # ---------------------------------------------------------------------------
 # App.foreground()
 # ---------------------------------------------------------------------------
@@ -53,7 +92,9 @@ def test_foreground_resolves_to_a_foreground_app(app):
     as AccessKit-on-Xvfb), the resolved pid must be ours.
     """
     try:
-        fg = xa11y.App.foreground(timeout=5.0)
+        fg, frontmost = _observe_with_stable_foreground(
+            app, lambda: xa11y.App.foreground(timeout=5.0)
+        )
     except xa11y.SelectorNotMatchedError:
         pytest.skip("nothing holds the system foreground in this harness")
 
@@ -62,7 +103,7 @@ def test_foreground_resolves_to_a_foreground_app(app):
     # foreground application.
     assert fg.is_foreground is True
 
-    if _fresh_foreground_flag(app):
+    if frontmost:
         assert fg.pid == app.pid, (
             f"our app (pid={app.pid}) reports is_foreground but "
             f"App.foreground() resolved a different pid={fg.pid}"
@@ -119,7 +160,11 @@ def test_active_window(app, app_config):
     Strengthened to *exactly one* (and to our app's window) only when the OS
     reports our app as frontmost.
     """
-    windows = app.locator("window").elements()
+    # Same race as above: the window snapshot and the frontmost gate are two
+    # reads of moving state, so take the snapshot inside the sandwich.
+    windows, frontmost = _observe_with_stable_foreground(
+        app, lambda: app.locator("window").elements()
+    )
     if not windows:
         # Windows/UIA can model the app itself as the top-level window with no
         # separate `window` child; nothing to assert about window activeness.
@@ -132,7 +177,6 @@ def test_active_window(app, app_config):
         f"expected at most one active window, found {len(active_windows)}"
     )
 
-    frontmost = _fresh_foreground_flag(app)
     if frontmost:
         assert len(active_windows) == 1, (
             "app is frontmost but no window reports active=True"


### PR DESCRIPTION
`Integ (tauri) on windows-latest` went red on an unrelated PR with:

```
✖ App.foreground() resolves to a foreground app
  AssertionError: our app (pid=7764) reports isForeground but
  App.foreground() resolved a different pid=1704
```

Both readings were correct. The test takes them at different moments:

```js
fg = await App.foreground();          // read A — who holds the foreground?
if (await freshForegroundFlag(app)) { // read B — do *we* hold it?
  assert.equal(fg.pid, app.pid);      // compares A against B
}
```

The gate exists so the strong identity assertions only run on harnesses where
the OS actually puts the app in front — that part is right, and it is why the
suite is app-agnostic across qt / gtk / tauri. But the gate is a second read of
mutable global desktop state, taken *after* the observation it guards. When the
foreground moves to our app between A and B, the gate opens on a fact that was
not true when A was taken, and the assertion compares two moments that never
coexisted.

The reverse transition is the benign direction — the gate closes and the test
degrades — which is why this surfaces as an occasional red rather than a
consistent one.

## The fix

Read the gate either side of the observation, and honour it only when the two
agree:

```js
const before = await freshForegroundFlag(app);
const value  = await observe();
const after  = await freshForegroundFlag(app);
if (before === after) return { value, frontmost: before };
```

An observation the desktop held still for is safe to assert against; one taken
mid-transition is not, and falls back to the app-agnostic assertions the suite
already uses when the app is not frontmost at all. A few retries cover a
desktop that is merely settling.

`test_active_window` has the same shape — window snapshot first, gate
afterwards — so it goes through the same helper.

## Both languages

`tests/suites/python/test_foreground.py` is the mirror of the JS file and
carries the identical race in both tests. Fixing only the one that happened to
fail would leave the same flake armed on the Python side, so both are done.

## What this does not change

On a settled desktop the first attempt agrees and the strong invariants are
asserted exactly as before — no coverage is weakened, and the unconditional
assertions (`fg.pid > 0`, `fg.isForeground === true`, at-most-one-active-window)
are untouched. The cost is two extra `App.list()` calls per observation.

Independent of #357; branched from `main`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NooViB2BR9pAYrtbgog4ha

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NooViB2BR9pAYrtbgog4ha

---
_Generated by [Claude Code](https://claude.ai/code/session_01NooViB2BR9pAYrtbgog4ha)_