### PR TITLE
fix(tests): unflake the tauri/Windows integ cell — readiness gate, then focus race

### DIFF
--- a/tests/harness/launch.py
+++ b/tests/harness/launch.py
@@ -24,7 +24,6 @@ import signal
 import subprocess
 import sys
 import tempfile
-import time
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Sequence

--- a/tests/harness/launch.py
+++ b/tests/harness/launch.py
@@ -35,9 +35,25 @@ from typing import Sequence
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
-# Overall app-startup / content-readiness deadline, in seconds. Overridable
-# for slow machines and loaded CI runners (matches tests/helpers.py).
-STARTUP_TIMEOUT = float(os.environ.get("XA11Y_TEST_STARTUP_TIMEOUT", "30"))
+# How long to wait for the app to register with the accessibility API, and —
+# separately — how long to then wait for its content to load. Two budgets, not
+# one shared deadline: see _launch_app.
+#
+# Windows gets longer because both phases are measurably slower there and both
+# have been observed to overrun. UIA registration for the egui app finished at
+# the 30s boundary (the app was present in the very next enumeration), and
+# WebView2 had not loaded the Tauri page within the residue the old shared
+# deadline left it.
+_DEFAULT_STARTUP_TIMEOUT = 60.0 if sys.platform == "win32" else 30.0
+STARTUP_TIMEOUT = float(
+    os.environ.get("XA11Y_TEST_STARTUP_TIMEOUT", _DEFAULT_STARTUP_TIMEOUT)
+)
+
+# Content readiness gets its own budget of the same size. Sharing one deadline
+# with discovery meant a slow-registering app left readiness the 1-second floor.
+CONTENT_READY_TIMEOUT = float(
+    os.environ.get("XA11Y_TEST_CONTENT_TIMEOUT", STARTUP_TIMEOUT)
+)
 
 # Apps with a real, activatable macOS window whose tests depend on holding the
 # frontmost slot — input_sim delivers CGEvents to the frontmost app, and focus
