### PR TITLE
README: one Python example, install steps for all three packages

### DIFF
--- a/.github/styles/config/vocabularies/xa11y/accept.txt
+++ b/.github/styles/config/vocabularies/xa11y/accept.txt
@@ -63,6 +63,7 @@ froglogic
 libFuzzer
 maturin
 napi
+npm
 pytest
 pywinauto
 serde

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,6 +322,30 @@ Two things worth knowing before adding pages:
   `.vale.ini` skips those blocks explicitly. Top-level fences are handled by
   the parser.
 
+## READMEs
+
+`README.md` at the repo root is the source. `cargo xtask sync-readmes` renders
+it into `xa11y/README.md` (crates.io) and `xa11y-python/README.md` (PyPI), and
+CI runs `--check` and fails when either has drifted. Edit the root and
+re-render; never edit a package README directly. `xa11y-js/README.md` is
+hand-written and sits outside this pipeline.
+
+Language-specific content is marked, in one of two forms:
+
+- `<!-- python-only -->` ... `<!-- /python-only -->` renders in the root README
+  *and* in that language's package README. Every visible block shows on the
+  root page, which is why the root lists all three install steps while each
+  package README lists only its own.
+- `<!-- rust-only-hidden` ... `-->` puts the content inside the comment, so the
+  root README renders nothing while the package README still gets it. The Rust
+  quick example ships this way: the root page leads with Python, and crates.io
+  still gets a Rust snippet.
+
+The recognised language names are `rust`, `python`, and `js` (`README_LANGS` in
+`xtask/src/main.rs`). A typo'd name fails `sync-readmes` instead of shipping a
+literal marker to a package registry. Hidden content must not contain `-->`,
+which would end the comment early and leak the rest into the root page.
+
 ## Project Structure
 
 - `xa11y-core/` — Platform-independent types, traits, selector engine

--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ safari.locator("text_field[name^='Search']").set_value("hello world")
 <!-- rust-only -->
 **Rust**
 
-```toml
-[dependencies]
-xa11y = "0.12"
+```bash
+cargo add xa11y
 ```
 <!-- /rust-only -->
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/xa11y)](https://crates.io/crates/xa11y)
 [![PyPI](https://img.shields.io/pypi/v/xa11y)](https://pypi.org/project/xa11y/)
+[![npm](https://img.shields.io/npm/v/@crowecawcaw/xa11y)](https://www.npmjs.com/package/@crowecawcaw/xa11y)
 [![CI](https://github.com/xa11y/xa11y/actions/workflows/ci.yml/badge.svg)](https://github.com/xa11y/xa11y/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
@@ -10,11 +11,11 @@ A Playwright-style library for driving native desktop apps on macOS, Windows, an
 
 **Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 
-**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
+**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)** | **[JavaScript API](https://xa11y.dev/api/javascript/)**
 
 ## Quick Example
 
-<!-- rust-only -->
+<!-- rust-only-hidden
 ```rust
 use xa11y::*;
 use std::time::Duration;
@@ -35,7 +36,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 ```
-<!-- /rust-only -->
+-->
 
 <!-- python-only -->
 ```python
@@ -57,6 +58,8 @@ safari.locator("text_field[name^='Search']").set_value("hello world")
 ## Installation
 
 <!-- rust-only -->
+**Rust**
+
 ```toml
 [dependencies]
 xa11y = "0.12"
@@ -64,12 +67,24 @@ xa11y = "0.12"
 <!-- /rust-only -->
 
 <!-- python-only -->
+**Python**
+
 ```bash
 pip install xa11y
 ```
 
 Requires Python 3.9+. Pre-built wheels available for Linux, macOS, and Windows.
 <!-- /python-only -->
+
+<!-- js-only -->
+**JavaScript**
+
+```bash
+npm install @crowecawcaw/xa11y
+```
+
+Requires Node.js 18+. Pre-built native binaries available for Linux, macOS, and Windows.
+<!-- /js-only -->
 
 > On **macOS**, grant your terminal **two** permissions in **System Settings > Privacy & Security**:
 > 1. **Accessibility**, required for all accessibility API access.

--- a/docs/site/src/content/docs/guides/install.mdx
+++ b/docs/site/src/content/docs/guides/install.mdx
@@ -14,10 +14,11 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Tabs syncKey="lang">
   <TabItem label="Rust">
-    ```toml
-    [dependencies]
-    xa11y = "0.12"
+    ```bash
+    cargo add xa11y
     ```
