### PR TITLE
docs: give pytest-xa11y a reference page and wire up its discovery paths

### DIFF
--- a/.github/styles/config/vocabularies/xa11y/accept.txt
+++ b/.github/styles/config/vocabularies/xa11y/accept.txt
@@ -70,9 +70,13 @@ serde
 
 # ── Software-writing vocabulary ─────────────────────────────────────
 antialiasing
+argv
+autouse
+basename
 [Bb]oolean
 combinators?
 compat
+dataclass
 deduplicated
 enum
 env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Generating `_native.pyi` instead (with `pyo3-stub-gen`) is blocked: every versio
 
 ## Pre-Commit / Pre-PR Checklist
 
-Run `cargo xtask check` to run all pre-PR checks in one command. It covers formatting, linting, unit tests, and Python bindings.
+Run `cargo xtask check` to run all pre-PR checks in one command. It covers formatting, linting, unit tests, both bindings, the integ harness self-tests, and the pytest plugin.
 
 CI runs with `RUSTFLAGS: -Dwarnings`, so all warnings are errors. Individual checks:
 
@@ -217,8 +217,10 @@ CI runs with `RUSTFLAGS: -Dwarnings`, so all warnings are errors. Individual che
 3. **Unit tests** — `cargo xtask test`
 4. **Integration tests** (if touching provider/test-app code) — `cargo xtask test-integ`
 5. **Python bindings** — `cargo xtask test-python`
-6. **Docs prose** (if touching `README.md` or `docs/site/src/content/docs/`) — `cargo xtask lint-docs`
-7. **No new `#[allow(...)]` without justification** — if you must suppress a warning, add a comment explaining why
+6. **pytest plugin** (if touching `pytest-xa11y/`) — `cargo xtask test-pytest-plugin`
+7. **Docs prose** (if touching `README.md` or `docs/site/src/content/docs/`) — `cargo xtask lint-docs`
+8. **Docs site** (if touching `docs/site/src/content/docs/`) — `python docs/check_page_types.py`, `docs/check_tables.py`, `docs/check_links.py`
+9. **No new `#[allow(...)]` without justification** — if you must suppress a warning, add a comment explaining why
 
 Common CI failures:
 - `unused import` / `dead_code` — remove the unused code or add `#[allow(dead_code)]` with a reason
@@ -229,7 +231,8 @@ Common CI failures:
 ## Running Tests
 
 ```bash
-# All pre-PR checks (fmt, lint, test, test-python)
+# All pre-PR checks (fmt, lint, test, test-python, test-js, test-harness,
+# test-pytest-plugin, plus the macOS FFI and bindings-parity checks)
 cargo xtask check
 
 # Individual commands
@@ -238,6 +241,7 @@ cargo xtask fmt --check                       # check without modifying
 cargo xtask lint                              # clippy + ruff + Python Rust check
 cargo xtask test                              # unit tests
 cargo xtask test-python                       # build + test Python bindings
+cargo xtask test-pytest-plugin                # install + test pytest-xa11y
 cargo xtask test-integ                        # integration tests (auto-detects OS)
 cargo xtask test-integ-container              # Linux integration tests via Finch
 cargo xtask test-integ-container tree_has_buttons  # single test in container
@@ -345,25 +349,3 @@ The recognised language names are `rust`, `python`, and `js` (`README_LANGS` in
 `xtask/src/main.rs`). A typo'd name fails `sync-readmes` instead of shipping a
 literal marker to a package registry. Hidden content must not contain `-->`,
 which would end the comment early and leak the rest into the root page.
-
-## Project Structure
-
-- `xa11y-core/` — Platform-independent types, traits, selector engine
-- `xa11y-linux/` — AT-SPI2 backend via zbus
-- `xa11y-macos/` — macOS backend (AXUIElement, with ObjC exception safety)
-- `xa11y-windows/` — Windows backend (UI Automation)
-- `xa11y/` — Umbrella crate, unit tests, integration tests
-- `test-apps/accesskit/` — AccessKit + winit app used as target for Rust integration tests
-- `test-apps/qt/` — PySide6 Qt test app
-- `test-apps/gtk/` — GTK4 test app (Python, PyGObject)
-- `test-apps/cocoa/` — Cocoa/AppKit test app (Swift, macOS-only)
-- `test-apps/tauri/` — Tauri test app (Rust + HTML)
-- `test-apps/winforms/` — .NET Windows Forms test app (C#, Windows-only)
-- `test-apps/wpf/` — .NET WPF test app (C#, Windows-only)
-- `tests/` — Python integration test suites (pytest + xa11y-python)
-- `xa11y-python/` — Python bindings via PyO3/maturin (excluded from Cargo workspace)
-- `xa11y/fuzz/` — libFuzzer fuzz targets for the xa11y public API (requires nightly)
-- `xa11y-fuzz/` — Live provider fuzzer (randomised stress test against a running test app)
-- `xtask/` — Development workflow commands (`cargo xtask <command>`)
-- `scripts/` — Shell scripts for integration tests, fuzzing, coverage
-- `docs/` — Documentation site and generation scripts

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ pip install xa11y
 ```
 
 Requires Python 3.9+. Pre-built wheels available for Linux, macOS, and Windows.