@@ -280,8 +296,6 @@ def _launch_app(
 
     import xa11y  # imported late so the module is optional for callers that don't need it
 
-    deadline = time.monotonic() + STARTUP_TIMEOUT
-
     # Discovery is a single waited call: `App.find` polls the accessibility
     # API internally, so the harness no longer hand-rolls a retry loop. Match
     # on the PID we just launched *or* any of the platform's candidate names
@@ -320,18 +334,40 @@ def _launch_app(
 
     # Wait for content to be ready if a selector was specified — again one
     # library call (`wait_attached`) rather than a manual poll loop.
+    #
+    # Its own budget, not `deadline - now`. Discovery and readiness used to
+    # share one deadline, so an app that took most of the startup budget to
+    # register left the content wait its 1-second floor. On Windows that is
+    # what happened: WebView2 had not painted the Tauri page inside one
+    # second, the gate gave up, and the suites then ran against a window
+    # holding nothing but Minimize/Maximize/Close.
     if content_ready_selector is not None:
         print(f"Waiting for content: {content_ready_selector!r}")
-        remaining = max(deadline - time.monotonic(), 1.0)
         try:
-            app.locator(content_ready_selector).wait_attached(timeout=remaining)
-        except (xa11y.SelectorNotMatchedError, xa11y.TimeoutError, xa11y.PlatformError):
-            print(
-                f"WARNING: content selector {content_ready_selector!r} not ready "
-                f"after timeout; proceeding anyway"
+            app.locator(content_ready_selector).wait_attached(
+                timeout=CONTENT_READY_TIMEOUT
             )
-        else:
-            _print_content_state(app, content_ready_selector, "after launch")
+        except (xa11y.SelectorNotMatchedError, xa11y.TimeoutError, xa11y.PlatformError) as exc:
+            # Fail, rather than warn and continue. "Proceeding anyway" turned
+            # one clear "the app never became ready" into a scatter of
+            # unrelated-looking test failures in whichever suite ran first,
+            # while the app finished loading behind them — the same shape as
+            # issue #327, where a cell reported on work it had not really
+            # done. A gate that continues is not a gate.
+            try:
+                tree = app.dump(max_depth=8)
+            except Exception:  # noqa: BLE001 - diagnosis only
+                tree = "<tree unavailable>"
+            _kill_app(proc)
+            raise RuntimeError(
+                f"Test app (pid={proc.pid}) started but its content never became "
+                f"ready: selector {content_ready_selector!r} did not resolve within "
+                f"{CONTENT_READY_TIMEOUT:.0f}s.\n"
+                f"Raise XA11Y_TEST_CONTENT_TIMEOUT if this machine is simply slow.\n"
+                f"Last error: {exc}\n"
+                f"Tree at give-up:\n{tree}"
+            ) from exc
+        _print_content_state(app, content_ready_selector, "after launch")
 
     # macOS: claim the frontmost slot before handing the app to the suites, so
     # input_sim/focus tests aren't silently misdirected to whatever onboarding

--- a/tests/harness/test_launch.py
+++ b/tests/harness/test_launch.py
@@ -17,6 +17,7 @@ Run with:  cargo xtask test-harness   (or: python -m pytest tests/harness)
 from __future__ import annotations
 
 import subprocess
+import inspect
 import sys
 from pathlib import Path
 
@@ -222,3 +223,57 @@ def test_every_suite_writes_a_junit_report(suite, tmp_path):
     assert any(str(report) in arg for arg in cmd), (
         f"{suite} suite command does not write a junit report: {cmd}"
     )
+
+
+# ── Startup and content-readiness budgets ────────────────────────────────────
+
+
+def test_discovery_and_readiness_have_independent_budgets():
+    """Readiness must not inherit whatever discovery left over.
+
+    The two shared a deadline, so an app that took most of the startup budget
+    to register left the content wait its 1-second floor. That is how the
+    Tauri suites came to run against a Windows window holding nothing but
+    Minimize/Maximize/Close: WebView2 had not painted the page inside one
+    second, and the gate gave up.
+    """
+    assert launch.CONTENT_READY_TIMEOUT >= launch.STARTUP_TIMEOUT, (
+        "content readiness gets its own full budget, not the residue of discovery"
+    )
+
+
+def test_windows_gets_a_longer_startup_budget():
+    """Both phases are measurably slower on Windows, and both have overrun.
+
+    UIA registration for the egui app finished at the 30s boundary — the app
+    appeared in the very next enumeration — and WebView2 content load has
+    overrun as well.
+    """
+    expected = 60.0 if sys.platform == "win32" else 30.0
+    assert launch._DEFAULT_STARTUP_TIMEOUT == expected
+
+
+def test_both_budgets_are_overridable_by_environment():
+    """A slow machine must be able to buy more time without a code change."""
+    source = inspect.getsource(launch)
+    assert "XA11Y_TEST_STARTUP_TIMEOUT" in source
+    assert "XA11Y_TEST_CONTENT_TIMEOUT" in source
+
+
+def test_readiness_failure_is_fatal_not_a_warning():
+    """A gate that continues is not a gate.
+
+    "Proceeding anyway" turned one clear "the app never became ready" into a
+    scatter of unrelated-looking failures in whichever suite ran first, while
+    the app finished loading behind them — the shape of issue #327, where a
+    cell reported on work it had not really done.
+    """
+    source = inspect.getsource(launch._launch_app)
+    assert "proceeding anyway" not in source, (
+        "the content-readiness gate must fail rather than warn and continue"
+    )
+    # The message is wrapped across f-string lines, so match a contiguous
+    # fragment and the raise itself rather than the whole sentence.
+    assert "content never became " in source
+    assert "raise RuntimeError(" in source
+    assert "XA11Y_TEST_CONTENT_TIMEOUT" in source

--- a/tests/suites/python/test_input_sim.py
+++ b/tests/suites/python/test_input_sim.py
@@ -53,6 +53,9 @@ CLEAR_BUTTON = 'button[name="Clear log"]'
 # Wait up to this long for a log line to appear after we post an event.
 LOG_SETTLE_TIMEOUT = 2.0
 
+# Wait up to this long for focus to actually land before synthesising input.
+FOCUS_SETTLE_TIMEOUT = 5.0
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -65,7 +68,13 @@ def _read_log(app: xa11y.App) -> str:
 
 
 def _wait_for_log(app: xa11y.App, predicate, timeout: float = LOG_SETTLE_TIMEOUT) -> str:
-    """Poll the log until `predicate(text)` returns True or we time out."""
+    """Poll the log until `predicate(text)` returns True, or fail saying what it saw.
+
+    Raises rather than returning the last value. Returning it produced
+    `assert 'keydown' in ''` — an assertion that reports the symptom and hides
+    both the wait and what the page actually held. The traceback still names
+    the predicate, because it points at the calling line.
+    """
     deadline = time.monotonic() + timeout
     last = ""
     while time.monotonic() < deadline:
@@ -73,15 +82,26 @@ def _wait_for_log(app: xa11y.App, predicate, timeout: float = LOG_SETTLE_TIMEOUT
         if predicate(last):
             return last
         time.sleep(0.05)
-    return last
+    raise AssertionError(
+        f"Event log never matched within {timeout:.1f}s.\n"
+        f"  log was: {last!r}\n"
+        f"  an empty log means the synthesised input never reached the webview "
+        f"at all, rather than arriving in the wrong shape."
+    )
 
 
 def _clear_log(app: xa11y.App) -> None:
     app.locator(CLEAR_BUTTON).press()
     # The press itself is a synthetic a11y action (not input sim), so the
     # log should be empty immediately — but give one tick for the webview
-    # handler to run.
-    _wait_for_log(app, lambda t: t == "", timeout=0.5)
+    # handler to run. Best-effort on purpose: a stale line here is not worth
+    # failing the test that has not run yet, and every caller asserts on the
+    # content it goes on to produce.
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline:
+        if _read_log(app) == "":
+            return
+        time.sleep(0.05)
 
 
 def _line(log: str, kind: str) -> str:
@@ -101,13 +121,32 @@ def _field(line: str, key: str) -> str:
     return ""
 
 
+def _focus_settled(app: xa11y.App, selector: str) -> None:
+    """Focus `selector` and wait until the platform agrees it is focused.
+
+    `focus()` auto-waits for the target to be visible and enabled and then
+    issues the focus action; it does not wait for focus to *land*. Synthesised
+    keystrokes go to whatever holds keyboard focus at the moment they are
+    posted, so a test that types immediately after `focus()` can have its first
+    keystroke delivered to the previous holder and dropped.
+
+    That is a race the suite loses only occasionally, and only on the first
+    keyboard test after the mouse ones — the rest inherit settled focus, which
+    is why `test_key_press_reports_keydown_keyup` failed alone on Windows with
+    an empty event log while every later keyboard test passed.
+    """
+    locator = app.locator(selector)
+    locator.focus()
+    locator.wait_focused(timeout=FOCUS_SETTLE_TIMEOUT)
+
+
 def _focus_hit_target(app: xa11y.App) -> None:
     """Focus the hit target so keyboard events land on a meaningful element."""
-    app.locator(HIT_TARGET).focus()
+    _focus_settled(app, HIT_TARGET)
 
 
 def _focus_typed_field(app: xa11y.App) -> None:
-    app.locator(TYPED_FIELD).focus()
+    _focus_settled(app, TYPED_FIELD)
 
 
 def _hit_center(app: xa11y.App) -> tuple[int, int]:


### PR DESCRIPTION
Two flakes in `Integ (tauri) on windows-latest`, one behind the other. The second only became visible once the first was fixed, so they are in one PR: the first commit's CI run is what produced the evidence for the second.

## 1. The readiness gate (commit 1)

```
Test app visible: 'xa11y-tauri-test-app' (pid=2464)
Waiting for content: 'button[name="OK"]'
WARNING: content selector 'button[name="OK"]' not ready after timeout; proceeding anyway
Content state (before python): <unreadable: SelectorNotMatchedError(
  No element matched selector: button[name="OK"];
  candidates: button "Minimize", button "Maximize", button "Close")>

=== Running python suite against tauri ===

Content state (after python): button 'OK' visible=True enabled=True
--- python suite exited with code 1 ---
```

The entire Python suite ran against a window holding nothing but its title bar, and the page finished loading *while it ran*.

**Discovery and readiness shared a deadline.** `deadline` was set before `App.find`, and the content wait then took the remainder:

```python
deadline = time.monotonic() + STARTUP_TIMEOUT
app = xa11y.App.find(_is_test_app, timeout=STARTUP_TIMEOUT)   # can consume all of it
...
remaining = max(deadline - time.monotonic(), 1.0)             # often just the floor
```

An app that takes most of the startup budget to register — what a cold Windows runner does — left readiness the **1-second floor**, which WebView2 does not meet. Each phase now has its own budget.

**The gate warned and continued.** That turned one clear "never became ready" into a scatter of unrelated-looking failures in whichever suite ran first, with the cause a warning line above them — the shape of issue #327. It now fails with the selector, the budget, the underlying error and the tree it gave up on, and names the variable that buys more time.

The default rises to 60s on Windows for both phases. **An evidence-backed heuristic, not a root cause**: two cells, two apps, both startup-timing — the WebView2 case above, and `Integ (egui) on windows-latest` timing out discovery at 30s with the app present in the very next enumeration.

## 2. The focus race (commit 2)

Commit 1's CI run confirms the gate is fixed — no `WARNING`, no "proceeding anyway", the OK button resolved at stable bounds through all three suite boundaries. What it exposed:

```
tests/suites/python/test_input_sim.py::test_key_press_reports_keydown_keyup
E   AssertionError: assert 'keydown' in ''

1 failed, 102 passed, 9 skipped, 5 xfailed, 4 xpassed in 93.65s
```

An empty log means the keystroke never reached the webview. The failing test is the **first** keyboard test in the file, right after the mouse tests; every later keyboard test passed, including the chord ones that flaked in earlier runs.

`focus()` auto-waits for its target to be visible and enabled, then issues the focus action. It does not wait for focus to **land**. Synthesised keystrokes go wherever keyboard focus is when they are posted, so the first key after a `focus()` can go to the previous holder and be dropped — and only the first, because the rest inherit settled focus. That is precisely the observed shape. `_focus_hit_target` and `_focus_typed_field` now follow `focus()` with `wait_focused()`.

**Also fixed: the diagnostic that hid it.** `_wait_for_log` returned its last observation on timeout, which is how a dropped keystroke got reported as `assert 'keydown' in ''` — an assertion naming the symptom while hiding both the wait and what the page held. It now raises with the budget, the log contents, and the fact that empty means *never arrived* rather than *arrived malformed* (tenet 6). The traceback still names the predicate, since it points at the calling line. Every call site expects a match, so nothing relied on the tolerant return; `_clear_log`, which did, keeps its best-effort poll explicitly.

The CLI and JS suites do not carry this race — CLI key tests assert only on exit codes, and the JS suite never reads the event log after focusing.

## Scope

Distinct from #360, which fixes a third flake in the same cell (a foreground/gate race). No overlap: different files, different failures.

This supersedes what commit 1 said it was not fixing. `test_chord_reports_modifier` and `test_key_press_reports_keydown_keyup` are the same defect — a synthesised key arriving before focus settles — so the focus fix covers both, though only the latter is reproduced in a log here.

## Tests

Four harness cases in `tests/harness/test_launch.py` covering the independent budgets, the Windows default, both being overridable, and that the gate raises rather than warns. That last is a source assertion, which is blunt, but "proceeding anyway" is the regression worth pinning and the real path needs a slow app to exercise.

`cargo xtask test-harness`: 35 passed, 1 skipped. The input-sim change has no unit-level counterpart — it is only exercisable against a running app, which is what the integ cell on this PR does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NooViB2BR9pAYrtbgog4ha