+
+    Adds the current release to `Cargo.toml`. The platform backend is picked by target, so there are no feature flags to choose.
   </TabItem>
   <TabItem label="Python">
     ```bash

--- a/xa11y-python/README.md
+++ b/xa11y-python/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/xa11y)](https://crates.io/crates/xa11y)
 [![PyPI](https://img.shields.io/pypi/v/xa11y)](https://pypi.org/project/xa11y/)
+[![npm](https://img.shields.io/npm/v/@crowecawcaw/xa11y)](https://www.npmjs.com/package/@crowecawcaw/xa11y)
 [![CI](https://github.com/xa11y/xa11y/actions/workflows/ci.yml/badge.svg)](https://github.com/xa11y/xa11y/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
@@ -10,7 +11,7 @@ A Playwright-style library for driving native desktop apps on macOS, Windows, an
 
 **Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 
-**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
+**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)** | **[JavaScript API](https://xa11y.dev/api/javascript/)**
 
 ## Quick Example
 
@@ -30,6 +31,8 @@ safari.locator("text_field[name^='Search']").set_value("hello world")
 ```
 
 ## Installation
+
+**Python**
 
 ```bash
 pip install xa11y

--- a/xa11y/README.md
+++ b/xa11y/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/xa11y)](https://crates.io/crates/xa11y)
 [![PyPI](https://img.shields.io/pypi/v/xa11y)](https://pypi.org/project/xa11y/)
+[![npm](https://img.shields.io/npm/v/@crowecawcaw/xa11y)](https://www.npmjs.com/package/@crowecawcaw/xa11y)
 [![CI](https://github.com/xa11y/xa11y/actions/workflows/ci.yml/badge.svg)](https://github.com/xa11y/xa11y/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-xa11y.dev-blueviolet)](https://xa11y.dev)
@@ -10,7 +11,7 @@ A Playwright-style library for driving native desktop apps on macOS, Windows, an
 
 **Use cases:** end-to-end desktop testing, computer-use agents, MCP tools, assistive technology.
 
-**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)**
+**[Documentation](https://xa11y.dev)** | **[Rust API](https://docs.rs/xa11y)** | **[Python API](https://xa11y.dev/api/python/)** | **[JavaScript API](https://xa11y.dev/api/javascript/)**
 
 ## Quick Example
 
@@ -36,6 +37,8 @@ fn main() -> Result<()> {
 ```
 
 ## Installation
