### PR TITLE
MCP: expose accessibility events as a start/poll/stop tool trio

### DIFF
--- a/bindings/parity_allowlist.toml
+++ b/bindings/parity_allowlist.toml
@@ -147,7 +147,7 @@ files = [
 
 [[types.variant_coverage]]
 type = "EventKind"
-reason = "Each variant maps to a distinct event-type string in both bindings and in the CLI's `xa11y watch` output; an unmapped one would print as 'unknown'."
+reason = "Each variant maps to a distinct event-type string in both bindings and in the CLI's `xa11y watch` output; an unmapped one would print as 'unknown'. `xa11y/src/cli.rs` carries two lists that must grow together: `format_event_kind`'s arms and `event_kind_names`' KNOWN array, which is what MCP's events_start `kinds` filter validates against."
 files = [
     "xa11y-python/src/lib.rs",
     "xa11y-js/src/types.rs",
@@ -231,10 +231,11 @@ files = [
 
 [[types.variant_coverage]]
 type = "StateFlag"
-reason = "Each variant maps to a distinct state-name string in both bindings; an unmapped one would surface as 'unknown'."
+reason = "Each variant maps to a distinct state-name string in both bindings and in the CLI's `format_state_flag`, which MCP's events_poll reports as `state_flag`; an unmapped one would surface as 'unknown'."
 files = [
     "xa11y-python/src/lib.rs",
     "xa11y-js/src/types.rs",
+    "xa11y/src/cli.rs",
 ]
 
 # Types with no binding class of their own, whose members surface on another

--- a/docs/site/src/content/docs/guides/mcp.mdx
+++ b/docs/site/src/content/docs/guides/mcp.mdx
@@ -226,9 +226,43 @@ that matched too many lists what it matched, which is usually enough to fix the
 selector on the next call. See
 [Errors and diagnosis](/explanation/errors-and-diagnosis/).
 
+## Watch what an application does
+
+Reading the tree twice tells you what changed, not when. `events_start` opens
+a subscription to an application's accessibility events and returns a handle:
+
+```json
+{
+  "name": "events_start",
+  "arguments": { "app": "Calculator", "kinds": ["focus_changed", "value_changed"] }
+}
+```
+
+Events buffer from the moment that call returns, so open the subscription
+before the action you want to observe, act, then drain:
+
+```json
+{ "name": "events_poll", "arguments": { "subscription_id": "sub_1" } }
+```
+
+A poll returns the buffered events oldest first, each with its `kind`, a
+`sequence`, `at_ms` since the subscription started, and the `target` element in
+the shape `find` returns. It does not block by default, so an empty `events`
+means nothing has happened yet. Pass `timeout_ms` (up to 15000) to wait for the
+first event when you are expecting a specific one.
+
+Two fields say what the events cannot. `dropped` counts events lost to the
+buffer filling up since the previous poll: poll more often, narrow `kinds`, or
+accept the gap. `live: false` means the application is gone and no further
+event can arrive.
+
+Call `events_stop` when you are done. A subscription nobody polls for five
+minutes is reclaimed, and its handle then comes back as a
+`subscription_expired` failure.
+
 ## What is not there yet
 
-Event streaming has no tool. `xa11y events` blocks for as long as you watch,
-and a tool call that never returns hangs the client, so it needs a different
-shape — a handle from a start call, drained by a poll call. Until then, watch
-events from the [CLI](/reference/cli/#xa11y-events) or the library.
+Revision `2026-07-28` has `subscriptions/listen`, where the server pushes
+notifications instead of the model polling for them. That is the better shape
+for events, and the handle trio above is what works on every revision this
+server speaks, including the ones that have no such mechanism.

--- a/docs/site/src/content/docs/reference/cli.mdx
+++ b/docs/site/src/content/docs/reference/cli.mdx
@@ -358,6 +358,9 @@ gives it selectors to resolve.
 | `key` | `key`, `held` |
 | `type` | `text` |
 | `screenshot` | `x`, `y`, `width`, `height`, `annotate`, `app`, `pid`, `shell` |
+| `events_start` | `app`, `pid`, `kinds` |
+| `events_poll` | `subscription_id`, `max`, `timeout_ms` |
+| `events_stop` | `subscription_id` |
 
 `action` accepts the same verbs as [`xa11y action`](#xa11y-action). `key`
 accepts the same key names as [`xa11y key`](#input-simulation). Selectors are
@@ -397,8 +400,33 @@ and it is not a capability list: a slider that advertises nothing still
 increments. Pick the verb from the element's own properties — `numeric_value`
 for the value verbs, an `editable` state for the text verbs.
 
-Streaming events has no tool. A tool call that never returns would hang the
-client, so `xa11y events` has no MCP counterpart yet.
+### Events
+
+[`xa11y events`](#xa11y-events) blocks for as long as you watch, and a tool
+call that never returns hangs the client. The MCP counterpart is a trio
+instead: `events_start` returns a `subscription_id`, `events_poll` drains what
+has arrived, and `events_stop` closes it.
+
+Subscriptions are per application, so `events_start` takes `app` or `pid` and
+has no `shell` argument. `kinds` filters what gets buffered; the names are the
+ones in [Events](/reference/events/).
+
+Events buffer from the moment `events_start` returns, so a subscription has to
+exist before the action it is meant to observe. At most 1024 are held, and past
+that the oldest are evicted: `dropped` in each poll result counts what was lost
+since the previous poll, `dropped_total` over the subscription's life, and each
+event's `sequence` makes the gap visible in the events themselves.
+
+`events_poll` returns at most `max` events (100 by default) and does not block
+by default. A `timeout_ms` up to 15000 waits for the first event and returns as
+soon as one lands. `live: false` means the source is gone — the application
+exited, or the platform dropped the subscription — so nothing further can
+arrive.
+
+A handle lives in the server process and no longer. It stops resolving once
+`events_stop` closes it, or after five minutes without a poll. Either way the
+next call naming it is a `subscription_expired` failure, which is a different
+kind from the `subscription_not_found` an id that was never issued gets.
 
 ### Results
 

--- a/docs/site/src/content/docs/testing.mdx
+++ b/docs/site/src/content/docs/testing.mdx
@@ -28,7 +28,7 @@ JavaScript, and the CLI. Roughly:
 | Rust integration | ~150 | `xa11y/tests/integ/` | Live tree reads, action dispatch, events, screenshots against a running app |
 | Python binding unit | ~240 | `xa11y-python/tests/` | The PyO3 surface: types, actions, exceptions, GIL release, subscriptions |
 | Python integration | ~100 | `tests/suites/python/` | Per-app compat, actions, events, errors, input simulation, screenshots |
-| CLI integration | ~70 | `tests/suites/cli/` | The `xa11y` CLI end-to-end against running apps, plus the MCP server over every CLI launcher |
+| CLI integration | ~80 | `tests/suites/cli/` | The `xa11y` CLI end-to-end against running apps, plus the MCP server and its event subscriptions over every CLI launcher |
 | JavaScript unit | ~115 | `xa11y-js/__test__/unit/` | The napi-rs binding surface |
 | JavaScript integration | ~40 | `tests/suites/js/` | Per-app compat, actions, input simulation, screenshots |
 | MCP client interop | ~30 | `tests/mcp_client/` | `xa11y mcp` driven by the official MCP Python SDK, in both protocol eras |

--- a/tests/matrix.yaml
+++ b/tests/matrix.yaml
@@ -150,7 +150,7 @@ features:
       (rust_core).
 
   mcp:
-    description: "MCP stdio server: framing, dual-era handshake, tool schemas, tool contracts, and identical behaviour from all three CLI launchers"
+    description: "MCP stdio server: framing, dual-era handshake, tool schemas, tool contracts, event subscriptions, and identical behaviour from all three CLI launchers"
     per_app: false
     tested_on: [qt, gtk, cocoa, tauri, electron, egui, winforms, wpf]
     notes: >
@@ -175,6 +175,16 @@ features:
       matched several rather than acting on the first, `find` reporting the
       near misses it did see, and `set-numeric-value` moving a slider in one
       call. Each skips on an app that lacks the widget it needs.
+      The `events_start` / `events_poll` / `events_stop` trio is covered the
+      same way, split by what is platform-independent. The handle lifecycle —
+      a handle is issued, resolves while open, and reports `subscription_expired`
+      once stopped — asserts strictly on every cell. Whether an event actually
+      *arrives* after an action does not: bridge delivery for programmatic
+      actions is unreliable on several app/platform combinations (see the
+      per-combo markers in tests/suites/python/test_events.py), so that one
+      test carries a non-strict xfail. Buffer bounds, drop accounting and
+      expiry are unit-tested in xa11y/src/mcp/events.rs, which needs no
+      display: the registry is driven by a plain channel.
       Separately, tests/mcp_client/ drives the server with the official MCP
       Python SDK in both protocol eras, on ubuntu-latest only (the `mcp-client`
       CI job). It is not per-app and needs no display: the server is

--- a/tests/matrix.yaml
+++ b/tests/matrix.yaml
@@ -178,13 +178,19 @@ features:
       The `events_start` / `events_poll` / `events_stop` trio is covered the
       same way, split by what is platform-independent. The handle lifecycle —
       a handle is issued, resolves while open, and reports `subscription_expired`
-      once stopped — asserts strictly on every cell. Whether an event actually
-      *arrives* after an action does not: bridge delivery for programmatic
-      actions is unreliable on several app/platform combinations (see the
-      per-combo markers in tests/suites/python/test_events.py), so that one
-      test carries a non-strict xfail. Buffer bounds, drop accounting and
-      expiry are unit-tested in xa11y/src/mcp/events.rs, which needs no
-      display: the registry is driven by a plain channel.
+      once stopped — asserts strictly on every cell.
+      Whether an event *arrives* after an action is a platform question, and
+      delivery for programmatic actions is unreliable on several app/platform
+      combinations (see the per-combo markers in
+      tests/suites/python/test_events.py). Rather than xfail around that, which
+      would assert nothing in either direction, the test runs a control: xa11y's
+      own subscription, opened from the pytest process, watches the same app
+      through the same bridge, and the assertion is that an event the library
+      received also reached the MCP poll. It skips only when the bridge
+      delivered to neither, where there was nothing for MCP to lose.
+      Buffer bounds, drop accounting and expiry are unit-tested in
+      xa11y/src/mcp/events.rs, which needs no display: the registry is driven
+      by a plain channel.
       Separately, tests/mcp_client/ drives the server with the official MCP
       Python SDK in both protocol eras, on ubuntu-latest only (the `mcp-client`
       CI job). It is not per-app and needs no display: the server is

--- a/tests/mcp_client/test_interop.py
+++ b/tests/mcp_client/test_interop.py
@@ -40,6 +40,9 @@ EXPECTED_TOOLS = [
     "key",
     "type",
     "screenshot",
+    "events_start",
+    "events_poll",
+    "events_stop",
 ]
 
 # Every `ShellSurfaceKind` spelling, as `shell` reports them and the `shell`
@@ -436,6 +439,63 @@ def test_a_target_without_annotate_is_refused_rather_than_captured_full_screen(r
             assert key in message, f"{arguments}: {key} unnamed in {message}"
         assert "annotate" in message, message
         assert "plain capture" in message, message
+
+
+# ── Event subscriptions ──────────────────────────────────────────────────────
+
+
+def test_the_event_tools_round_trip_a_handle_through_a_real_client(run_client):
+    """The stateful-tools shape end to end, with no display and no app.
+
+    `events_start` cannot open a subscription here — there is nothing to
+    watch — so this drives the half that does not need one: an id the server
+    never issued has to come back as a tool error the model can act on, with
+    the open handles named.
+    """
+    result = run_client(
+        lambda c: c.call_tool("events_poll", {"subscription_id": "sub_1"})
+    )
+    assert result.is_error is True
+    structured = result.structured_content
+    assert structured["kind"] in {"subscription_expired", "subscription_not_found"}
+    assert structured["subscription_id"] == "sub_1"
+    assert structured["live_subscriptions"] == []
+
+
+def test_the_event_tools_declare_the_arguments_a_client_validates(run_client):
+    start = _tool(run_client, "events_start")
+    assert "shell" not in start.input_schema["properties"], (
+        "events are subscribed per application"
+    )
+    kinds = start.input_schema["properties"]["kinds"]
+    assert "focus_changed" in kinds["items"]["enum"]
+
+    poll = _tool(run_client, "events_poll")
+    assert poll.input_schema["required"] == ["subscription_id"]
+    assert poll.input_schema["properties"]["timeout_ms"]["maximum"] == 15000
+
+
+def test_events_start_states_its_handles_retention(run_client):
+    """The spec asks a stateful tool to say how long its handle lives."""
+    description = _tool(run_client, "events_start").description
+    assert "reclaimed after" in description
+    assert "subscription_expired" in description
+
+
+def test_a_poll_with_a_bad_timeout_is_refused_rather_than_clamped(run_client):
+    result = run_client(
+        lambda c: c.call_tool(
+            "events_poll", {"subscription_id": "sub_1", "timeout_ms": 600000}
+        )
+    )
+    assert result.is_error is True
+    assert result.structured_content["kind"] == "invalid_arguments"
+
+
+def test_the_instructions_mention_watching_events(run_client):
+    """A model that never learns the trio exists polls the tree instead."""
+    instructions = run_client(lambda c: _identity(c.instructions))
+    assert "events_start" in instructions
 
 
 def test_the_instructions_mention_the_shell_surfaces(run_client):

--- a/tests/suites/cli/test_mcp.py
+++ b/tests/suites/cli/test_mcp.py
@@ -271,6 +271,9 @@ def test_tools_list_is_complete_and_deterministic(mcp):
         "key",
         "type",
         "screenshot",
+        "events_start",
+        "events_poll",
+        "events_stop",
     ]
 
 
@@ -1154,3 +1157,163 @@ def test_a_missing_shell_surface_is_an_operation_failure_not_a_usage_error(entry
     result = _run(entry_point, "find", "*", "--shell", absent[0])
     assert result.returncode == 1, result.stdout
     assert absent[0] in result.stderr, result.stderr
+
+
+# ── Event subscriptions ──────────────────────────────────────────────────────
+#
+# The lifecycle is protocol, not platform: a handle is issued, resolves while
+# it is open, and stops resolving once it is closed. Those tests assert
+# strictly everywhere.
+#
+# Whether an event *arrives* is a different question. Bridge delivery for
+# programmatic actions is unreliable on several app/platform combinations —
+# tests/suites/python/test_events.py documents which — so the one test that
+# waits for an event carries the same non-strict xfail rather than pretending
+# the MCP layer can make a bridge emit what it does not emit.
+
+TEST_APP = os.environ.get("XA11Y_TEST_APP", "tauri")
+
+
+@pytest.fixture
+def subscription(mcp, app_pid):
+    """An open subscription on the test app, closed however the test ends."""
+    started = mcp.call_tool("events_start", {"pid": app_pid})["result"]
+    assert started["isError"] is False, started["content"]
+    handle = started["structuredContent"]["subscription_id"]
+    try:
+        yield handle
+    finally:
+        mcp.call_tool("events_stop", {"subscription_id": handle}, id_=98)
+
+
+def test_events_start_hands_out_a_handle_with_its_limits(mcp, app_pid):
+    """A model has to know the buffer size and the retention to poll sanely."""
+    started = mcp.call_tool("events_start", {"pid": app_pid})["result"]
+    assert started["isError"] is False, started["content"]
+    structured = started["structuredContent"]
+    assert structured["subscription_id"]
+    assert structured["pid"] == app_pid
+    assert structured["kinds"] is None, "no filter means every kind"
+    assert structured["buffer_capacity"] > 0
+    assert structured["expires_after_ms"] > 0
+    mcp.call_tool(
+        "events_stop", {"subscription_id": structured["subscription_id"]}, id_=98
+    )
+
+
+def test_an_idle_poll_is_an_empty_result_not_a_failure(mcp, subscription):
+    """An empty `events` must not read as a broken subscription."""
+    result = mcp.call_tool("events_poll", {"subscription_id": subscription})["result"]
+    assert result["isError"] is False, result["content"]
+    structured = result["structuredContent"]
+    assert structured["subscription_id"] == subscription
+    assert isinstance(structured["events"], list)
+    assert structured["dropped"] == 0
+    assert structured["live"] is True, "the application is still running"
+
+
+def test_a_blocking_poll_returns_within_its_timeout(mcp, subscription):
+    """The cap exists because the session loop handles one message at a time."""
+    start = time.monotonic()
+    result = mcp.call_tool(
+        "events_poll", {"subscription_id": subscription, "timeout_ms": 500}
+    )["result"]
+    elapsed = time.monotonic() - start
+    assert result["isError"] is False, result["content"]
+    assert elapsed < 20, f"a 500ms poll took {elapsed:.1f}s"
+
+
+def test_a_stopped_handle_reports_expiry_rather_than_a_generic_miss(mcp, app_pid):
+    """The two misses have different recoveries, so they are different kinds."""
+    started = mcp.call_tool("events_start", {"pid": app_pid})["result"]
+    handle = started["structuredContent"]["subscription_id"]
+
+    stopped = mcp.call_tool("events_stop", {"subscription_id": handle})["result"]
+    assert stopped["isError"] is False, stopped["content"]
+    assert stopped["structuredContent"]["stopped"] is True
+
+    after = mcp.call_tool("events_poll", {"subscription_id": handle})["result"]
+    assert after["isError"] is True
+    assert after["structuredContent"]["kind"] == "subscription_expired"
+    assert after["structuredContent"]["subscription_id"] == handle
+
+
+def test_a_handle_that_was_never_issued_is_a_different_kind(mcp):
+    result = mcp.call_tool("events_poll", {"subscription_id": "sub_nonexistent"})["result"]
+    assert result["isError"] is True
+    assert result["structuredContent"]["kind"] == "subscription_not_found"
+    assert "live_subscriptions" in result["structuredContent"], (
+        "the open handles are what a model needs to recover"
+    )
+
+
+def test_events_are_subscribed_per_application_not_per_surface(mcp):
+    """`shell` is absent from the schema and refused with the reason."""
+    schema = None
+    for tool in mcp.request(1, "tools/list")["result"]["tools"]:
+        if tool["name"] == "events_start":
+            schema = tool["inputSchema"]
+    assert schema is not None
+    assert "shell" not in schema["properties"]
+
+    result = mcp.call_tool("events_start", {"shell": "taskbar"})["result"]
+    assert result["isError"] is True
+    assert result["structuredContent"]["kind"] == "invalid_arguments"
+    assert "per application" in result["structuredContent"]["message"]
+
+
+def test_an_unknown_event_kind_is_refused_with_the_names_that_exist(mcp):
+    """Accepting it would look exactly like an application that emits nothing.
+
+    No application is named, and the answer is still about `kinds`: the
+    arguments are parsed before anything reaches the accessibility layer, so a
+    bad filter cannot leave a subscription open behind it.
+    """
+    result = mcp.call_tool(
+        "events_start", {"app": "NoSuchApplicationHere", "kinds": ["focus_change"]}
+    )["result"]
+    assert result["isError"] is True
+    assert result["structuredContent"]["kind"] == "invalid_arguments"
+    assert "focus_change" in result["structuredContent"]["message"]
+    assert "focus_changed" in result["structuredContent"]["message"]
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Accessibility-event delivery for programmatic actions is unreliable "
+        "on several app/platform combinations (see the per-combo markers in "
+        "tests/suites/python/test_events.py). The subscription plumbing is "
+        "asserted strictly by the tests above; this one asserts that an event "
+        "the bridge does emit reaches a poll."
+    ),
+    strict=False,
+)
+def test_an_action_reaches_a_poll_as_a_shaped_event(mcp, app_pid):
+    """Start, act, poll — the order the tool descriptions tell a model to use."""
+    started = mcp.call_tool("events_start", {"pid": app_pid})["result"]
+    handle = started["structuredContent"]["subscription_id"]
+    try:
+        acted = mcp.call_tool(
+            "action", {"action": "focus", "selector": "button", "pid": app_pid}
+        )["result"]
+        if acted["isError"]:
+            pytest.skip(f"the {TEST_APP} app has no focusable button to drive")
+
+        events = []
+        deadline = time.monotonic() + 10
+        while not events and time.monotonic() < deadline:
+            polled = mcp.call_tool(
+                "events_poll", {"subscription_id": handle, "timeout_ms": 2000}
+            )["result"]
+            assert polled["isError"] is False, polled["content"]
+            events = polled["structuredContent"]["events"]
+
+        assert events, "no event arrived within 10s of a focus action"
+        first = events[0]
+        assert first["kind"], "every event names its kind"
+        assert first["sequence"] == 0, "the first event of a subscription is 0"
+        assert "at_ms" in first
+        if "target" in first:
+            assert first["target"]["role"], "a target is shaped like a find match"
+    finally:
+        mcp.call_tool("events_stop", {"subscription_id": handle}, id_=98)

--- a/tests/suites/cli/test_mcp.py
+++ b/tests/suites/cli/test_mcp.py
@@ -1165,13 +1165,24 @@ def test_a_missing_shell_surface_is_an_operation_failure_not_a_usage_error(entry
 # it is open, and stops resolving once it is closed. Those tests assert
 # strictly everywhere.
 #
-# Whether an event *arrives* is a different question. Bridge delivery for
+# Whether an event *arrives* is a platform question. Bridge delivery for
 # programmatic actions is unreliable on several app/platform combinations —
-# tests/suites/python/test_events.py documents which — so the one test that
-# waits for an event carries the same non-strict xfail rather than pretending
-# the MCP layer can make a bridge emit what it does not emit.
+# tests/suites/python/test_events.py documents which — so a bare "an event
+# shows up" assertion would flake, and an xfail around it would assert
+# nothing in either direction.
+#
+# The way out is a control. xa11y's own subscription, from this process,
+# watches the same application through the same bridge, and the test compares
+# the two: an event the library received and the MCP registry did not is a
+# defect in this layer, which is the only defect this layer can have. When the
+# bridge delivers to neither, there was nothing to carry and the test says so.
 
 TEST_APP = os.environ.get("XA11Y_TEST_APP", "tauri")
+
+# Longest the two subscribers are given to see the same action. Generous
+# because it is a failure deadline, not a wait: a delivering bridge answers in
+# well under a second.
+EVENT_DEADLINE = 15.0
 
 
 @pytest.fixture
@@ -1278,41 +1289,77 @@ def test_an_unknown_event_kind_is_refused_with_the_names_that_exist(mcp):
     assert "focus_changed" in result["structuredContent"]["message"]
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Accessibility-event delivery for programmatic actions is unreliable "
-        "on several app/platform combinations (see the per-combo markers in "
-        "tests/suites/python/test_events.py). The subscription plumbing is "
-        "asserted strictly by the tests above; this one asserts that an event "
-        "the bridge does emit reaches a poll."
-    ),
-    strict=False,
-)
-def test_an_action_reaches_a_poll_as_a_shaped_event(mcp, app_pid):
-    """Start, act, poll — the order the tool descriptions tell a model to use."""
+@pytest.fixture
+def library_subscription(app):
+    """A second subscriber on the same application, from this process.
+
+    xa11y's own subscription, opened through the library rather than through
+    MCP, and living in a different process from the server's. It is the
+    control for `test_an_action_reaches_a_poll_as_a_shaped_event`.
+    """
+    with app.subscribe() as subscription:
+        yield subscription
+
+
+def test_an_action_reaches_a_poll_as_a_shaped_event(
+    mcp, app_pid, library_subscription
+):
+    """Whatever xa11y's own subscription receives, a poll has to receive too.
+
+    Start, act, poll — the order the tool descriptions tell a model to use.
+    Both subscribers are open before the action, and the assertion is
+    conditional on the control rather than on the platform: if the library
+    saw an event and the MCP registry did not, this layer dropped it.
+    """
     started = mcp.call_tool("events_start", {"pid": app_pid})["result"]
+    assert started["isError"] is False, started["content"]
     handle = started["structuredContent"]["subscription_id"]
     try:
+        # `OK` is the one button every test app has, and pressing it by name
+        # is what `test_action_presses_a_button` already does on all of them.
         acted = mcp.call_tool(
-            "action", {"action": "focus", "selector": "button", "pid": app_pid}
+            "action",
+            {"action": "press", "selector": 'button[name="OK"]', "pid": app_pid},
         )["result"]
         if acted["isError"]:
-            pytest.skip(f"the {TEST_APP} app has no focusable button to drive")
+            pytest.skip(f"the {TEST_APP} app did not accept a press on OK: {acted}")
 
-        events = []
-        deadline = time.monotonic() + 10
-        while not events and time.monotonic() < deadline:
+        library_events = []
+        mcp_events = []
+        deadline = time.monotonic() + EVENT_DEADLINE
+        while time.monotonic() < deadline and not (library_events and mcp_events):
+            event = library_subscription.try_recv()
+            if event is not None:
+                library_events.append(event)
             polled = mcp.call_tool(
-                "events_poll", {"subscription_id": handle, "timeout_ms": 2000}
+                "events_poll", {"subscription_id": handle, "timeout_ms": 250}
             )["result"]
             assert polled["isError"] is False, polled["content"]
-            events = polled["structuredContent"]["events"]
+            structured = polled["structuredContent"]
+            assert structured["dropped"] == 0, "a handful of events cannot overflow"
+            mcp_events.extend(structured["events"])
 
-        assert events, "no event arrived within 10s of a focus action"
-        first = events[0]
+        if not library_events:
+            pytest.skip(
+                f"the bridge delivered no event to xa11y's own subscription "
+                f"either, so there was nothing for MCP to carry ({TEST_APP} on "
+                f"{sys.platform}; tests/suites/python/test_events.py records "
+                f"which combinations deliver)"
+            )
+        assert mcp_events, (
+            f"xa11y's own subscription received {len(library_events)} event(s) "
+            f"from this action and the MCP subscription received none"
+        )
+
+        first = mcp_events[0]
         assert first["kind"], "every event names its kind"
         assert first["sequence"] == 0, "the first event of a subscription is 0"
-        assert "at_ms" in first
+        assert isinstance(first["at_ms"], int)
+        # The originating process as the backend reported it, which is not
+        # asserted equal to `app_pid`: that is the backend's business, and a
+        # disagreement there would be a finding about the provider rather than
+        # about this layer.
+        assert isinstance(first["pid"], int), "an event names where it came from"
         if "target" in first:
             assert first["target"]["role"], "a target is shaped like a find match"
     finally:

--- a/xa11y/src/cli.rs
+++ b/xa11y/src/cli.rs
@@ -60,6 +60,27 @@ pub enum CliError {
         /// Candidate list and what was observed.
         diagnosis: Box<Diagnosis>,
     },
+    /// An MCP event-subscription handle could not be resolved — exit code 1.
+    ///
+    /// Constructed by the `events_poll` / `events_stop` tools. MCP has no
+    /// protocol-level session, so a subscription is addressed by an opaque
+    /// handle, and a handle can miss for two reasons a model must tell apart:
+    /// it was issued and is now closed — stopped, or reclaimed for idling —
+    /// in which case starting another one works; or it was never issued, in
+    /// which case the id itself is wrong. `expired` carries that distinction
+    /// and `failure_kind` maps the two to separate tags.
+    ///
+    /// `live` names the handles that *are* open, so the recovery is readable
+    /// straight off the error rather than requiring another call (tenet 6).
+    NoSubscription {
+        /// The handle the caller passed.
+        id: String,
+        /// Whether this handle was issued and later reclaimed for idling, as
+        /// opposed to never having been issued at all.
+        expired: bool,
+        /// Handles that are open right now, in issue order.
+        live: Vec<String>,
+    },
     /// An underlying xa11y operation failed — exit code 1.
     Xa11y(Error),
 }
@@ -72,6 +93,7 @@ impl CliError {
             CliError::NotFound(_)
             | CliError::Ambiguous { .. }
             | CliError::AmbiguousShellSurface { .. }
+            | CliError::NoSubscription { .. }
             | CliError::Xa11y(_) => 1,
         }
     }
@@ -101,6 +123,26 @@ impl std::fmt::Display for CliError {
                  operation targets exactly one; pick one by process id — `--pid PID` on \
                  the command line, the `pid` argument in MCP{diagnosis}"
             ),
+            CliError::NoSubscription { id, expired, live } => {
+                let cause = if *expired {
+                    "is no longer open: `events_stop` closed it, or it expired \
+                     after idling past the retention window `events_start` \
+                     reported as `expires_after_ms`"
+                } else {
+                    "is not a handle this server issued: check the id against \
+                     what `events_start` returned"
+                };
+                let open = if live.is_empty() {
+                    "no subscriptions are open".to_string()
+                } else {
+                    format!("open subscriptions: {}", live.join(", "))
+                };
+                write!(
+                    f,
+                    "subscription \"{id}\" {cause}. Start another with \
+                     `events_start`; {open}"
+                )
+            }
             CliError::Xa11y(e) => write!(f, "{e}"),
         }
     }
@@ -1310,6 +1352,76 @@ pub(crate) fn format_event_kind(kind: &EventKind) -> &'static str {
     }
 }
 