+
+For pytest suites, [`pytest-xa11y`](https://xa11y.dev/reference/pytest/) adds
+fixtures that launch the app under test, capability markers that skip what the
+machine cannot do, and the accessibility tree on every failure:
+
+```bash
+pip install pytest-xa11y
+```
 <!-- /python-only -->
 
 <!-- js-only -->

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -104,6 +104,7 @@ export default defineConfig({
             { label: "Events", slug: "reference/events" },
             { label: "Errors", slug: "reference/errors" },
             { label: "CLI", slug: "reference/cli" },
+            { label: "pytest plugin", slug: "reference/pytest" },
             { label: "Platform Details", slug: "reference/platform-details" },
             {
               label: "Rust API",

--- a/docs/site/src/content/docs/guides/ci.mdx
+++ b/docs/site/src/content/docs/guides/ci.mdx
@@ -177,6 +177,52 @@ dbus-run-session -- bash -c '
 '
 ```
 
+## Running a pytest-xa11y suite
+
+If your suite uses [`pytest-xa11y`](/reference/pytest/), install it alongside
+`xa11y` and give the run the flags CI needs and a laptop does not:
+
+```yaml
+      - run: pip install xa11y pytest pytest-xa11y
+      - run: |
+          pytest tests/ \
+            --xa11y-startup-timeout=90 \
+            --xa11y-artifacts=artifacts/
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: xa11y-artifacts
+          path: artifacts/
+```
+
+`--xa11y-startup-timeout` covers a cold runner, where a first launch pays for
+page cache misses and an accessibility bridge that is still coming up. The
+30-second default is tuned for a warm machine.
+
+`--xa11y-artifacts` writes a screenshot of every live application on each
+failing test and names the path in the failure report. Upload the directory so
+the screenshots outlive the runner. The accessibility tree, the app's output,
+and xa11y's own error diagnosis are already in the report, so a failure is
+usually readable without them.
+
+On **macOS and Windows runners without the input grant**, declare it:
+
+```bash
+pytest tests/ --xa11y-skip=input_sim
+```
+
+Neither platform can be probed for it. `CGEventPost` returns void, so synthetic
+events are discarded silently and every layer reports success. Without the
+flag, tests marked `@pytest.mark.xa11y_requires("input_sim")` run and assert
+against a UI that never received the input. `XA11Y_SKIP_INPUT_SIM=1` does the
+same job for a runner-wide setting.
+
+One thing to know before reaching for `pytest-xdist`: tests needing
+`input_sim`, and tests marked `xa11y_frontmost`, skip when more than one worker
+is running. Input synthesis and the macOS frontmost slot are process-global,
+and parallel workers take them from each other. Split those tests into a
+serial job rather than losing them to a silent skip.
+
 ## Troubleshooting
 
 | Symptom | Likely cause |
@@ -187,3 +233,4 @@ dbus-run-session -- bash -c '
 | Window never appears in the tree | The toolkit needs a window manager. Set `setup-window-manager: true`. |
 | `Xvfb` fails to start | The display number is taken. Set a different `display` (e.g. `:98`). |
 | Tests hang or flake on macOS | An onboarding window (Setup Assistant) holds front-app focus. Dismiss it before running input-driven tests. |
+| Tests skip with "needs exclusive use of the desktop session" | `pytest-xdist` is running more than one worker. Run the input and frontmost tests with `-p no:xdist` or `-n0`. |

--- a/docs/site/src/content/docs/guides/desktop-testing.mdx
+++ b/docs/site/src/content/docs/guides/desktop-testing.mdx
@@ -123,6 +123,10 @@ capture or input synthesis skips with the reason when the session cannot provide
 that exits mid-run is reported once, in place of every later test failing on a lookup that
 cannot succeed.
 
+The fixtures, the `AppLauncher` fields, the capability markers, and the
+command-line options are listed on the [pytest plugin
+reference](/reference/pytest/).
+
 ## Example: testing a calculator
 
 This test opens Calculator, performs `7 × 8`, and asserts the result is `56`.

--- a/docs/site/src/content/docs/reference/pytest.mdx
+++ b/docs/site/src/content/docs/reference/pytest.mdx
@@ -1,0 +1,275 @@
+---
+title: pytest plugin
+description: Reference for pytest-xa11y — the fixtures, AppLauncher fields, capability markers, command-line options, and failure-report sections it adds to a pytest suite.
+pageType: reference
+---
+
+{/* DIATAXIS: reference — a factual description of the machinery, structured
+    for lookup rather than for reading through. Neutral and complete. No task
+    narratives, no rationale, no teaching. */}
+
+[`pytest-xa11y`](https://pypi.org/project/pytest-xa11y/) packages the
+launch-and-attach flow as pytest fixtures. It ships separately from the `xa11y`
+package and versions on its own line.
+
+```bash
+pip install pytest-xa11y
+```
+
+The plugin loads through the `pytest11` entry point, so installing it is all
+the wiring there is. It stays inert until a test requests one of its fixtures.
+
+A suite supplies one fixture, `xa11y_launcher`, and takes the running
+application from `xa11y_app`:
+
+```python
+# conftest.py
+import pytest
+from pytest_xa11y import AppLauncher
+
+
+@pytest.fixture(scope="session")
+def xa11y_launcher():
+    return AppLauncher(command=["./my-app"], ready='button[name="Sign in"]')
+```
+
+```python
+def test_sign_in(xa11y_app):
+    xa11y_app.locator('text_field[name="Email"]').set_value("a@b.c")
+    xa11y_app.locator('button[name="Sign in"]').press()
+```
+
+`xa11y_app` is an `xa11y.App`. Locators, elements, actions, and errors are the
+library's own, documented under [Locator & Element](/reference/locator/) and
+[Errors](/reference/errors/). The plugin adds no second API for driving the UI.
+
+## Fixtures
+
+| Fixture | Scope | Value |
+| --- | --- | --- |
+| `xa11y_launcher` | session | Supplied by the suite. An `AppLauncher`. The built-in definition raises `LauncherNotConfigured`. |
+| `xa11y_app` | session | The application under test, launched once per session and terminated at the end of it. |
+| `xa11y_fresh_app` | function | A newly launched application, terminated at the end of the test. |
+| `xa11y_app_factory` | session | `launch(AppLauncher) -> App`, for additional applications. Each is terminated at the end of the session. |
+| `xa11y_events` | function | `record(App) -> EventRecorder`. Recorders are closed at the end of the test. |
+| `xa11y_capabilities` | session | The session's `Capabilities`. |
+| `xa11y_artifacts` | session | The resolved artifacts directory as a `Path`, or `None` when `--xa11y-artifacts` is unset. |
+
+An autouse fixture runs around every test once an application is live. It
+checks each live application is still running, then calls
+`AppLauncher.reset` for the session application. The death of an application
+launched by `xa11y_app` stops the run. The death of one launched by
+`xa11y_fresh_app` or `xa11y_app_factory` drops it from the live set, and the
+run continues.
+
+## AppLauncher
+
+`AppLauncher` is a frozen dataclass. Every field except `command` is optional,
+and invalid combinations raise `ValueError` at construction.
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `command` | sequence of str | `()` | argv for the application. A bare string is rejected. |
+| `env` | mapping | `None` | Extra environment variables, merged over `os.environ`. |
+| `cwd` | str or Path | `None` | Working directory for the subprocess. |
+| `app_names` | sequence of str | `()` | Accessibility names to match in addition to the spawned PID. Widens the match. |
+| `app_name_prefix` | str | `None` | Match a candidate whose PID is ours and whose name starts with this. Narrows the match. |
+| `spawns_and_exits` | bool | `False` | The command hands off to another process and exits. Switches off death detection. |
+| `ready` | str | `None` | Selector that must resolve before the first test runs. |
+| `startup_timeout` | float | `None` | Seconds to appear and become ready. Overrides `--xa11y-startup-timeout`. |
+| `frontmost` | bool | `False` | Claim and verify the macOS frontmost slot at launch. No-op off macOS. |
+| `reset` | callable | `None` | Called with the `App` before each test. |
+| `attach_pid` | int | `None` | Attach to a running process instead of launching one. |
+| `label` | str | `None` | Name used in diagnostics and artifact filenames. Defaults to the command's basename. |
+
+Mutually exclusive pairs, each rejected at construction: `command` with
+`attach_pid`, `app_names` with `app_name_prefix`, and `attach_pid` with
+`spawns_and_exits`. `startup_timeout` must be positive and finite, and `reset`
+must be callable.
+
+`startup_timeout` is one budget covering both phases, appearing in the
+accessibility tree and satisfying `ready`. A process the plugin attached to is
+never terminated by it.
+
+`AppLauncher.display_name` returns `label`, the command's basename, or
+`pid-<n>` in attach mode. `AppLauncher.resolved_env()` returns the merged
+subprocess environment, or `None` when `env` is unset.
+
+## Markers
+
+```python
+@pytest.mark.xa11y_requires("screenshot")
+@pytest.mark.xa11y_frontmost
+def test_capture(xa11y_app): ...
+```
+
+| Marker | Arguments | Effect |
+| --- | --- | --- |
+| `xa11y_requires` | one or more capability names | Skips the test unless every named capability is available. |
+| `xa11y_frontmost` | none | Claims and verifies the macOS frontmost slot before the test body. Skips with the name of the offending application when the claim fails. No-op off macOS. |
+
+The `xa11y_` marker prefix is reserved. Collection fails, rather than warns, on
+an unknown `xa11y_` marker, an unknown capability name, `xa11y_requires()` with
+no arguments, or arguments passed to `xa11y_frontmost`. Every offending marker
+in the run is reported at once.
+
+Tests requiring `input_sim`, and tests marked `xa11y_frontmost`, skip when
+`pytest-xdist` reports more than one worker. Input synthesis and the frontmost
+slot are process-global state that parallel workers take from each other. Run
+those tests with `-p no:xdist` or `-n0`.
+
+### Capabilities
+
+| Name | Probe | Notes |
+| --- | --- | --- |
+| `screenshot` | One full-display capture, once per session. | Only the errors meaning "this session has no capture path" produce a skip. Any other capture failure propagates. A full-display capture can succeed where a region capture is rejected. |
+| `input_sim` | Constructs the input backend, once per session. | Real on Linux, where both backends validate eagerly. macOS and Windows always report available: `CGEventPost` returns void, so a missing grant is indistinguishable from success. Declare it with `--xa11y-skip=input_sim`. |
+
+`pytest_xa11y.Capability` is a `str` enum of the same names.
+`Capability.SCREENSHOT` and `"screenshot"` are interchangeable everywhere a
+capability is named. `pytest_xa11y.KNOWN_CAPABILITIES` is the tuple of valid
+names.
+
+## Command-line options
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `--xa11y-timeout=SECONDS` | the library default of 5s | Calls `xa11y.set_default_timeout()`. Outranks `XA11Y_DEFAULT_TIMEOUT`; a per-call `timeout=` outranks both. |
+| `--xa11y-startup-timeout=SECONDS` | `30` | Time allowed for the application to appear and satisfy `ready`. An `AppLauncher`'s own `startup_timeout` overrides it. |
+| `--xa11y-artifacts=DIR` | off | Write a screenshot of each live application's window to `DIR` on every failing test, framing the whole display when the application has no window with bounds. Nothing is written when the `screenshot` capability is unavailable. |
+| `--xa11y-skip=CAPABILITY` | none | Declare a capability unavailable. Repeatable. Accepts only known capability names. |
+| `--xa11y-dump-depth=N` | `12` | Depth of the tree dump attached to failing tests. |
+| `--xa11y-max-diagnostics=N` | `10` | Attach application state to at most `N` failing tests per run. |
+
+| Environment variable | Effect |
+| --- | --- |
+| `XA11Y_SKIP_INPUT_SIM=1` | Equivalent to `--xa11y-skip=input_sim`. |
+| `XA11Y_DEFAULT_TIMEOUT` | Read by the library. `--xa11y-timeout` outranks it. |
+
+The plugin prints a `xa11y:` header line reporting the timeouts, disabled
+capabilities, and artifacts directory. The line is omitted when nothing was
+configured, so a suite that never launches an application prints no header.
+
+## Failure reports
+
+A failing test gets up to three report sections.
+
+| Section | Contents |
+| --- | --- |
+| `xa11y diagnosis` | The structured fields of an xa11y error: `condition`, `selector`, `elapsed`, `last_observed`, `candidates`, `scope`. Present only when the failure carries a [Diagnosis](/explanation/errors-and-diagnosis/). |
+| `xa11y app state` | Per live application: its identity, a tree dump to `--xa11y-dump-depth`, and the tail of its output. The first block also carries the macOS frontmost state and any recorded events. With `--xa11y-artifacts`, the path of the screenshot written for that application. |
+| `xa11y diagnostics cap` | Emitted once, on the failure that reaches `--xa11y-max-diagnostics`. Later failures get no application state. |
+
+Collection is bounded and runs on the failure path alone. A collector that
+raises is reported in place of its block rather than dropped.
+
+### register_diagnostic
+
+```python
+import pytest_xa11y
+
+pytest_xa11y.register_diagnostic(
+    "event log",
+    lambda app: app.locator('text_area[name="Event log"]').element().value or "",
+)
+```
+
+`register_diagnostic(name, collector)` adds a suite-specific collector to the
+`xa11y app state` section. The collector receives the live `App` and returns a
+string.
+
+## EventRecorder
+
+Obtained from `xa11y_events`. Whatever a recorder has seen is attached to the
+failure report.
+
+```python
+def test_focus_moves(xa11y_app, xa11y_events):
+    with xa11y_events(xa11y_app) as events:
+        xa11y_app.locator('button[name="OK"]').focus()
+        events.expect("focus_changed", name="OK", timeout=2.0)
+```
+
+| Member | Signature | Behaviour |
+| --- | --- | --- |
+| `expect` | `(event_type=None, *, name=None, predicate=None, timeout=5.0)` | Waits for a matching event and returns it, or fails the test with what did arrive. Blocks in xa11y's own wait, releasing the GIL. |
+| `seen` | `(event_type=None, *, name=None, predicate=None)` | Already-recorded matches. Does not wait. |
+| `drain` | `(duration=0.3)` | Every event delivered over the next `duration` seconds. |
+| `recorded` | property | Every event seen, oldest first. |
+| `render` | `(*, indent="", limit=25)` | Bounded rendering of what was recorded. |
+| `subscription` | property | The underlying `xa11y.Subscription`. Raises `RuntimeError` when the recorder is not open. |
+| `open` / `close` | `()` | Lifecycle. A recorder is also a context manager. |
+
+`event_type` takes one type name or several, where several means any of them.
+Platforms disagree about which event an interaction emits, so a checkbox toggle
+is `state_changed` on one bridge and `value_changed` on another:
+
+```python
+events.expect(("state_changed", "value_changed"), timeout=5.0)
+```
+
+`name` matches the target element's name exactly. At least one of
+`event_type`, `name`, or `predicate` is required: `expect()` with no filter
+would match whatever arrived, and `ValueError` is raised instead. Use
+[`Subscription.recv`](/reference/events/) to wait for the next event of any
+kind.
+
+Recorders retain the last 200 events, and `render` shows the last 25 of them.
+
+## Capabilities
+
+The object behind `xa11y_capabilities`. Every method takes a capability name
+and raises `ValueError` on an unknown one. Probes run at most once per session,
+including the failing case: a probe that raises has its exception cached and
+re-raised.
+
+| Method | Returns | Behaviour |
+| --- | --- | --- |
+| `available(name)` | bool | Whether the capability can be exercised here. |
+| `reason(name)` | str or `None` | Why it is unavailable, or `None` when it is available. |
+| `check(name)` | `(available, reason)` | Both of the above, in one call. |
+| `skip_unless(name)` | `None` | Skips the current test when the capability is unavailable. What `xa11y_requires` calls. |
+| `guard(name)` | context manager | Turns a capability-unavailable error raised inside the block into a skip, and re-raises everything else. |
+| `summary()` | str | One clause per capability, as used in the session header. |
+
+`guard` exists alongside the marker because availability is not one yes or no.
+A region capture can be rejected in a session where a full-display capture
+succeeds, so the narrower question is answered at the call:
+
+```python
+def test_region(xa11y_capabilities):
+    with xa11y_capabilities.guard("screenshot"):
+        shot = xa11y.screenshot(region=(0, 0, 50, 40))
+```
+
+## Exceptions
+
+Raised by the plugin, never by the application under test. All are importable
+from `pytest_xa11y`.
+
+| Exception | Raised when |
+| --- | --- |
+| `PytestXa11yError` | Base class for the three below. |
+| `LauncherNotConfigured` | A fixture asked for `xa11y_launcher` and the suite defined none. |
+| `AppLaunchError` | The application could not be launched, found, or made ready. Carries the exit code and output tail for a process that exited during startup. |
+| `AppDied` | The application exited mid-run. Raised between tests, and it stops the run for the session application. |
+
+## Lower-level pieces
+
+`AppSession(launcher, *, startup_timeout, critical=True)` is the object behind
+each fixture: `start()`, `check_alive()`, `run_reset()`, `stop()`, and
+`output_tails()`. The fixtures manage its lifecycle, and a suite driving one
+by hand owns the teardown.
+
+`ensure_macos_frontmost(pid, *, timeout=10.0)` returns `(ok, detail)` after
+claiming the front slot for `pid` and polling until the system confirms it.
+`detail` names the application holding the front when the claim fails. Off
+macOS it reports success without acting.
+
+## See also
+
+- [Write desktop tests](/guides/desktop-testing/) for the launch-and-attach
+  flow the plugin packages.
+- [Testing in CI](/guides/ci/) for the options a CI run needs.
+- The [package README](https://github.com/xa11y/xa11y/blob/main/pytest-xa11y/README.md)
+  for the design reasoning behind the fields above.

--- a/docs/site/src/content/docs/reference/pytest.mdx
+++ b/docs/site/src/content/docs/reference/pytest.mdx
@@ -1,6 +1,6 @@
 ---
 title: pytest plugin
-description: Reference for pytest-xa11y — the fixtures, AppLauncher fields, capability markers, command-line options, and failure-report sections it adds to a pytest suite.
+description: Reference for pytest-xa11y. The fixtures, AppLauncher fields, capability markers, command-line options, and failure-report sections it adds to a pytest suite.
 pageType: reference
 ---
 
@@ -9,8 +9,8 @@ pageType: reference
     narratives, no rationale, no teaching. */}
 
 [`pytest-xa11y`](https://pypi.org/project/pytest-xa11y/) packages the
-launch-and-attach flow as pytest fixtures. It ships separately from the `xa11y`
-package and versions on its own line.
+launch-and-attach flow as pytest fixtures. It is published separately from the
+`xa11y` package and versions on its own line.
 
 ```bash
 pip install pytest-xa11y

--- a/pytest-xa11y/README.md
+++ b/pytest-xa11y/README.md
@@ -38,6 +38,11 @@ own API — locators, elements, actions and errors are xa11y's, documented in
 xa11y's own reference. There is no second API surface here to learn or to
 drift out of step.
 
+**The full reference — every fixture, `AppLauncher` field, marker, and
+command-line option — is at <https://xa11y.dev/reference/pytest/>.** This file
+covers what the plugin does and why the sharper edges are shaped the way they
+are.
+
 ## What the plugin does
 
 **Launch and attach.** `AppLauncher` describes how the app starts; the plugin
@@ -66,38 +71,11 @@ its report. xa11y's structured error diagnosis (what it waited for, what it
 last observed, near-miss candidates) is rendered as its own labelled section.
 All of it bounded, on the failure path only, capped per run.
 
-## Fixtures
+## Finding the app
 
-| Fixture | Scope | What it gives you |
-| --- | --- | --- |
-| `xa11y_launcher` | session | **You define this.** The launch recipe. |
-| `xa11y_app` | session | The app under test. |
-| `xa11y_fresh_app` | function | A newly launched app, torn down after the test. |
-| `xa11y_app_factory` | session | Launch additional apps (dialogs that register separately, multi-process suites). |
-| `xa11y_events` | function | An `EventRecorder` for a block of test code. |
-| `xa11y_capabilities` | session | What this session can exercise, and why not. |
-| `xa11y_artifacts` | session | The artifacts directory, or `None`. |
-
-## AppLauncher
-
-```python
-AppLauncher(
-    command=[BINARY, "--headless"],   # argv, as a list
-    env={"QT_ACCESSIBILITY": "1"},    # merged over os.environ
-    cwd=PROJECT_ROOT,
-    app_names=["my-app"],             # match the a11y name too, not just the PID
-    app_name_prefix="Submit to ",     # ...or narrow to one app within our PID
-    spawns_and_exits=False,           # the command hands off and exits
-    ready='button[name="OK"]',        # gate startup on content
-    startup_timeout=60,               # overrides --xa11y-startup-timeout
-    frontmost=True,                   # claim the macOS front slot
-    reset=lambda app: app.locator('button[name="Home"]').press(),
-    label="widgets",                  # used in diagnostics and artifact names
-)
-```
-
-`attach_pid=N` attaches to an already-running process instead of launching
-one; the plugin never terminates a process it did not start.
+The default is a self-contained binary that registers under its own PID.
+Three fields cover the cases that are not, and the distinctions between them
+matter:
 
 `app_names` matters when the process that registers with the accessibility
 API is not the one you launched — Electron helper processes, launcher shims
@@ -120,12 +98,10 @@ sharing the host's PID on Windows UIA, and matching on PID alone attaches to
 the host. The two fields are mutually exclusive — one widens what the other
 narrows.
 
-## Markers
+`attach_pid=N` attaches to an already-running process instead of launching
+one; the plugin never terminates a process it did not start.
 
-```python
-@pytest.mark.xa11y_requires("screenshot")   # or "input_sim"
-@pytest.mark.xa11y_frontmost                # claim the macOS front slot first
-```
+## Capabilities and markers
 
 Capability names are plain strings. `pytest_xa11y.Capability` is a `str` enum
 of the same values, for completion and type checking; `Capability.SCREENSHOT`
@@ -181,17 +157,6 @@ events.expect(("state_changed", "value_changed"), timeout=5.0)
 There is no `expect()` that means "the next event, whatever it is". A filter
 left off by accident would pass against anything that arrived; use
 `Subscription.recv` when that is genuinely what you want.
-
-## Options
-
-| Option | Default | Effect |
-| --- | --- | --- |
-| `--xa11y-timeout=SECONDS` | library default (5s) | Calls `xa11y.set_default_timeout()`. Outranks `XA11Y_DEFAULT_TIMEOUT`; a per-call `timeout=` still wins over both. |
-| `--xa11y-startup-timeout=SECONDS` | 30 | Waiting for the app to appear and become ready. |
-| `--xa11y-artifacts=DIR` | off | Save a screenshot of each failing test. |
-| `--xa11y-skip=CAPABILITY` | none | Declare a capability unavailable. Repeatable. |
-| `--xa11y-dump-depth=N` | 12 | Depth of the tree dump on failure. |
-| `--xa11y-max-diagnostics=N` | 10 | Cap diagnostics per run, so a wholesale failure does not bury its own report. |
 
 ## Suite-specific diagnostics
 

--- a/pytest-xa11y/pyproject.toml
+++ b/pytest-xa11y/pyproject.toml
@@ -46,7 +46,7 @@ xa11y = "pytest_xa11y.plugin"
 [project.urls]
 Homepage = "https://github.com/xa11y/xa11y"
 Repository = "https://github.com/xa11y/xa11y"
-Documentation = "https://xa11y.dev/guides/desktop-testing/"
+Documentation = "https://xa11y.dev/reference/pytest/"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pytest_xa11y"]

--- a/xa11y-python/README.md
+++ b/xa11y-python/README.md
@@ -40,6 +40,14 @@ pip install xa11y
 
 Requires Python 3.9+. Pre-built wheels available for Linux, macOS, and Windows.
 
+For pytest suites, [`pytest-xa11y`](https://xa11y.dev/reference/pytest/) adds
+fixtures that launch the app under test, capability markers that skip what the
+machine cannot do, and the accessibility tree on every failure:
+
+```bash
+pip install pytest-xa11y
+```
+
 > On **macOS**, grant your terminal **two** permissions in **System Settings > Privacy & Security**:
 > 1. **Accessibility**, required for all accessibility API access.
 > 2. **Screen & System Audio Recording** (macOS 26+), required to read window content. Without it, only menu bars are visible.


### PR DESCRIPTION
The plugin shipped in #357 with a thorough package README and almost no
presence anywhere else: no page on the docs site, no sidebar entry, no
mention in the root README, and a `Documentation` URL on PyPI pointing at
a guide that never lists an option or a marker.

Add `reference/pytest`, holding the fixtures, every `AppLauncher` field,
the markers and their collection-time validation, the command-line
options and environment variables, the failure-report sections, and the
`Capabilities`, `EventRecorder`, `AppSession` and exception surfaces that
`__init__` exports but nothing documented. The tables move there rather
than being copied: the package README keeps the narrative and the design
reasoning and links to the reference, so neither can drift.

Around it:

- sidebar entry under Reference, and a link from the desktop-testing
  guide, which had a short section and no onward path;
- a CI section covering the flags a runner needs — the startup timeout on
  a cold machine, artifact screenshots, and `--xa11y-skip=input_sim`,
  which macOS and Windows cannot probe for — plus the `pytest-xdist`
  worker skip, which silently drops the input and frontmost tests;
- an install line in the root README, which listed the three libraries
  and not the plugin;
- `Documentation` in `pyproject.toml` repointed at the new page.

AGENTS.md picks up `cargo xtask test-pytest-plugin` (it exists, runs in
`cargo xtask check`, and was unlisted) and the docs-site checks, and
loses the Project Structure list, which had already gone stale.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M2s9zAShat8UC6KXAhaqLY