+
+**Rust**
 
 ```toml
 [dependencies]

--- a/xa11y/README.md
+++ b/xa11y/README.md
@@ -40,9 +40,8 @@ fn main() -> Result<()> {
 
 **Rust**
 
-```toml
-[dependencies]
-xa11y = "0.12"
+```bash
+cargo add xa11y
 ```
 
 > On **macOS**, grant your terminal **two** permissions in **System Settings > Privacy & Security**:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -705,9 +705,20 @@ fn do_sync_readmes(args: &[String]) -> bool {
 
     let mut ok = true;
     for &(keep, dest) in targets {
-        let remove = if keep == "rust" { "python" } else { "rust" };
-        let expected = strip_lang_blocks(&source, keep, remove);
+        let expected = render_readme(&source, keep);
         let path = root.join(dest);
+
+        // A marker surviving the render is a typo'd language name: it would
+        // ship to crates.io or PyPI as literal text, and the block it guards
+        // would land in the wrong README.
+        for residue in ["-only -->", "-only-hidden"] {
+            if expected.contains(residue) {
+                eprintln!(
+                    "{dest}: unresolved `{residue}` marker — language names must be one of {README_LANGS:?}"
+                );
+                ok = false;
+            }
+        }
 
         if check {
             let actual = fs::read_to_string(&path).unwrap_or_default();
@@ -727,38 +738,93 @@ fn do_sync_readmes(args: &[String]) -> bool {
     ok
 }
 
-/// Remove `<!-- {remove}-only -->...<!-- /{remove}-only -->` blocks entirely,
-/// and unwrap `<!-- {keep}-only -->...<!-- /{keep}-only -->` markers (keeping content).
-fn strip_lang_blocks(source: &str, keep: &str, remove: &str) -> String {
-    let open_remove = format!("<!-- {remove}-only -->\n");
-    let close_remove = format!("<!-- /{remove}-only -->\n");
-    let open_keep = format!("<!-- {keep}-only -->\n");
-    let close_keep = format!("<!-- /{keep}-only -->\n");
+/// Languages a README block can be tagged for. The root README renders every
+/// visible block, so it is the one page that shows all three install steps;
+/// each package README keeps its own language's blocks and drops the rest.
+const README_LANGS: &[&str] = &["rust", "python", "js"];
 
-    // Remove the other language's blocks
-    let mut result = String::with_capacity(source.len());
-    let mut rest = source;
-    while let Some(start) = rest.find(&open_remove) {
-        result.push_str(&rest[..start]);
-        rest = &rest[start + open_remove.len()..];
-        if let Some(end) = rest.find(&close_remove) {
-            rest = &rest[end + close_remove.len()..];
-        } else {
-            // Unclosed marker — keep the rest as-is
-            break;
-        }
+/// Render the package README for `keep` from the root README: keep that
+/// language's blocks, drop every other language's, and collapse the blank
+/// lines the dropped blocks leave behind.
+fn render_readme(source: &str, keep: &str) -> String {
+    let mut result = source.to_string();
+    for lang in README_LANGS {
+        result = resolve_lang_blocks(&result, lang, *lang == keep);
     }
-    result.push_str(rest);
 
-    // Unwrap the kept language's markers
-    result = result.replace(&open_keep, "");
-    result = result.replace(&close_keep, "");
-
-    // Collapse triple+ blank lines
     while result.contains("\n\n\n") {
         result = result.replace("\n\n\n", "\n\n");
     }
+    result
+}
 
+/// Resolve every block tagged for `lang`, keeping its content without the
+/// markers when `keep` and dropping the whole block otherwise.
+///
+/// Two spellings are recognised. A visible block renders as ordinary Markdown
+/// in the root README:
+///
+/// ```text
+/// <!-- python-only -->
+/// ...content...
+/// <!-- /python-only -->
+/// ```
+///
+/// A hidden block puts the content *inside* the comment, so the root README
+/// renders nothing while that language's package README still gets it. This is
+/// how the crates.io README keeps a Rust example that the root README, which
+/// leads with Python, doesn't show:
+///
+/// ```text
+/// <!-- rust-only-hidden
+/// ...content...
+/// -->
+/// ```
+///
+/// Hidden content must not itself contain `-->`, which would end the comment
+/// early and leak the remainder into the rendered root README.
+///
+/// An unclosed marker leaves the rest of the document untouched, so a
+/// malformed README fails the `--check` diff instead of being silently
+/// truncated.
+fn resolve_lang_blocks(source: &str, lang: &str, keep: bool) -> String {
+    let visible_open = format!("<!-- {lang}-only -->\n");
+    let visible_close = format!("<!-- /{lang}-only -->\n");
+    let hidden_open = format!("<!-- {lang}-only-hidden\n");
+    let hidden_close = "-->\n";
+
+    let mut result = String::with_capacity(source.len());
+    let mut rest = source;
+    loop {
+        // Whichever spelling comes first wins. The two openers cannot match
+        // the same marker: one ends in `-only -->`, the other in `-only-hidden`.
+        let hidden = rest.find(&hidden_open).map(|at| (at, true));
+        let visible = rest.find(&visible_open).map(|at| (at, false));
+        let (start, is_hidden) = match (hidden, visible) {
+            (Some(h), Some(v)) if v.0 < h.0 => v,
+            (Some(h), _) => h,
+            (None, Some(v)) => v,
+            (None, None) => break,
+        };
+        let (open, close) = if is_hidden {
+            (hidden_open.as_str(), hidden_close)
+        } else {
+            (visible_open.as_str(), visible_close.as_str())
+        };
+
+        result.push_str(&rest[..start]);
+        let body = &rest[start + open.len()..];
+        let Some(end) = body.find(close) else {
+            result.push_str(&rest[start..]);
+            return result;
+        };
+        if keep {
+            result.push_str(&body[..end]);
+        }
+        rest = &body[end + close.len()..];
+    }
+
+    result.push_str(rest);
     result
 }
 
@@ -997,4 +1063,80 @@ fn do_check() -> bool {
         heading("Some checks failed");
     }
     ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_readme, README_LANGS};
+
+    #[test]
+    fn visible_block_survives_only_in_its_own_readme() {
+        let source = "\
+# Title
+
+<!-- rust-only -->
+cargo
+<!-- /rust-only -->
+
+<!-- python-only -->
+pip
+<!-- /python-only -->
+
+<!-- js-only -->
+npm
+<!-- /js-only -->
+";
+        // The trailing blank line is what the dropped blocks leave behind:
+        // blank-line collapsing folds runs of three or more newlines only.
+        assert_eq!(render_readme(source, "rust"), "# Title\n\ncargo\n\n");
+        assert_eq!(render_readme(source, "python"), "# Title\n\npip\n\n");
+        assert_eq!(render_readme(source, "js"), "# Title\n\nnpm\n");
+    }
+
+    #[test]
+    fn hidden_block_is_unwrapped_for_its_own_readme() {
+        let source = "\
+## Quick Example
+
+<!-- rust-only-hidden
+fn main() -> Result<()> { Ok(()) }
+-->
+
+<!-- python-only -->
+import xa11y
+<!-- /python-only -->
+";
+        assert_eq!(
+            render_readme(source, "rust"),
+            "## Quick Example\n\nfn main() -> Result<()> { Ok(()) }\n\n"
+        );
+        assert_eq!(
+            render_readme(source, "python"),
+            "## Quick Example\n\nimport xa11y\n"
+        );
+    }
+
+    #[test]
+    fn unclosed_marker_leaves_the_document_intact() {
+        // No close marker: the text is preserved verbatim so `--check` reports
+        // a diff rather than the generator silently truncating the README.
+        let source = "# Title\n\n<!-- rust-only -->\ncargo\n";
+        assert_eq!(render_readme(source, "rust"), source);
+        assert_eq!(render_readme(source, "python"), source);
+    }
+
+    #[test]
+    fn the_real_readme_resolves_every_marker() {
+        let source = std::fs::read_to_string(super::project_root().join("README.md"))
+            .expect("root README.md is readable");
+        for keep in README_LANGS {
+            let rendered = render_readme(&source, keep);
+            for residue in ["-only -->", "-only-hidden"] {
+                assert!(
+                    !rendered.contains(residue),
+                    "`{residue}` survived rendering README.md for {keep}"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
The root README carried both a Rust and a Python quick example and install
steps for two of the three published packages. It now leads with a single
Python example and lists cargo, pip, and npm under Installation, with an npm
badge and a JavaScript API link alongside the existing ones.

The root README is the source that `cargo xtask sync-readmes` renders into
the crates.io and PyPI READMEs, so two changes to the generator back this:

- `js` joins `rust` and `python` as a recognised block language, replacing the
  hardcoded keep/remove pair with a loop over `README_LANGS`. A `js-only`
  block therefore drops out of both package READMEs, and a typo'd language
  name now fails the command instead of shipping a literal marker to a
  package registry.
- A new `<!-- rust-only-hidden` ... `-->` form keeps content inside the HTML
  comment, so the root README renders nothing while the package README still
  gets it. The Rust quick example uses it: the landing page leads with Python
  and crates.io keeps its Rust snippet.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C99o28UGeDQHafe4dMSfNo