+/// Every spelling [`format_event_kind`] can produce, for MCP's `events_start`
+/// `kinds` filter to validate a requested name against.
+///
+/// Derived by running the formatter over one value of each variant rather than
+/// written out a second time, so the filter cannot advertise a name the
+/// formatter never emits, and cannot spell one differently.
+///
+/// What it cannot do is notice a variant missing from `KNOWN` below.
+/// [`EventKind`] is `#[non_exhaustive]`, so a `match` here would compile with
+/// a `_` arm just as `format_event_kind` does, and there is nothing to
+/// enumerate the variants at runtime. The guards are the
+/// `[[types.variant_coverage]]` entry for `EventKind`, which requires this
+/// file to name every variant, and
+/// `every_advertised_event_kind_name_round_trips`, which fails if an entry
+/// here formats as `unknown` or repeats another. **A new variant belongs in
+/// both `format_event_kind` and `KNOWN`.**
+pub(crate) fn event_kind_names() -> &'static [&'static str] {
+    /// One value per variant. `StateChanged`'s payload is arbitrary: only the
+    /// variant reaches `format_event_kind`.
+    const KNOWN: &[EventKind] = &[
+        EventKind::FocusChanged,
+        EventKind::ValueChanged,
+        EventKind::NameChanged,
+        EventKind::StateChanged {
+            flag: StateFlag::Enabled,
+            value: true,
+        },
+        EventKind::StructureChanged,
+        EventKind::WindowOpened,
+        EventKind::WindowClosed,
+        EventKind::WindowActivated,
+        EventKind::WindowDeactivated,
+        EventKind::SelectionChanged,
+        EventKind::MenuOpened,
+        EventKind::MenuClosed,
+        EventKind::TextChanged,
+        EventKind::Announcement,
+    ];
+    static NAMES: std::sync::LazyLock<Vec<&'static str>> =
+        std::sync::LazyLock::new(|| KNOWN.iter().map(format_event_kind).collect());
+    NAMES.as_slice()
+}
+
+/// snake_case name for a state flag, matching the spelling both bindings use
+/// for `Event.state_flag` and the one `states` uses in element payloads.
+///
+/// Hand-mapped rather than derived from `Debug`, which would render a future
+/// multi-word variant as one lowercase run. `[[types.variant_coverage]]` lists
+/// this file for `StateFlag` so a new variant cannot quietly reach a client as
+/// `unknown`.
+pub(crate) fn format_state_flag(flag: StateFlag) -> &'static str {
+    match flag {
+        StateFlag::Enabled => "enabled",
+        StateFlag::Visible => "visible",
+        StateFlag::Focused => "focused",
+        StateFlag::Checked => "checked",
+        StateFlag::Selected => "selected",
+        StateFlag::Expanded => "expanded",
+        StateFlag::Editable => "editable",
+        StateFlag::Focusable => "focusable",
+        StateFlag::Modal => "modal",
+        StateFlag::Required => "required",
+        StateFlag::Busy => "busy",
+        // `StateFlag` is `#[non_exhaustive]`. Same reasoning as
+        // `format_event_kind`: naming the flag vaguely beats dropping the
+        // event that carries it.
+        _ => "unknown",
+    }
+}
+
 pub(crate) fn format_event_detail(event: &Event) -> String {
     if let EventKind::StateChanged { flag, value } = event.kind {
         format!(" {flag:?}={value}")
@@ -2370,6 +2482,56 @@ mod tests {
             "state_changed"
         );
         assert_eq!(format_event_kind(&EventKind::Announcement), "announcement");
+    }
+
+    #[test]
+    fn every_advertised_event_kind_name_round_trips() {
+        // `event_kind_names` is what MCP's `kinds` filter validates against.
+        // A name that formats as "unknown" would be advertised and never
+        // match; a repeat would mean two variants collapsed onto one spelling.
+        let names = event_kind_names();
+        assert!(!names.contains(&"unknown"), "{names:?}");
+        let mut sorted = names.to_vec();
+        sorted.sort_unstable();
+        let before = sorted.len();
+        sorted.dedup();
+        assert_eq!(before, sorted.len(), "duplicate spelling in {names:?}");
+        assert!(names.contains(&"focus_changed"));
+        assert!(names.contains(&"state_changed"));
+    }
+
+    #[test]
+    fn state_flags_are_snake_case_and_match_the_binding_spellings() {
+        assert_eq!(format_state_flag(StateFlag::Checked), "checked");
+        assert_eq!(format_state_flag(StateFlag::Focusable), "focusable");
+    }
+
+    #[test]
+    fn a_missing_subscription_says_which_kind_of_miss_and_what_is_open() {
+        // Tenet 6: the recovery is readable off the error rather than needing
+        // another call to discover.
+        let expired = CliError::NoSubscription {
+            id: "sub_1".into(),
+            expired: true,
+            live: vec!["sub_2".into(), "sub_3".into()],
+        };
+        let text = expired.to_string();
+        assert!(text.contains("sub_1"), "{text}");
+        assert!(text.contains("expired"), "{text}");
+        assert!(text.contains("sub_2, sub_3"), "{text}");
+        assert_eq!(expired.exit_code(), 1);
+
+        let unknown = CliError::NoSubscription {
+            id: "sub_9".into(),
+            expired: false,
+            live: Vec::new(),
+        }
+        .to_string();
+        assert!(unknown.contains("not a handle this server issued"), "{unknown}");
+        assert!(
+            unknown.contains("no subscriptions are open"),
+            "an empty list still has to read as a sentence: {unknown}"
+        );
     }
 
     #[test]

--- a/xa11y/src/cli.rs
+++ b/xa11y/src/cli.rs
@@ -2527,7 +2527,10 @@ mod tests {
             live: Vec::new(),
         }
         .to_string();
-        assert!(unknown.contains("not a handle this server issued"), "{unknown}");
+        assert!(
+            unknown.contains("not a handle this server issued"),
+            "{unknown}"
+        );
         assert!(
             unknown.contains("no subscriptions are open"),
             "an empty list still has to read as a sentence: {unknown}"

--- a/xa11y/src/mcp/events.rs
+++ b/xa11y/src/mcp/events.rs
@@ -1,0 +1,954 @@
+//! Live event subscriptions, held across tool calls.
+//!
+//! `xa11y events` blocks for as long as you watch it. A `tools/call` that
+//! never returns hangs the client, so the operation cannot be one tool: it is
+//! a start / poll / stop trio, following the MCP specification's [Stateful
+//! Tools] guidance — a creation tool returns an opaque handle, later calls
+//! take it as an argument.
+//!
+//! [Stateful Tools]: https://modelcontextprotocol.io/specification/2026-07-28/server/tools#stateful-tools
+//!
+//! # What the registry has to solve
+//!
+//! A [`Subscription`] is a channel that fills whether or not anyone is
+//! reading, and `Send` but not `Sync` — it cannot be shared between a tool
+//! call and whatever delivers events. So each subscription gets one drainer
+//! thread that owns it and moves events into a bounded ring buffer:
+//!
+//! - **Bounded**, because nothing else limits how far behind a model may fall.
+//!   A chatty application emits thousands of events a minute, and holding all
+//!   of them to hand over eventually is a memory leak with a delay on it.
+//! - **Reported**, because an event stream that silently loses entries is
+//!   worse than one that says it lost forty (tenet 1). Every poll carries
+//!   `dropped` since the last poll and `dropped_total`, and each event carries
+//!   a `sequence` so a gap is visible in the events themselves.
+//! - **Oldest-first eviction**, because the newest events describe the UI as
+//!   it is now, which is what the caller is polling for.
+//!
+//! The thread also gives the poll its long-poll: it signals a condition
+//! variable, so a poll with a `timeout_ms` wakes on the first event rather
+//! than sleeping out its whole timeout.
+//!
+//! # Lifetime
+//!
+//! Nothing in MCP tells a server that a client lost interest in a handle, so
+//! subscriptions expire: [`EXPIRY`] without a poll and the next tool call
+//! reclaims it. `events_start` states the window in its description and
+//! reports it as `expires_after_ms`, and a reclaimed handle comes back as
+//! [`CliError::NoSubscription`] with `expired: true`, which is a different
+//! failure kind from an id that was never issued.
+//!
+//! Handles never outlive the process. stdio is one server per client, so the
+//! session *is* the process: when it ends, [`Registry`] drops, every drainer
+//! stops, and every platform subscription is cancelled.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Map, Value};
+
+use super::tools::element_data_json;
+use crate::cli::{format_event_kind, format_state_flag, CliError, CliResult};
+use crate::{Event, EventKind, RecvStatus, Subscription};
+
+/// Events held per subscription before the oldest are evicted.
+///
+/// One `Event` carries an `ElementData` snapshot, so this is a few hundred
+/// kilobytes for a subscription nobody is draining — bounded, and small
+/// beside the tree a single `tree` call builds.
+pub(super) const BUFFER_CAPACITY: usize = 1_024;
+
+/// Idle time after which a subscription is reclaimed.
+///
+/// Long enough that a model can think between polls, short enough that a
+/// client which walked away does not leave a platform subscription running
+/// for the life of the process.
+pub(super) const EXPIRY: Duration = Duration::from_secs(300);
+
+/// How often the drainer re-checks its stop flag while waiting for an event.
+const DRAIN_TICK: Duration = Duration::from_millis(100);
+
+/// One buffered event, with the ordering data the poll result reports.
+struct Buffered {
+    /// Monotonic per subscription, assigned before any eviction, so a gap in
+    /// the sequence is exactly the events that were dropped.
+    sequence: u64,
+    /// Milliseconds between the subscription starting and this event arriving.
+    ///
+    /// Relative because `Event::timestamp` is an [`Instant`], which has no
+    /// wall-clock rendering — and relative is what a caller wants anyway:
+    /// monotonic, immune to clock changes, and directly comparable between
+    /// two events of one subscription.
+    at_ms: u64,
+    event: Event,
+}
+
+/// The buffer, shared between the drainer thread and the polling tool call.
+struct Queue {
+    events: VecDeque<Buffered>,
+    /// Dropped since the last poll read it. Reset on each poll.
+    dropped_since_poll: u64,
+    /// Dropped over the life of the subscription.
+    dropped_total: u64,
+    /// Handed to the caller over the life of the subscription.
+    delivered: u64,
+    next_sequence: u64,
+    /// False once the event source disconnected — no further event can
+    /// arrive, so a caller can stop polling instead of burning calls.
+    live: bool,
+    /// Set by [`Entry::shut_down`] to end the drainer.
+    stopping: bool,
+}
+
+/// Everything the drainer and the tool call share.
+struct Shared {
+    queue: Mutex<Queue>,
+    /// Signalled when an event lands or the stream ends, so a long poll wakes
+    /// on the first event rather than sleeping out its timeout.
+    ready: Condvar,
+}
+
+impl Shared {
+    /// Lock the queue, recovering from a poisoned mutex (tenet 4).
+    ///
+    /// A panic in the drainer would poison this, and the queue is a buffer:
+    /// the worst case is that the events already in it are handed over after
+    /// a panic that had nothing to do with them.
+    fn queue(&self) -> std::sync::MutexGuard<'_, Queue> {
+        self.queue.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+/// One open subscription.
+struct Entry {
+    id: String,
+    app_name: String,
+    app_pid: Option<u32>,
+    last_poll: Mutex<Instant>,
+    shared: Arc<Shared>,
+    drainer: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl Entry {
+    fn touch(&self) {
+        *self.last_poll.lock().unwrap_or_else(|e| e.into_inner()) = Instant::now();
+    }
+
+    fn idle_for(&self) -> Duration {
+        self.last_poll
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .elapsed()
+    }
+
+    /// Stop the drainer and wait for it to release the platform subscription.
+    ///
+    /// The join is bounded by [`DRAIN_TICK`]: the drainer blocks for at most
+    /// that long between stop-flag checks.
+    fn shut_down(&self) {
+        {
+            let mut queue = self.shared.queue();
+            queue.stopping = true;
+            queue.live = false;
+        }
+        self.shared.ready.notify_all();
+        let handle = self
+            .drainer
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+        if let Some(handle) = handle {
+            // A panicked drainer is already gone; there is nothing to report
+            // to a caller who asked us to stop it.
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for Entry {
+    fn drop(&mut self) {
+        self.shut_down();
+    }
+}
+
+/// Every open subscription in this session.
+///
+/// Held by the tool host, so it lives exactly as long as the process — which
+/// on stdio is exactly as long as the client's session.
+pub(super) struct Registry {
+    subs: Mutex<Vec<Arc<Entry>>>,
+    next_id: AtomicU64,
+}
+
+impl Registry {
+    pub(super) fn new() -> Self {
+        Self {
+            subs: Mutex::new(Vec::new()),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    fn subs(&self) -> std::sync::MutexGuard<'_, Vec<Arc<Entry>>> {
+        self.subs.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Start draining `sub` and return the handle result.
+    ///
+    /// `kinds` filters at the drainer rather than at the poll, so a filtered
+    /// subscription's buffer holds only what was asked for — which is the
+    /// point of the filter on a noisy application.
+    pub(super) fn start(
+        &self,
+        app_name: &str,
+        app_pid: Option<u32>,
+        sub: Subscription,
+        kinds: Option<Vec<String>>,
+    ) -> CliResult<Value> {
+        self.sweep();
+        let id = format!("sub_{}", self.next_id.fetch_add(1, Ordering::Relaxed));
+        let shared = Arc::new(Shared {
+            queue: Mutex::new(Queue {
+                events: VecDeque::with_capacity(64),
+                dropped_since_poll: 0,
+                dropped_total: 0,
+                delivered: 0,
+                next_sequence: 0,
+                live: true,
+                stopping: false,
+            }),
+            ready: Condvar::new(),
+        });
+        let started = Instant::now();
+        let drainer = spawn_drainer(Arc::clone(&shared), sub, kinds.clone(), started)?;
+
+        let entry = Arc::new(Entry {
+            id: id.clone(),
+            app_name: app_name.to_string(),
+            app_pid,
+            last_poll: Mutex::new(started),
+            shared,
+            drainer: Mutex::new(Some(drainer)),
+        });
+        self.subs().push(entry);
+
+        Ok(json!({
+            "subscription_id": id,
+            "application": app_name,
+            "pid": app_pid,
+            "kinds": kinds,
+            "buffer_capacity": BUFFER_CAPACITY,
+            "expires_after_ms": EXPIRY.as_millis() as u64,
+        }))
+    }
+
+    /// Hand over up to `max` buffered events, waiting up to `timeout` for the
+    /// first one.
+    pub(super) fn poll(&self, id: &str, max: usize, timeout: Duration) -> CliResult<Value> {
+        self.sweep();
+        let entry = self.lookup(id)?;
+        entry.touch();
+
+        let mut queue = entry.shared.queue();
+        if queue.events.is_empty() && !timeout.is_zero() {
+            let deadline = Instant::now() + timeout;
+            // Condvar wakeups are not guaranteed to mean progress, so the
+            // wait is a loop over the real condition and the real deadline.
+            while queue.events.is_empty() && queue.live {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                let (next, _) = entry
+                    .shared
+                    .ready
+                    .wait_timeout(queue, remaining)
+                    .unwrap_or_else(|e| e.into_inner());
+                queue = next;
+            }
+        }
+
+        let take = queue.events.len().min(max);
+        let taken: Vec<Buffered> = queue.events.drain(..take).collect();
+        let dropped = std::mem::take(&mut queue.dropped_since_poll);
+        queue.delivered += taken.len() as u64;
+        let buffered = queue.events.len();
+        let live = queue.live;
+        let dropped_total = queue.dropped_total;
+        drop(queue);
+
+        // Refresh the idle clock *after* the wait, so a long poll is not
+        // charged for the time it spent blocking.
+        entry.touch();
+
+        Ok(json!({
+            "subscription_id": entry.id,
+            "application": entry.app_name,
+            "pid": entry.app_pid,
+            "events": taken.iter().map(event_json).collect::<Vec<Value>>(),
+            "count": taken.len(),
+            "dropped": dropped,
+            "dropped_total": dropped_total,
+            "buffered": buffered,
+            "truncated": buffered > 0,
+            "live": live,
+        }))
+    }
+
+    /// Close a subscription and report what it did.
+    pub(super) fn stop(&self, id: &str) -> CliResult<Value> {
+        self.sweep();
+        let entry = self.take(id)?;
+        entry.shut_down();
+        let queue = entry.shared.queue();
+        Ok(json!({
+            "subscription_id": entry.id,
+            "stopped": true,
+            "delivered": queue.delivered,
+            "dropped_total": queue.dropped_total,
+            "discarded": queue.events.len(),
+        }))
+    }
+
+    /// Remove a handle from the registry, or say why it did not resolve.
+    ///
+    /// One lock for the find and the removal, so two `events_stop` calls
+    /// racing on one handle cannot both report having stopped it.
+    fn take(&self, id: &str) -> CliResult<Arc<Entry>> {
+        let mut subs = self.subs();
+        match subs.iter().position(|e| e.id == id) {
+            Some(position) => Ok(subs.remove(position)),
+            None => Err(self.miss(id, &subs)),
+        }
+    }
+
+    /// Resolve a handle, or say why it did not resolve.
+    fn lookup(&self, id: &str) -> CliResult<Arc<Entry>> {
+        let subs = self.subs();
+        match subs.iter().find(|e| e.id == id) {
+            Some(entry) => Ok(Arc::clone(entry)),
+            None => Err(self.miss(id, &subs)),
+        }
+    }
+
+    /// The error for a handle this registry does not hold.
+    fn miss(&self, id: &str, subs: &[Arc<Entry>]) -> CliError {
+        CliError::NoSubscription {
+            id: id.to_string(),
+            // An id this session handed out and no longer holds was either
+            // reclaimed for idling or stopped; one it never handed out is a
+            // different mistake, and the model's next move differs. `next_id`
+            // is the only record of what was issued once the entry is gone.
+            expired: was_issued(id, self.next_id.load(Ordering::Relaxed)),
+            live: subs.iter().map(|e| e.id.clone()).collect(),
+        }
+    }
+
+    /// Reclaim subscriptions nobody has polled for [`EXPIRY`].
+    ///
+    /// Lazy rather than timed: a sweeper thread would have to outlive every
+    /// subscription to be useful, and every path into this registry is a tool
+    /// call, so there is no state a caller can observe between sweeps.
+    fn sweep(&self) {
+        self.sweep_idle(EXPIRY);
+    }
+
+    /// [`sweep`](Self::sweep) with the threshold as an argument, so the tests
+    /// can reclaim a subscription without waiting out [`EXPIRY`].
+    fn sweep_idle(&self, expiry: Duration) {
+        let mut subs = self.subs();
+        subs.retain(|entry| entry.idle_for() < expiry);
+    }
+
+    /// Buffered count, dropped-since-poll, and dropped-total for one handle.
+    ///
+    /// Reading the buffer without draining it, which is the only way a test
+    /// can watch the drainer fill it.
+    #[cfg(test)]
+    fn snapshot(&self, id: &str) -> Option<(usize, u64, u64)> {
+        let subs = self.subs();
+        let entry = subs.iter().find(|e| e.id == id)?;
+        let queue = entry.shared.queue();
+        Some((
+            queue.events.len(),
+            queue.dropped_since_poll,
+            queue.dropped_total,
+        ))
+    }
+}
+
+/// Whether `id` looks like a handle this session issued and has since let go.
+///
+/// The registry keeps no tombstones — the alternative is a list that grows for
+/// the life of the process — so this reads the one number that does record
+/// what was issued: the next id counter.
+fn was_issued(id: &str, next_id: u64) -> bool {
+    id.strip_prefix("sub_")
+        .and_then(|n| n.parse::<u64>().ok())
+        .is_some_and(|n| n > 0 && n < next_id)
+}
+
+/// Move events from `sub` into `shared` until told to stop or the source ends.
+///
+/// `sub` is moved into the thread, so the platform subscription is released
+/// when the loop returns — on the stop flag, on a disconnect, or when the
+/// spawn itself fails and the closure is dropped un-run.
+/// A thread the OS refused to create is reported rather than panicked on
+/// (tenet 4): the subscription simply does not open, and the caller can act
+/// on that.
+fn spawn_drainer(
+    shared: Arc<Shared>,
+    sub: Subscription,
+    kinds: Option<Vec<String>>,
+    started: Instant,
+) -> CliResult<JoinHandle<()>> {
+    std::thread::Builder::new()
+        .name("xa11y-mcp-events".into())
+        .spawn(move || {
+            loop {
+                if shared.queue().stopping {
+                    return;
+                }
+                match sub.recv_status(DRAIN_TICK) {
+                    RecvStatus::Event(event) => {
+                        if let Some(kinds) = &kinds {
+                            if !kinds.iter().any(|k| k == format_event_kind(&event.kind)) {
+                                continue;
+                            }
+                        }
+                        let at_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+                        let mut queue = shared.queue();
+                        let sequence = queue.next_sequence;
+                        queue.next_sequence += 1;
+                        if queue.events.len() >= BUFFER_CAPACITY {
+                            // Evict the oldest: the newest events describe the
+                            // UI as it is now, which is what a caller polling
+                            // a live application is asking for.
+                            queue.events.pop_front();
+                            queue.dropped_since_poll += 1;
+                            queue.dropped_total += 1;
+                        }
+                        queue.events.push_back(Buffered {
+                            sequence,
+                            at_ms,
+                            event: *event,
+                        });
+                        drop(queue);
+                        shared.ready.notify_all();
+                    }
+                    RecvStatus::Timeout => continue,
+                    RecvStatus::Disconnected => {
+                        // The application exited or the platform dropped the
+                        // subscription. Say so rather than leaving the caller
+                        // polling an empty buffer forever (tenet 1).
+                        shared.queue().live = false;
+                        shared.ready.notify_all();
+                        return;
+                    }
+                }
+            }
+        })
+        .map_err(|e| {
+            CliError::Xa11y(crate::Error::Platform {
+                code: e.raw_os_error().unwrap_or(0).into(),
+                message: format!("could not start the event drainer thread: {e}"),
+            })
+        })
+}
+
+/// One event, in the shape the other element-returning tools use.
+fn event_json(buffered: &Buffered) -> Value {
+    let event = &buffered.event;
+    let mut out = Map::new();
+    out.insert("sequence".into(), json!(buffered.sequence));
+    out.insert("at_ms".into(), json!(buffered.at_ms));
+    out.insert("kind".into(), json!(format_event_kind(&event.kind)));
+    if let EventKind::StateChanged { flag, value } = event.kind {
+        out.insert("state_flag".into(), json!(format_state_flag(flag)));
+        out.insert("state_value".into(), json!(value));
+    }
+    out.insert("application".into(), json!(event.app_name));
+    out.insert("pid".into(), json!(event.app_pid));
+    if let Some(target) = &event.target {
+        out.insert("target".into(), element_data_json(target));
+    }
+    Value::Object(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CancelHandle, ElementData, EventReceiver, Role, StateFlag};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::mpsc::{self, Sender};
+
+    /// Longest any test here waits for the drainer thread to catch up. Every
+    /// wait is on a condition, so this is a failure deadline rather than a
+    /// sleep — a passing run never spends it.
+    const DEADLINE: Duration = Duration::from_secs(5);
+
+    /// A registry with one subscription fed by the returned sender.
+    fn registry_with(kinds: Option<Vec<String>>) -> (Registry, Sender<Event>, String) {
+        let (tx, rx) = mpsc::channel::<Event>();
+        let sub = Subscription::new(EventReceiver::new(rx), CancelHandle::noop());
+        let registry = Registry::new();
+        let started = registry
+            .start("Test App", Some(4321), sub, kinds)
+            .expect("a drainer thread can be spawned");
+        let id = started["subscription_id"]
+            .as_str()
+            .expect("start reports a handle")
+            .to_string();
+        (registry, tx, id)
+    }
+
+    fn event(kind: EventKind) -> Event {
+        Event::new(kind, "Test App", 4321)
+    }
+
+    fn send(tx: &Sender<Event>, kind: EventKind) {
+        tx.send(event(kind)).expect("drainer is receiving");
+    }
+
+    /// Block until `predicate` holds, or fail after [`DEADLINE`].
+    fn until(what: &str, predicate: impl Fn() -> bool) {
+        let start = Instant::now();
+        while start.elapsed() < DEADLINE {
+            if predicate() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        panic!("timed out after {DEADLINE:?} waiting for {what}");
+    }
+
+    /// Poll until `want` events have been collected across however many calls
+    /// it takes. The drainer is a separate thread, so one poll is not
+    /// guaranteed to see everything already sent.
+    fn collect(registry: &Registry, id: &str, want: usize) -> Vec<Value> {
+        let mut events = Vec::new();
+        let start = Instant::now();
+        while events.len() < want && start.elapsed() < DEADLINE {
+            let result = registry
+                .poll(id, 500, Duration::from_millis(100))
+                .expect("handle is open");
+            events.extend(
+                result["events"]
+                    .as_array()
+                    .expect("events is an array")
+                    .clone(),
+            );
+        }
+        assert_eq!(events.len(), want, "collected {events:?}");
+        events
+    }
+
+    #[test]
+    fn a_new_subscription_reports_its_handle_and_its_limits() {
+        // The buffer size and the retention window are what a caller needs to
+        // decide how often to poll, so they come back with the handle rather
+        // than only in the tool description.
+        let (tx, rx) = mpsc::channel::<Event>();
+        drop(tx);
+        let registry = Registry::new();
+        let started = registry
+            .start(
+                "Test App",
+                Some(4321),
+                Subscription::new(EventReceiver::new(rx), CancelHandle::noop()),
+                None,
+            )
+            .expect("a drainer thread can be spawned");
+        assert_eq!(started["subscription_id"], json!("sub_1"));
+        assert_eq!(started["application"], json!("Test App"));
+        assert_eq!(started["pid"], json!(4321));
+        assert_eq!(started["kinds"], Value::Null, "no filter means every kind");
+        assert_eq!(started["buffer_capacity"], json!(BUFFER_CAPACITY));
+        assert_eq!(
+            started["expires_after_ms"],
+            json!(EXPIRY.as_millis() as u64)
+        );
+    }
+
+    #[test]
+    fn each_subscription_gets_its_own_handle() {
+        let (registry, _tx, first) = registry_with(None);
+        let (tx, rx) = mpsc::channel::<Event>();
+        drop(tx);
+        let second = registry
+            .start(
+                "Other App",
+                None,
+                Subscription::new(EventReceiver::new(rx), CancelHandle::noop()),
+                None,
+            )
+            .expect("a drainer thread can be spawned");
+        assert_ne!(json!(first), second["subscription_id"]);
+        assert_eq!(
+            second["pid"],
+            Value::Null,
+            "an application with no reported pid says so rather than omitting it"
+        );
+        registry
+            .poll(&first, 1, Duration::ZERO)
+            .expect("still open");
+    }
+
+    #[test]
+    fn events_come_back_in_order_with_their_sequence_and_target() {
+        let (registry, tx, id) = registry_with(None);
+        let mut data = ElementData::for_role(Role::Button);
+        data.name = Some("Submit".into());
+        let mut with_target = event(EventKind::FocusChanged);
+        with_target.target = Some(data);
+        tx.send(with_target).expect("drainer is receiving");
+        send(&tx, EventKind::ValueChanged);
+
+        let events = collect(&registry, &id, 2);
+        assert_eq!(events[0]["sequence"], json!(0));
+        assert_eq!(events[0]["kind"], json!("focus_changed"));
+        assert_eq!(
+            events[0]["target"]["name"],
+            json!("Submit"),
+            "the target is the same shape `find` returns"
+        );
+        assert_eq!(events[1]["sequence"], json!(1));
+        assert_eq!(events[1]["kind"], json!("value_changed"));
+        assert!(
+            events[1].get("target").is_none(),
+            "an event with no target says so by omission, as element payloads do"
+        );
+    }
+
+    #[test]
+    fn a_state_change_carries_the_flag_and_the_value_as_fields() {
+        // Not only in the kind string: a harness branching on which flag
+        // changed should not have to parse prose (tenet 6).
+        let (registry, tx, id) = registry_with(None);
+        send(
+            &tx,
+            EventKind::StateChanged {
+                flag: StateFlag::Checked,
+                value: true,
+            },
+        );
+        let events = collect(&registry, &id, 1);
+        assert_eq!(events[0]["kind"], json!("state_changed"));
+        assert_eq!(events[0]["state_flag"], json!("checked"));
+        assert_eq!(events[0]["state_value"], json!(true));
+    }
+
+    #[test]
+    fn a_full_buffer_evicts_the_oldest_and_reports_the_loss() {
+        let (registry, tx, id) = registry_with(None);
+        let overflow = 10;
+        for _ in 0..BUFFER_CAPACITY + overflow {
+            send(&tx, EventKind::FocusChanged);
+        }
+        until("the buffer to fill and overflow", || {
+            registry.snapshot(&id) == Some((BUFFER_CAPACITY, overflow as u64, overflow as u64))
+        });
+
+        let result = registry
+            .poll(&id, BUFFER_CAPACITY, Duration::ZERO)
+            .expect("handle is open");
+        assert_eq!(result["dropped"], json!(overflow));
+        assert_eq!(result["dropped_total"], json!(overflow));
+        assert_eq!(result["count"], json!(BUFFER_CAPACITY));
+        let events = result["events"].as_array().expect("events is an array");
+        assert_eq!(
+            events[0]["sequence"],
+            json!(overflow),
+            "the oldest events go, so the surviving run starts at the gap"
+        );
+    }
+
+    #[test]
+    fn dropped_resets_between_polls_but_the_total_does_not() {
+        let (registry, tx, id) = registry_with(None);
+        for _ in 0..BUFFER_CAPACITY + 3 {
+            send(&tx, EventKind::FocusChanged);
+        }
+        until("the buffer to overflow", || {
+            matches!(registry.snapshot(&id), Some((_, 3, 3)))
+        });
+
+        let first = registry
+            .poll(&id, BUFFER_CAPACITY, Duration::ZERO)
+            .expect("handle is open");
+        assert_eq!(first["dropped"], json!(3));
+
+        let second = registry
+            .poll(&id, 10, Duration::ZERO)
+            .expect("handle is open");
+        assert_eq!(
+            second["dropped"],
+            json!(0),
+            "`dropped` counts loss since the last poll, so it does not re-report"
+        );
+        assert_eq!(
+            second["dropped_total"],
+            json!(3),
+            "the running total still remembers it"
+        );
+    }
+
+    #[test]
+    fn a_poll_takes_at_most_max_and_says_what_is_left() {
+        let (registry, tx, id) = registry_with(None);
+        for _ in 0..5 {
+            send(&tx, EventKind::FocusChanged);
+        }
+        until("all five events to be buffered", || {
+            matches!(registry.snapshot(&id), Some((5, _, _)))
+        });
+
+        let result = registry
+            .poll(&id, 2, Duration::ZERO)
+            .expect("handle is open");
+        assert_eq!(result["count"], json!(2));
+        assert_eq!(result["buffered"], json!(3));
+        assert_eq!(
+            result["truncated"],
+            json!(true),
+            "a shortened result that does not say so reads as a complete one"
+        );
+    }
+
+    #[test]
+    fn an_empty_poll_is_not_a_failure() {
+        let (registry, _tx, id) = registry_with(None);
+        let result = registry
+            .poll(&id, 10, Duration::ZERO)
+            .expect("an idle subscription is not an error");
+        assert_eq!(result["count"], json!(0));
+        assert_eq!(result["truncated"], json!(false));
+        assert_eq!(result["live"], json!(true));
+    }
+
+    #[test]
+    fn a_blocking_poll_returns_on_the_first_event_not_at_its_timeout() {
+        let (registry, tx, id) = registry_with(None);
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            send(&tx, EventKind::WindowOpened);
+            // Hold the sender until the poll has certainly returned, so this
+            // tests the event path rather than the disconnect path.
+            std::thread::sleep(Duration::from_secs(2));
+        });
+
+        let start = Instant::now();
+        let result = registry
+            .poll(&id, 10, Duration::from_secs(10))
+            .expect("handle is open");
+        assert_eq!(result["count"], json!(1));
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "the poll waited {:?}, so it slept out its timeout instead of \
+             waking on the event",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn a_blocking_poll_gives_up_at_its_timeout() {
+        let (registry, _tx, id) = registry_with(None);
+        let start = Instant::now();
+        let result = registry
+            .poll(&id, 10, Duration::from_millis(100))
+            .expect("handle is open");
+        assert_eq!(result["count"], json!(0));
+        assert!(start.elapsed() >= Duration::from_millis(100));
+        assert!(
+            start.elapsed() < DEADLINE,
+            "a poll that times out must return at its timeout"
+        );
+    }
+
+    #[test]
+    fn a_disconnected_source_stops_being_live() {
+        let (registry, tx, id) = registry_with(None);
+        send(&tx, EventKind::WindowClosed);
+        drop(tx);
+
+        // The buffered event is still handed over: disconnect ends the stream,
+        // it does not discard what already arrived.
+        let result = registry
+            .poll(&id, 10, Duration::from_secs(1))
+            .expect("handle is open");
+        assert_eq!(result["count"], json!(1));
+
+        let after = registry
+            .poll(&id, 10, Duration::from_secs(1))
+            .expect("handle is open");
+        assert_eq!(after["count"], json!(0));
+        assert_eq!(
+            after["live"],
+            json!(false),
+            "a caller polling a dead stream must be told, not left waiting"
+        );
+    }
+
+    #[test]
+    fn a_dead_stream_does_not_hold_a_blocking_poll_open() {
+        let (registry, tx, id) = registry_with(None);
+        drop(tx);
+        until("the drainer to notice the disconnect", || {
+            registry
+                .poll(&id, 10, Duration::ZERO)
+                .is_ok_and(|r| r["live"] == json!(false))
+        });
+
+        let start = Instant::now();
+        let result = registry
+            .poll(&id, 10, Duration::from_secs(10))
+            .expect("handle is open");
+        assert_eq!(result["live"], json!(false));
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "a poll on a finished stream waited {:?} for an event that cannot arrive",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn a_kind_filter_keeps_only_what_was_asked_for() {
+        // Filtering at the drainer rather than at the poll is what makes the
+        // buffer hold what the caller wants on a chatty application.
+        let (registry, tx, id) = registry_with(Some(vec!["value_changed".into()]));
+        send(&tx, EventKind::FocusChanged);
+        send(&tx, EventKind::ValueChanged);
+        send(&tx, EventKind::StructureChanged);
+
+        let events = collect(&registry, &id, 1);
+        assert_eq!(events[0]["kind"], json!("value_changed"));
+        assert_eq!(
+            registry.snapshot(&id).map(|s| s.0),
+            Some(0),
+            "the filtered-out kinds never reached the buffer"
+        );
+    }
+
+    #[test]
+    fn an_unknown_handle_names_the_ones_that_are_open() {
+        let (registry, _tx, id) = registry_with(None);
+        let err = registry
+            .poll("sub_999", 10, Duration::ZERO)
+            .expect_err("an id this session never issued");
+        match err {
+            CliError::NoSubscription { expired, live, .. } => {
+                assert!(!expired, "never issued is not the same as expired");
+                assert_eq!(live, vec![id], "the way out is in the error");
+            }
+            other => panic!("expected NoSubscription, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_stopped_handle_reads_as_expired_rather_than_unknown() {
+        // The recovery differs: an expired handle means "start another one",
+        // an unknown one means the id itself is wrong.
+        let (registry, _tx, id) = registry_with(None);
+        registry.stop(&id).expect("handle is open");
+        let err = registry
+            .poll(&id, 10, Duration::ZERO)
+            .expect_err("a stopped handle no longer resolves");
+        match err {
+            CliError::NoSubscription { expired, live, .. } => {
+                assert!(expired);
+                assert!(live.is_empty());
+            }
+            other => panic!("expected NoSubscription, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stopping_reports_what_it_delivered_and_what_it_discarded() {
+        let (registry, tx, id) = registry_with(None);
+        for _ in 0..3 {
+            send(&tx, EventKind::FocusChanged);
+        }
+        until("all three events to be buffered", || {
+            matches!(registry.snapshot(&id), Some((3, _, _)))
+        });
+        let polled = registry
+            .poll(&id, 1, Duration::ZERO)
+            .expect("handle is open");
+        assert_eq!(polled["count"], json!(1));
+
+        let stopped = registry.stop(&id).expect("handle is open");
+        assert_eq!(stopped["stopped"], json!(true));
+        assert_eq!(stopped["delivered"], json!(1));
+        assert_eq!(stopped["discarded"], json!(2));
+    }
+
+    #[test]
+    fn an_idle_subscription_is_reclaimed() {
+        let (registry, _tx, id) = registry_with(None);
+        registry.sweep_idle(Duration::ZERO);
+        let err = registry
+            .poll(&id, 10, Duration::ZERO)
+            .expect_err("a reclaimed handle no longer resolves");
+        assert!(matches!(
+            err,
+            CliError::NoSubscription { expired: true, .. }
+        ));
+    }
+
+    #[test]
+    fn a_poll_keeps_the_subscription_alive() {
+        let (registry, _tx, id) = registry_with(None);
+        registry.poll(&id, 10, Duration::ZERO).expect("open");
+        registry.sweep_idle(Duration::from_secs(60));
+        registry
+            .poll(&id, 10, Duration::ZERO)
+            .expect("a polled subscription is not idle");
+    }
+
+    /// A subscription whose cancellation is observable, standing in for the
+    /// platform subscription a real one holds.
+    fn cancellable() -> (Subscription, Arc<AtomicBool>, Sender<Event>) {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&cancelled);
+        let (tx, rx) = mpsc::channel::<Event>();
+        let sub = Subscription::new(
+            EventReceiver::new(rx),
+            CancelHandle::new(move || flag.store(true, Ordering::SeqCst)),
+        );
+        (sub, cancelled, tx)
+    }
+
+    #[test]
+    fn stopping_releases_the_platform_subscription() {
+        let (sub, cancelled, _tx) = cancellable();
+        let registry = Registry::new();
+        let started = registry
+            .start("Test App", Some(1), sub, None)
+            .expect("a drainer thread can be spawned");
+        let id = started["subscription_id"].as_str().unwrap().to_string();
+
+        registry.stop(&id).expect("handle is open");
+        assert!(
+            cancelled.load(Ordering::SeqCst),
+            "stop returned while the platform subscription was still running"
+        );
+    }
+
+    #[test]
+    fn dropping_the_registry_releases_every_subscription() {
+        // stdio is one server per client, so the session ending is the only
+        // shutdown there is: nothing else would ever unsubscribe.
+        let (sub, cancelled, _tx) = cancellable();
+        let registry = Registry::new();
+        registry
+            .start("Test App", Some(1), sub, None)
+            .expect("a drainer thread can be spawned");
+        drop(registry);
+        assert!(
+            cancelled.load(Ordering::SeqCst),
+            "the session ended with a platform subscription still running"
+        );
+    }
+}

--- a/xa11y/src/mcp/mod.rs
+++ b/xa11y/src/mcp/mod.rs
@@ -15,10 +15,13 @@
 //! - [`transport`] — newline-delimited JSON-RPC framing.
 //! - [`protocol`] — envelope handling, dual-era method routing, error mapping.
 //! - [`tools`] — the tool table and the handlers that reach the provider.
+//! - [`events`] — subscriptions held across calls for the `events_*` trio.
 //! - [`base64`] — image-content encoding.
 //!
 //! Only `tools` touches the accessibility layer, so everything else is
-//! covered by ordinary unit tests on every platform.
+//! covered by ordinary unit tests on every platform — `events` included: it
+//! is driven by a plain channel, so its buffering and expiry are testable
+//! with no display.
 //!
 //! # stdout is the wire
 //!
@@ -30,6 +33,7 @@
 //! check` enforces this by scanning for print macros under `src/mcp/`.
 
 mod base64;
+mod events;
 mod protocol;
 mod tools;
 mod transport;
@@ -75,7 +79,7 @@ fn serve_streams<R: std::io::BufRead, W: std::io::Write>(
     input: &mut R,
     output: &mut W,
 ) -> CliResult<()> {
-    let mut session = protocol::Session::new(tools::Xa11yTools);
+    let mut session = protocol::Session::new(tools::Xa11yTools::new());
     loop {
         let message = match transport::read_message(input) {
             Ok(Some(message)) => message,

--- a/xa11y/src/mcp/protocol.rs
+++ b/xa11y/src/mcp/protocol.rs
@@ -101,6 +101,11 @@ matches several is refused rather than applied to the first, and no retry loop \
 of your own is needed. Its `ok: true` means the application accepted the call, \
 not that anything changed — confirm by reading the tree again.
 
+To watch what an application does rather than poll its tree, \
+`events_start` returns a handle, `events_poll` drains buffered events, and \
+`events_stop` closes it. Start the subscription before the action you want to \
+observe.
+
 The input and screenshot tools work in screen coordinates only. Get those from \
 `find`, which returns each match's `bounds` and `center`.
 

--- a/xa11y/src/mcp/tools.rs
+++ b/xa11y/src/mcp/tools.rs
@@ -20,9 +20,10 @@
 use serde_json::{json, Map, Value};
 
 use super::base64;
+use super::events::{Registry, BUFFER_CAPACITY, EXPIRY};
 use crate::cli::{
-    self, parse_button, parse_held, parse_key_name, resolve_target, CliError, CliResult, Opts,
-    Target, ACTIONS_REQUIRING_VALUE, ACTION_NAMES,
+    self, parse_button, parse_held, parse_key_name, resolve_app, resolve_target, CliError,
+    CliResult, Opts, Target, ACTIONS_REQUIRING_VALUE, ACTION_NAMES,
 };
 use crate::{
     App, AppExt, ClickOptions, ClickTarget, DragOptions, Element, Locator, Rect, ScrollDelta,
@@ -39,6 +40,10 @@ const FIND_DEFAULT_LIMIT: usize = 50;
 const FIND_MAX_LIMIT: usize = 500;
 /// Longest candidate list carried in a failure's diagnosis.
 const MAX_DIAGNOSIS_CANDIDATES: usize = 20;
+/// Events returned by one `events_poll` when the caller does not ask.
+const EVENTS_DEFAULT_MAX: usize = 100;
+/// Ceiling on `events_poll`'s `max`, so one poll cannot dump a full buffer.
+const EVENTS_MAX_MAX: usize = 500;
 
 /// Inclusive bounds for one integer tool argument.
 ///
@@ -87,6 +92,20 @@ const DRAG_DURATION_MS: Bounds = Bounds {
 const SCREENSHOT_EXTENT: Bounds = Bounds {
     min: 1,
     max: u32::MAX as i64,
+};
+/// `events_poll`'s `max`. Zero would report no events while draining none.
+const EVENTS_MAX: Bounds = Bounds {
+    min: 1,
+    max: EVENTS_MAX_MAX as i64,
+};
+/// `events_poll`'s `timeout_ms`.
+///
+/// The ceiling is well under any typical client request timeout, and it has a
+/// second reason to stay low: the stdio session loop handles one message at a
+/// time, so a blocking poll blocks every other tool call for its duration.
+const EVENTS_TIMEOUT_MS: Bounds = Bounds {
+    min: 0,
+    max: 15_000,
 };
 
 impl Bounds {
@@ -232,7 +251,22 @@ pub(crate) trait ToolHost {
 }
 
 /// The real tool host, backed by the platform accessibility provider.
-pub(crate) struct Xa11yTools;
+///
+/// Holds the session's event subscriptions. Everything else here is
+/// stateless, and this is state only because MCP has no session of its own to
+/// hang a live subscription on — see [`super::events`]. Dropping the host
+/// stops every drainer and cancels every platform subscription.
+pub(crate) struct Xa11yTools {
+    events: Registry,
+}
+
+impl Xa11yTools {
+    pub(crate) fn new() -> Self {
+        Self {
+            events: Registry::new(),
+        }
+    }
+}
 
 /// Every tool name, in list order.
 const TOOL_NAMES: &[&str] = &[
@@ -248,6 +282,9 @@ const TOOL_NAMES: &[&str] = &[
     "key",
     "type",
     "screenshot",
+    "events_start",
+    "events_poll",
+    "events_stop",
 ];
 
 impl ToolHost for Xa11yTools {
@@ -276,6 +313,9 @@ impl ToolHost for Xa11yTools {
             "key" => tool_key(args),
             "type" => tool_type(args),
             "screenshot" => tool_screenshot(args),
+            "events_start" => tool_events_start(&self.events, args),
+            "events_poll" => tool_events_poll(&self.events, args),
+            "events_stop" => tool_events_stop(&self.events, args),
             // Unreachable through `Session`, which checks `has_tool` first.
             // Kept as a real error rather than an `unreachable!` so a future
             // caller that skips the check gets a diagnosis, not a panic
@@ -684,6 +724,51 @@ fn tool_definition(name: &str) -> Value {
                 object_schema(props, &[]),
             )
         }
+        "events_start" => tool(
+            "events_start",
+            "Start watching events",
+            &events_start_description(),
+            object_schema(events_start_properties(), &[]),
+        ),
+        "events_poll" => {
+            let mut props = subscription_id_property();
+            props.insert(
+                "max".into(),
+                EVENTS_MAX.property(format!(
+                    "Most events to return in one call. Default {EVENTS_DEFAULT_MAX}. \
+                     `buffered` in the result says how many are still waiting and \
+                     `truncated` says whether any were."
+                )),
+            );
+            props.insert(
+                "timeout_ms".into(),
+                EVENTS_TIMEOUT_MS.property(
+                    "How long to wait for the first event when the buffer is empty. \
+                     Default 0, which drains whatever has arrived and returns straight \
+                     away — poll again rather than holding a call open unless you are \
+                     waiting for a specific event. A blocking poll returns as soon as \
+                     one event lands, not after the whole timeout, and it blocks every \
+                     other tool call for as long as it waits."
+                        .into(),
+                ),
+            );
+            tool(
+                "events_poll",
+                "Poll buffered events",
+                &events_poll_description(),
+                object_schema(props, &["subscription_id"]),
+            )
+        }
+        "events_stop" => tool(
+            "events_stop",
+            "Stop watching events",
+            "Close a subscription and release the underlying platform subscription. \
+             Reports how many events it delivered, how many it dropped, and how many \
+             were still buffered when it closed. Stopping a subscription you are done \
+             with is worth doing rather than letting it expire: until it does, the \
+             application keeps delivering events into a buffer nobody reads.",
+            object_schema(subscription_id_property(), &["subscription_id"]),
+        ),
         // `TOOL_NAMES` is the single source of truth and every entry has an
         // arm above; an unnamed tool would be a programming error, so it
         // surfaces as one rather than shipping an empty definition.
@@ -693,6 +778,104 @@ fn tool_definition(name: &str) -> Value {
             "inputSchema": { "type": "object" },
         }),
     }
+}
+
+/// `events_start`'s arguments: an application, and an optional kind filter.
+///
+/// Written out rather than taken from [`app_target_properties`] because
+/// `shell` is not among them — accessibility events are subscribed per
+/// application, exactly as `xa11y events` refuses `--shell` — and an argument
+/// a schema advertises but a handler refuses is worse than one that is absent.
+fn events_start_properties() -> Map<String, Value> {
+    let mut props = Map::new();
+    props.insert(
+        "app".into(),
+        json!({
+            "type": "string",
+            "description": "Application name, matched exactly and case-sensitively. \
+                            Take the spelling from the `apps` tool rather than \
+                            guessing it. Give this or `pid`.",
+        }),
+    );
+    props.insert(
+        "pid".into(),
+        PID.property("Process id of the application to watch. Give this or `app`.".into()),
+    );
+    props.insert(
+        "kinds".into(),
+        json!({
+            "type": "array",
+            "items": { "type": "string", "enum": cli::event_kind_names() },
+            "description": "Kinds to buffer, e.g. [\"focus_changed\", \"value_changed\"]. \
+                            Omit for every kind. Filtering happens before buffering, so \
+                            on a chatty application it is what keeps the events you \
+                            care about from being evicted by ones you do not.",
+        }),
+    );
+    props
+}
+
+/// The `subscription_id` argument, shared by `events_poll` and `events_stop`.
+fn subscription_id_property() -> Map<String, Value> {
+    let mut props = Map::new();
+    props.insert(
+        "subscription_id".into(),
+        json!({
+            "type": "string",
+            "description": "Handle returned by `events_start`.",
+        }),
+    );
+    props
+}
+
+/// The `events_start` tool's description.
+///
+/// Built rather than written as a literal because it states the retention
+/// window and the buffer size, both of which are constants in
+/// [`super::events`] — a description naming a different number than the
+/// registry enforces is the drift this file exists to avoid. The
+/// specification asks a stateful tool to state its handle's retention here,
+/// which is the only place a model reads before calling.
+fn events_start_description() -> String {
+    format!(
+        "Start watching an application's accessibility events — focus moves, value \
+         and state changes, windows opening, selections, announcements. Returns a \
+         `subscription_id` to pass to `events_poll` and `events_stop`.\n\n\
+         Watching is per application: there is no `shell` argument, because \
+         accessibility events are delivered by an application's own \
+         subscription.\n\n\
+         Events are buffered from the moment this returns, so start the \
+         subscription *before* the action you want to observe, then act, then \
+         poll. Up to {BUFFER_CAPACITY} events are held; past that the oldest are \
+         evicted and every poll reports how many were lost, so a gap is always \
+         visible rather than silent.\n\n\
+         The handle lives in this server process and no longer: it is reclaimed \
+         after {} minutes without a poll, and a reclaimed handle comes back from \
+         `events_poll` as a `subscription_expired` failure. Call `events_stop` when \
+         you are done.",
+        EXPIRY.as_secs() / 60,
+    )
+}
+
+/// The `events_poll` tool's description.
+fn events_poll_description() -> String {
+    format!(
+        "Take buffered events from a subscription, oldest first. Returns at most \
+         `max` of them ({EVENTS_DEFAULT_MAX} by default), and by default does not \
+         block: an empty `events` means nothing has happened yet, not that the \
+         subscription is broken.\n\n\
+         Each event carries a `kind`, a `sequence` (monotonic, so a gap is exactly \
+         what was dropped), `at_ms` since the subscription started, and the `target` \
+         element in the same shape `find` returns — bounds, states and all. A \
+         `state_changed` event also carries `state_flag` and `state_value`.\n\n\
+         Two fields say what the events alone cannot. `dropped` counts events lost \
+         to buffer eviction since the previous poll — poll more often, narrow \
+         `kinds`, or accept the gap. `live: false` means the source is gone (the \
+         application exited, or the platform dropped the subscription): drain what \
+         is left, then stop polling, because nothing further can arrive.\n\n\
+         An event is a snapshot from when it fired. Read the tree again to see the \
+         UI as it is now."
+    )
 }
 
 /// The `screenshot` tool's description.
@@ -914,6 +1097,20 @@ fn quoted_list(names: &[&str]) -> String {
     }
 }
 
+/// Read the `pid` argument, range-checked and narrowed.
+fn pid_arg(args: &Value) -> CliResult<Option<u32>> {
+    match opt_int(args, "pid")? {
+        None => Ok(None),
+        Some(v) => {
+            let v = PID.check("pid", v)?;
+            // `PID` is `1..=u32::MAX`, so the conversion cannot fail.
+            Ok(Some(u32::try_from(v).map_err(|_| {
+                usage(format!("\"pid\" is not a valid process id: {v}"))
+            })?))
+        }
+    }
+}
+
 /// Resolve the target — an application or a shell surface — from `app` /
 /// `pid` / `shell`, through the CLI's own resolver so name matching, kind
 /// parsing and the ambiguity refusal stay identical on both surfaces.
@@ -925,20 +1122,9 @@ fn quoted_list(names: &[&str]) -> String {
 /// application, and a kind to a surface on screen, stays in `cli`, so the two
 /// surfaces cannot drift on what `app` or `shell` means.
 fn target(args: &Value) -> CliResult<Target> {
-    let pid = match opt_int(args, "pid")? {
-        None => None,
-        Some(v) => {
-            let v = PID.check("pid", v)?;
-            // `PID` is `1..=u32::MAX`, so the conversion cannot fail.
-            Some(
-                u32::try_from(v)
-                    .map_err(|_| usage(format!("\"pid\" is not a valid process id: {v}")))?,
-            )
-        }
-    };
     let opts = Opts {
         app: opt_str(args, "app")?.map(str::to_string),
-        pid,
+        pid: pid_arg(args)?,
         shell: opt_str(args, "shell")?.map(str::to_string),
         ..Default::default()
     };
@@ -1453,6 +1639,105 @@ fn tool_screenshot(args: &Value) -> CliResult<ToolOutput> {
 ///
 /// One builder for both paths, so the plain capture cannot drift from the
 /// annotated one on what it says about the image.
+fn tool_events_start(registry: &Registry, args: &Value) -> CliResult<ToolOutput> {
+    // Parse everything before subscribing, so a bad `kinds` entry cannot
+    // leave a live platform subscription behind that nobody holds a handle to.
+    let kinds = event_kinds(args)?;
+    let app = events_app(args)?;
+    let sub = app.subscribe()?;
+    Ok(ToolOutput::json(
+        registry.start(&app.name, app.pid, sub, kinds)?,
+    ))
+}
+
+fn tool_events_poll(registry: &Registry, args: &Value) -> CliResult<ToolOutput> {
+    let id = req_str(args, "subscription_id")?;
+    let max = opt_usize(args, "max", EVENTS_DEFAULT_MAX, EVENTS_MAX)?;
+    let timeout_ms = opt_bounded(args, "timeout_ms", 0, EVENTS_TIMEOUT_MS)?;
+    // `EVENTS_TIMEOUT_MS.min` is 0, so the conversion cannot fail.
+    let timeout = std::time::Duration::from_millis(
+        u64::try_from(timeout_ms)
+            .map_err(|_| usage(format!("\"timeout_ms\" must not be negative: {timeout_ms}")))?,
+    );
+    Ok(ToolOutput::json(registry.poll(id, max, timeout)?))
+}
+
+fn tool_events_stop(registry: &Registry, args: &Value) -> CliResult<ToolOutput> {
+    let id = req_str(args, "subscription_id")?;
+    Ok(ToolOutput::json(registry.stop(id)?))
+}
+
+/// Resolve the application to watch.
+///
+/// Separate from [`target`] because there is no shell surface to resolve:
+/// events come from an application's own subscription. `shell` is refused by
+/// name rather than by `additionalProperties`, so a client that does not
+/// validate against the schema gets the reason instead of a silent
+/// full-application subscription — the same answer `xa11y events` gives
+/// `--shell`.
+fn events_app(args: &Value) -> CliResult<crate::App> {
+    if opt_str(args, "shell")?.is_some() {
+        return Err(usage(
+            "\"shell\" is not a target for the event tools: accessibility events are \
+             subscribed per application, and a shell surface has no subscription of \
+             its own. Give \"app\" or \"pid\"",
+        ));
+    }
+    let opts = Opts {
+        app: opt_str(args, "app")?.map(str::to_string),
+        pid: pid_arg(args)?,
+        ..Default::default()
+    };
+    if opts.app.is_none() && opts.pid.is_none() {
+        return Err(usage(
+            "specify \"app\" (application name, matched exactly) or \"pid\" (process \
+             id); the `apps` tool lists both for every running application",
+        ));
+    }
+    resolve_app(&opts)
+}
+
+/// The `kinds` filter, validated against the names events actually report.
+///
+/// An unknown name is refused rather than accepted-and-never-matched: a
+/// filter that silently matches nothing looks exactly like an application
+/// that emits nothing, and the model has no way to tell which it got.
+fn event_kinds(args: &Value) -> CliResult<Option<Vec<String>>> {
+    let known = cli::event_kind_names();
+    match args.get("kinds") {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Array(items)) if items.is_empty() => Err(usage(
+            "\"kinds\" must name at least one event kind; omit it to receive every kind",
+        )),
+        Some(Value::Array(items)) => {
+            let mut kinds: Vec<String> = Vec::with_capacity(items.len());
+            for item in items {
+                let name = match item {
+                    Value::String(name) if !name.is_empty() => name,
+                    _ => {
+                        return Err(usage(
+                            "each entry in \"kinds\" must be a non-empty event-kind name",
+                        ))
+                    }
+                };
+                if !known.contains(&name.as_str()) {
+                    return Err(usage(format!(
+                        "unknown event kind: \"{name}\" (expected one of {})",
+                        known.join(", ")
+                    )));
+                }
+                if !kinds.iter().any(|k| k == name) {
+                    kinds.push(name.clone());
+                }
+            }
+            Ok(Some(kinds))
+        }
+        Some(_) => Err(usage(
+            "\"kinds\" must be an array of event-kind names, e.g. [\"focus_changed\"]",
+        )),
+    }
+}
+
 fn capture_summary(shot: &crate::Screenshot, png: &[u8]) -> Map<String, Value> {
     let mut out = Map::new();
     out.insert("width".into(), json!(shot.width));
@@ -1486,7 +1771,7 @@ fn legend_json<T: serde::Serialize>(what: &str, value: &T) -> CliResult<Value> {
 /// pointer), neither of which means anything to a model and both of which
 /// would dominate the payload. Absent fields are omitted rather than sent as
 /// nulls, for the same reason.
-fn element_data_json(data: &crate::ElementData) -> Value {
+pub(super) fn element_data_json(data: &crate::ElementData) -> Value {
     let mut node = Map::new();
     node.insert("role".into(), json!(data.role.to_snake_case()));
     insert_some(&mut node, "name", data.name.as_deref().map(Value::from));
@@ -1619,6 +1904,11 @@ pub(crate) fn describe_failure(tool: &str, err: &CliError) -> (String, Value) {
             structured.insert("shell_kind".into(), json!(kind));
             structured.insert("diagnosis".into(), diagnosis_json(diagnosis));
         }
+        CliError::NoSubscription { id, expired, live } => {
+            structured.insert("subscription_id".into(), json!(id));
+            structured.insert("expired".into(), json!(expired));
+            structured.insert("live_subscriptions".into(), json!(live));
+        }
         CliError::Usage(_) | CliError::NotFound(_) => {}
     }
     (text, Value::Object(structured))
@@ -1679,6 +1969,11 @@ fn failure_kind(err: &CliError) -> &'static str {
         CliError::NotFound(_) => return "no_match",
         CliError::Ambiguous { .. } => return "ambiguous_selector",
         CliError::AmbiguousShellSurface { .. } => return "ambiguous_shell_surface",
+        // Two tags, not one: an expired handle means "start another
+        // subscription", an unknown one means "the id is wrong", and a model
+        // that cannot tell them apart retries the wrong one.
+        CliError::NoSubscription { expired: true, .. } => return "subscription_expired",
+        CliError::NoSubscription { expired: false, .. } => return "subscription_not_found",
         CliError::Xa11y(inner) => inner,
     };
     match inner {
@@ -1761,7 +2056,7 @@ mod tests {
 
     #[test]
     fn every_listed_tool_has_a_definition_and_is_callable() {
-        let host = Xa11yTools;
+        let host = Xa11yTools::new();
         let defs = host.list();
         assert_eq!(defs.len(), TOOL_NAMES.len());
         for def in &defs {
@@ -1906,6 +2201,8 @@ mod tests {
             ("limit", FIND_DEFAULT_LIMIT as i64, FIND_LIMIT),
             ("count", 1, CLICK_COUNT),
             ("duration_ms", 150, DRAG_DURATION_MS),
+            ("max", EVENTS_DEFAULT_MAX as i64, EVENTS_MAX),
+            ("timeout_ms", 0, EVENTS_TIMEOUT_MS),
         ] {
             assert!(
                 bounds.check(label, default).is_ok(),
@@ -2128,6 +2425,171 @@ mod tests {
         assert_eq!(encoded[0]["reason"], "outside_capture");
     }
 
+    // ── Event subscriptions ─────────────────────────────────────────────
+
+    #[test]
+    fn the_event_tools_are_a_trio_and_the_handle_ties_them_together() {
+        // The shape the specification's Stateful Tools guidance asks for:
+        // a creation tool hands out a handle, the others take it.
+        for name in ["events_poll", "events_stop"] {
+            let schema = tool_definition(name)["inputSchema"].clone();
+            assert_eq!(schema["required"], json!(["subscription_id"]));
+            assert!(
+                schema["properties"]["subscription_id"]["description"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("events_start"),
+                "{name} must say where its handle comes from"
+            );
+        }
+    }
+
+    #[test]
+    fn events_start_states_the_retention_the_registry_actually_enforces() {
+        // The specification asks a stateful tool to state its handle's
+        // retention, and a description naming a different number than the
+        // registry enforces is worse than one that says nothing.
+        let description = tool_definition("events_start")["description"]
+            .as_str()
+            .expect("a description")
+            .to_string();
+        assert!(
+            description.contains(&format!("{} minutes", EXPIRY.as_secs() / 60)),
+            "{description}"
+        );
+        assert!(
+            description.contains(&BUFFER_CAPACITY.to_string()),
+            "the buffer size a caller has to poll fast enough to stay inside: {description}"
+        );
+        assert!(
+            description.contains("*before* the action"),
+            "a subscription started after the click observes nothing: {description}"
+        );
+    }
+
+    #[test]
+    fn events_poll_says_what_an_empty_result_and_a_dropped_count_mean() {
+        let definition = tool_definition("events_poll");
+        let description = definition["description"].as_str().expect("a description");
+        assert!(
+            description.contains("does not block"),
+            "a model that expects a long poll by default waits for nothing: {description}"
+        );
+        assert!(
+            description.contains("dropped"),
+            "loss is only actionable if the caller knows the field exists: {description}"
+        );
+        assert!(
+            description.contains("live: false"),
+            "polling a dead stream forever is the failure mode this prevents: {description}"
+        );
+    }
+
+    #[test]
+    fn events_start_offers_no_shell_argument_and_says_why_when_one_arrives() {
+        // The schema is the first answer; the handler is the one a client that
+        // does not validate against it gets.
+        let props = tool_definition("events_start")["inputSchema"]["properties"].clone();
+        assert!(props.get("shell").is_none(), "{props}");
+
+        let err = tool_events_start(&Registry::new(), &args(json!({ "shell": "taskbar" })))
+            .expect_err("a shell surface has no subscription of its own");
+        assert!(
+            err.to_string().contains("per application"),
+            "must say why rather than reading as a misspelled argument: {err}"
+        );
+    }
+
+    #[test]
+    fn events_start_without_a_target_names_the_arguments_that_fix_it() {
+        let err = tool_events_start(&Registry::new(), &args(json!({})))
+            .expect_err("something has to be watched");
+        assert!(err.to_string().contains("\"app\""), "{err}");
+        assert!(err.to_string().contains("\"pid\""), "{err}");
+    }
+
+    #[test]
+    fn the_kinds_filter_advertises_exactly_the_names_events_report() {
+        let items =
+            tool_definition("events_start")["inputSchema"]["properties"]["kinds"]["items"].clone();
+        let advertised: Vec<String> = items["enum"]
+            .as_array()
+            .expect("the filter enumerates its names")
+            .iter()
+            .map(|v| v.as_str().unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(advertised, cli::event_kind_names());
+    }
+
+    #[test]
+    fn an_unknown_event_kind_is_refused_with_the_ones_that_exist() {
+        // Accepting it would look exactly like an application that emits
+        // nothing, and the caller could not tell which it got.
+        let err = event_kinds(&args(json!({ "kinds": ["focus_change"] })))
+            .expect_err("a near-miss spelling is still a miss");
+        assert!(err.to_string().contains("focus_change"), "{err}");
+        assert!(err.to_string().contains("focus_changed"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_kinds_list_is_refused_rather_than_read_as_no_filter() {
+        // `[]` reads as "no kinds at all", which would buffer nothing forever.
+        let err = event_kinds(&args(json!({ "kinds": [] }))).expect_err("must refuse");
+        assert!(err.to_string().contains("omit it"), "{err}");
+        assert_eq!(event_kinds(&args(json!({}))).unwrap(), None);
+    }
+
+    #[test]
+    fn a_repeated_kind_is_kept_once() {
+        let kinds = event_kinds(&args(
+            json!({ "kinds": ["focus_changed", "focus_changed"] }),
+        ))
+        .expect("a repeat is a caller's redundancy, not an error");
+        assert_eq!(kinds, Some(vec!["focus_changed".to_string()]));
+    }
+
+    #[test]
+    fn a_poll_needs_its_handle_and_range_checks_the_rest() {
+        let registry = Registry::new();
+        let err = tool_events_poll(&registry, &args(json!({}))).expect_err("must refuse");
+        assert!(err.to_string().contains("subscription_id"), "{err}");
+
+        let err = tool_events_poll(
+            &registry,
+            &args(json!({ "subscription_id": "sub_1", "timeout_ms": 60_000 })),
+        )
+        .expect_err("a timeout past the cap is refused, not silently clamped");
+        assert!(err.to_string().contains("15000"), "{err}");
+    }
+
+    #[test]
+    fn an_unknown_handle_is_a_fixable_tool_error_carrying_its_kind() {
+        let registry = Registry::new();
+        let err = tool_events_poll(&registry, &args(json!({ "subscription_id": "sub_7" })))
+            .expect_err("nothing was ever started");
+        assert_eq!(failure_kind(&err), "subscription_not_found");
+        let (_, structured) = describe_failure("events_poll", &err);
+        assert_eq!(structured["subscription_id"], json!("sub_7"));
+        assert_eq!(structured["expired"], json!(false));
+        assert_eq!(structured["live_subscriptions"], json!([]));
+    }
+
+    #[test]
+    fn an_expired_handle_is_a_different_kind_from_an_unknown_one() {
+        let err = CliError::NoSubscription {
+            id: "sub_1".into(),
+            expired: true,
+            live: vec!["sub_2".into()],
+        };
+        assert_eq!(failure_kind(&err), "subscription_expired");
+        let (text, structured) = describe_failure("events_poll", &err);
+        assert!(
+            text.contains("sub_2"),
+            "the open handles are the way out, so they belong in the message: {text}"
+        );
+        assert_eq!(structured["live_subscriptions"], json!(["sub_2"]));
+    }
+
     #[test]
     fn failure_kinds_cover_the_error_surface() {
         assert_eq!(
@@ -2138,6 +2600,14 @@ mod tests {
         assert_eq!(
             failure_kind(&CliError::Xa11y(crate::Error::NoElementBounds)),
             "no_element_bounds"
+        );
+        assert_eq!(
+            failure_kind(&CliError::NoSubscription {
+                id: "sub_1".into(),
+                expired: false,
+                live: Vec::new(),
+            }),
+            "subscription_not_found"
         );
     }
 


### PR DESCRIPTION
Closes #371.

`events` was the one CLI verb with no MCP counterpart. `xa11y events` blocks for as long as you watch, and a `tools/call` that never returns hangs the client, so the operation needed a different shape before it could be a tool at all.

It is now three, following the specification's [Stateful Tools](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#stateful-tools) guidance:

| Tool | Arguments | Returns |
| --- | --- | --- |
| `events_start` | `app` \| `pid`, `kinds?` | `subscription_id`, `buffer_capacity`, `expires_after_ms` |
| `events_poll` | `subscription_id`, `max?`, `timeout_ms?` | `events`, `dropped`, `dropped_total`, `buffered`, `truncated`, `live` |
| `events_stop` | `subscription_id` | `delivered`, `dropped_total`, `discarded` |

## The registry

`xa11y/src/mcp/events.rs` holds the subscriptions. A `Subscription` is a channel that fills whether or not anyone reads it, and is `Send` but not `Sync`, so each one gets a drainer thread that owns it and moves events into a bounded ring buffer:

- **Bounded** at 1024, because nothing else limits how far behind a model may fall, and holding everything is a memory leak with a delay on it.
- **Reported**: every poll carries `dropped` since the last poll and `dropped_total`, and each event carries a `sequence`, so a gap is visible in the events themselves rather than silent (tenet 1).
- **Oldest-first eviction**, because the newest events describe the UI as it is now, which is what the caller is polling for.
- **`live: false`** once the source disconnects, so a caller stops polling a stream nothing can arrive on.

The thread also gives the poll its long poll: it signals a condition variable, so a `timeout_ms` wakes on the first event rather than sleeping out its timeout. The cap is 15s and the default is 0 — the stdio session loop handles one message at a time, so a blocking poll blocks every other call for its duration, and the tool description says so.

## Handle lifetime

Nothing in MCP tells a server that a client lost interest in a handle, so a subscription is reclaimed after five minutes without a poll. `events_start` states that window and reports it as `expires_after_ms`, which is what the spec asks a stateful tool to do.

A handle that was issued and is now closed comes back as `subscription_expired`; an id that was never issued as `subscription_not_found`. The recoveries differ, so the tags do, and both name the handles that are open (tenet 6).

## No second mapping table

Kind strings come from `cli::format_event_kind`, so a new `EventKind` variant has one place to be handled rather than two. The `kinds` filter validates against `cli::event_kind_names`, derived from that same formatter and living beside it. `StateFlag` gains `format_state_flag` in `cli.rs`, and that file is now listed under the enum's `[[types.variant_coverage]]` entry.

## Coverage

- **Unit** (`mcp/events.rs`, no display — the registry is driven by a plain channel): buffer bounds and eviction, `dropped` resetting per poll while the total does not, `max` and `truncated`, a long poll waking on the first event and giving up at its timeout, disconnect, expiry, and that stopping or dropping the registry releases the platform subscription.
- **Per CLI launcher** (`tests/suites/cli/test_mcp.py`): the handle lifecycle, the two failure kinds, `shell` refused with its reason, an unknown kind refused before anything reaches the accessibility layer.
- **Through the official SDK** (`tests/mcp_client/`): the trio lists, the schemas validate, and a miss parses as a tool error carrying its kind.

Event *delivery* is a platform question — bridge delivery for programmatic actions is unreliable on several app/platform combinations. Rather than xfail around that, which would assert nothing in either direction, the delivery test runs a control: xa11y's own subscription, opened from the pytest process, watches the same application through the same bridge, and the assertion is that an event the library received also reached the MCP poll. It skips only when the bridge delivered to neither, where there was nothing for MCP to lose.

## Not in this change

Revision `2026-07-28` has `subscriptions/listen`, which is the shape this wants once clients catch up: the server pushes instead of the model polling. It serves only the modern era, and the handle trio serves every revision this server speaks, so the docs' "What is not there yet" now points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014owQEdmGzDQJKyitzyX9e5

---
_Generated by [Claude Code](https://claude.ai/code/session_014owQEdmGzDQJKyitzyX9e5)_