### PR TITLE
Shell surfaces: assert a surface is found, per platform (#383)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,15 @@ jobs:
           setup-display: "false"
           setup-atspi: "false"
 
+      # The desktop panel fixture (test-apps/panel/panel.py) that
+      # run_integ_tests.sh launches for the shell-surface tests. A bare Xvfb
+      # display vends no `window-type:dock` frame, so without this the Linux
+      # half of xa11y/tests/integ/shell.rs would have nothing to find — and
+      # the harness fails rather than running a quietly narrower suite.
+      # GTK 3 specifically: GTK 4 dropped window type hints.
+      - name: Install the panel fixture's GTK 3 bindings
+        run: sudo apt-get update && sudo apt-get install -y python3-gi gir1.2-gtk-3.0
+
       - name: Run unit tests
         run: cargo test --workspace
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,15 @@ When adding new tests:
 2. All integration tests must be `#[ignore]` and run via `cargo xtask test-integ`.
 3. Run `cargo xtask test-integ` to verify tests pass before committing.
 
+A test that needs something the *desktop* owns rather than the app is the one
+exception to "add it to the test app". `test-apps/panel/panel.py` is the
+precedent: `xa11y/tests/integ/shell.rs` needs a Linux `window-type:dock` frame
+and a bare Xvfb display has none, so `scripts/run_integ_tests.sh` launches a
+GTK 3 dock window as a fixture. It needs `python3-gi gir1.2-gtk-3.0`, and the
+harness fails rather than running without it — a shell test that skips on an
+empty enumeration passes just as well when the classifier is broken, which is
+the hole issue #383 was about.
+
 ### Test helpers
 
 Integration tests use shared helpers from `xa11y/tests/integ/mod.rs`:

--- a/docs/site/src/content/docs/testing.mdx
+++ b/docs/site/src/content/docs/testing.mdx
@@ -25,7 +25,7 @@ JavaScript, and the CLI. Roughly:
 | Suite | Approx. tests | Location | What it covers |
 | --- | --- | --- | --- |
 | Rust unit | ~60 | `xa11y/tests/unit_test.rs` | Selector engine, locators, roles, state sets, error mapping, serialization (against an in-memory mock provider) |
-| Rust integration | ~150 | `xa11y/tests/integ/` | Live tree reads, action dispatch, events, screenshots against a running app |
+| Rust integration | ~160 | `xa11y/tests/integ/` | Live tree reads, action dispatch, events, screenshots against a running app, and the OS shell surfaces |
 | Python binding unit | ~240 | `xa11y-python/tests/` | The PyO3 surface: types, actions, exceptions, GIL release, subscriptions |
 | Python integration | ~100 | `tests/suites/python/` | Per-app compat, actions, events, errors, input simulation, screenshots |
 | CLI integration | ~80 | `tests/suites/cli/` | The `xa11y` CLI end-to-end against running apps, plus the MCP server and its event subscriptions over every CLI launcher |
@@ -97,6 +97,24 @@ renderers, and two first-party Microsoft UIA providers rather than third-party
 bridges, by way of Windows Forms and WPF. The
 toolkit-specific quirks this surfaces are documented in
 [Accessibility Quirks](/explanation/accessibility-quirks/).
+
+## Shell surfaces are tested against a desktop that has them
+
+Shell surfaces (the taskbar, a menu bar, a desktop panel) are found by three
+hand-written classifiers, one per platform, each keyed on a platform constant:
+a window class name on Windows, an AX attribute name on macOS, an AT-SPI
+`window-type` attribute on Linux. A classifier that stops matching returns an
+empty list, which reads exactly like a desktop that owns no shell UI. A test
+that skips when nothing is listed passes just as happily when the feature is
+broken.
+
+So `xa11y/tests/integ/shell.rs` states what each platform's desktop must vend
+and fails when it is missing. Windows must have a `Shell_TrayWnd` taskbar,
+macOS the menu bar of whichever application is in front, Linux a
+`window-type:dock` frame. The Linux one needs a fixture: a bare Xvfb display runs no desktop
+environment, so the harness launches `test-apps/panel/panel.py`, a GTK 3 dock
+window, and the test asserts it can reach the panel's own button through the
+surface root.
 
 ## One suite, every binding
 

--- a/scripts/Containerfile.base
+++ b/scripts/Containerfile.base
@@ -2,7 +2,12 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# System deps for AT-SPI2 + Xvfb + X11 (matches CI)
+# System deps for AT-SPI2 + Xvfb + X11 (matches CI).
+#
+# python3-gi + gir1.2-gtk-3.0 are for the desktop panel fixture
+# (test-apps/panel/panel.py) that scripts/run_integ_tests.sh launches: the
+# Linux shell-surface tests need a real `window-type:dock` frame on the
+# display, and nothing else here vends one.
 RUN apt-get update && apt-get install -y \
     curl build-essential pkg-config \
     xvfb dbus dbus-x11 \
@@ -15,6 +20,7 @@ RUN apt-get update && apt-get install -y \
     libxcb-shape0 libxcb-shape0-dev \
     libxcb-xfixes0 libxcb-xfixes0-dev \
     x11-utils \
+    python3-gi gir1.2-gtk-3.0 \
     && (apt-get install -y at-spi2-core || apt-get install -y at-spi2-common) \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/run_integ_tests.sh
+++ b/scripts/run_integ_tests.sh
@@ -64,7 +64,50 @@ if [ "${BUILD_ONLY:-}" = "1" ]; then
     exit 0
 fi
 
-# 4. Launch the test application (run binary directly, not via cargo run,
+# 4. Launch the desktop panel fixture.
+#
+#    The Linux shell-surface classifier matches an AT-SPI frame carrying
+#    `window-type:dock`, and a bare Xvfb display vends none — no desktop
+#    environment runs here. Without this fixture the shell tests in
+#    xa11y/tests/integ/shell.rs could only skip on an empty enumeration,
+#    which is the coverage hole issue #383 is about, so the panel is a hard
+#    requirement rather than a best-effort extra.
+#
+#    It needs a Python with the GTK 3 typelib. That is deliberately not
+#    whichever `python3` is first on PATH: CI installs actions/setup-python,
+#    whose interpreter has no PyGObject, while the system one does.
+#
+#    Its output goes to a log rather than the terminal: GTK 3's ATK bridge
+#    emits a CRITICAL for every Text/Value probe against a widget that
+#    implements neither, so a tree read from the panel would interleave a
+#    dozen of them into the test output.
+PANEL_PY=""
+for candidate in "${XA11Y_PANEL_PYTHON:-}" /usr/bin/python3 /usr/bin/python3.12 python3; do
+    [ -n "$candidate" ] || continue
+    command -v "$candidate" >/dev/null 2>&1 || continue
+    if "$candidate" -c 'import gi; gi.require_version("Gtk", "3.0"); from gi.repository import Gtk' \
+        >/dev/null 2>&1; then
+        PANEL_PY="$candidate"
+        break
+    fi
+done
+if [ -z "$PANEL_PY" ]; then
+    echo "error: no Python with GTK 3 (PyGObject) found, so the desktop panel" >&2
+    echo "       fixture cannot start and the shell-surface tests would have" >&2
+    echo "       nothing to find." >&2
+    echo "       Install it:  sudo apt-get install -y python3-gi gir1.2-gtk-3.0" >&2
+    echo "       Or point at an interpreter that has it: XA11Y_PANEL_PYTHON=..." >&2
+    echo "       In the container flow, an image built before the panel landed" >&2
+    echo "       predates that package: rebuild it (<runtime> image rm xa11y-base)." >&2
+    exit 1
+fi
+PANEL_LOG="target/xa11y-test-panel.log"
+mkdir -p target
+echo "Launching xa11y test panel ($PANEL_PY, log: $PANEL_LOG)..."
+"$PANEL_PY" test-apps/panel/panel.py > "$PANEL_LOG" 2>&1 &
+CLEANUP_PIDS+=($!)
+
+# 5. Launch the test application (run binary directly, not via cargo run,
 #    because cargo run changes the process owner name in AT-SPI)
 echo "Launching xa11y-test-app..."
 ./target/debug/xa11y-test-app --headless &
@@ -74,7 +117,7 @@ CLEANUP_PIDS+=($!)
 echo "Waiting for test app to register with AT-SPI..."
 sleep 3
 
-# 5. Run integration tests
+# 6. Run integration tests
 echo "Running integration tests..."
 TEST_FILTER="${TEST_FILTER:-}"
 set +e

--- a/scripts/run_integ_tests.sh
+++ b/scripts/run_integ_tests.sh
@@ -107,6 +107,32 @@ echo "Launching xa11y test panel ($PANEL_PY, log: $PANEL_LOG)..."
 "$PANEL_PY" test-apps/panel/panel.py > "$PANEL_LOG" 2>&1 &
 CLEANUP_PIDS+=($!)
 
+# Verify the fixture is actually up before running anything against it. A
+# panel that failed to start is a broken harness, and saying so here beats six
+# shell tests failing with "no shell surfaces at all" and a log nobody prints:
+# the first time this fixture ran on CI it died on a PyGObject version
+# conflict, and the traceback was sitting in $PANEL_LOG unread.
+echo "Waiting for the panel to register as a shell surface..."
+PANEL_READY=0
+for _ in $(seq 1 20); do
+    if ./target/debug/xa11y shell 2>/dev/null | grep -q "^panel"; then
+        PANEL_READY=1
+        break
+    fi
+    sleep 1
+done
+if [ "$PANEL_READY" != "1" ]; then
+    echo "error: the panel fixture never appeared as a shell surface." >&2
+    echo "--- $PANEL_LOG ---" >&2
+    cat "$PANEL_LOG" >&2 || true
+    echo "--- xa11y shell ---" >&2
+    ./target/debug/xa11y shell >&2 || true
+    echo "--- xa11y apps ---" >&2
+    ./target/debug/xa11y apps >&2 || true
+    exit 1
+fi
+./target/debug/xa11y shell
+
 # 5. Launch the test application (run binary directly, not via cargo run,
 #    because cargo run changes the process owner name in AT-SPI)
 echo "Launching xa11y-test-app..."

--- a/test-apps/panel/panel.py
+++ b/test-apps/panel/panel.py
@@ -1,0 +1,72 @@
+"""xa11y test panel — a Linux desktop panel for the shell-surface tests.
+
+The Linux shell-surface classifier keys on one thing: an AT-SPI `frame`
+carrying the `window-type:dock` attribute, which mirrors the window
+manager's `_NET_WM_WINDOW_TYPE` hint. Nothing in the Xvfb integ environment
+vends one — no desktop environment runs there — so
+`ShellSurface::by_kind(Panel)` had nothing to match and the Linux half of
+the feature was covered only by a unit test against a synthetic attribute
+map (issue #383).
+
+This is the smallest thing that produces a real one: a GTK3 window with
+`GDK_WINDOW_TYPE_HINT_DOCK`, which sets both the X11 property and the
+AT-SPI attribute the classifier reads. GTK3 rather than GTK4 because GTK4
+dropped type hints entirely and has no way to express "this window is a
+dock".
+
+Launched by `scripts/run_integ_tests.sh`; the widgets below are what
+`xa11y/tests/integ/shell.rs` asserts it can reach through the surface root.
+
+    python3 test-apps/panel/panel.py
+
+Needs PyGObject and the GTK 3 typelib (`python3-gi gir1.2-gtk-3.0` on
+Debian/Ubuntu).
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, Gtk  # noqa: E402
+
+# The window title becomes the surface's name, since a frame's AT-SPI name is
+# its title. `shell.rs` matches on it to prove it found *this* panel rather
+# than some other dock frame that happened to be on the display.
+PANEL_TITLE = "xa11y-test-panel"
+
+# One named, pressable widget inside the panel: the assertion that a surface
+# root is an ordinary search root, not just a node that enumerates.
+PANEL_BUTTON_LABEL = "Panel Button"
+
+
+def main() -> int:
+    window = Gtk.Window(title=PANEL_TITLE)
+    # The one line this fixture exists for.
+    window.set_type_hint(Gdk.WindowTypeHint.DOCK)
+    window.set_default_size(640, 32)
+    window.move(0, 0)
+
+    row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+    row.pack_start(Gtk.Label(label="xa11y panel"), False, False, 8)
+    row.pack_start(Gtk.Button(label=PANEL_BUTTON_LABEL), False, False, 8)
+    window.add(row)
+
+    window.connect("destroy", Gtk.main_quit)
+    window.show_all()
+
+    # The harness stops the panel with SIGTERM; without this the default
+    # handler kills the process before GTK can unmap the window, which leaves
+    # the frame in the AT-SPI registry for the next run to trip over.
+    signal.signal(signal.SIGTERM, lambda *_: Gtk.main_quit())
+    signal.signal(signal.SIGINT, lambda *_: Gtk.main_quit())
+
+    Gtk.main()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test-apps/panel/panel.py
+++ b/test-apps/panel/panel.py
@@ -30,7 +30,15 @@ import sys
 
 import gi
 
+# Both versions have to be pinned, not just Gtk. A machine that also has the
+# GTK 4 typelib installed — which any checkout running the `gtk` test app does
+# — resolves a bare `from gi.repository import Gdk` to Gdk 4.0, the newest
+# available, and Gtk 3.0 then fails to load against it with
+# `RepositoryError: Requiring namespace 'Gdk' version '3.0', but '4.0' is
+# already loaded`. The panel dies on import and the display vends no dock
+# frame.
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk, Gtk  # noqa: E402
 
 # The window title becomes the surface's name, since a frame's AT-SPI name is

--- a/tests/matrix.yaml
+++ b/tests/matrix.yaml
@@ -149,6 +149,29 @@ features:
       Python: Tauri app. JS: Tauri + Electron apps. Rust: AccessKit app
       (rust_core).
 
+  shell:
+    description: "OS shell surfaces: enumeration, per-kind lookup, and searching a surface root"
+    per_app: false
+    tested_on: [accesskit]
+    notes: >
+      Not an app feature at all — the surfaces belong to the OS, so the app a
+      cell launched is irrelevant to it. Three vehicles carry it:
+      xa11y/tests/integ/shell.rs (the Rust integ suite: Linux in the `Linux`
+      job, Windows in the `windows` job, macOS locally via
+      run_integ_tests_macos.sh), and tests/suites/cli/test_mcp.py, whose shell
+      tests run in every cell that runs the cli suite.
+      Each platform declares what its desktop must vend and fails when it is
+      absent — Windows a `Shell_TrayWnd` taskbar, macOS the frontmost app's
+      menu bar (the cli suite asserts only that the listing is non-empty
+      there, since which kinds appear depends on what is frontmost), Linux a
+      `window-type:dock` frame. That declaration is the feature: #377 shipped
+      three hand-written classifiers whose whole test suite would have stayed
+      green if enumeration had returned nothing on every platform (#383).
+      The Linux frame comes from test-apps/panel/panel.py, a GTK3 dock window
+      the Rust integ harness launches — a bare Xvfb display has no desktop
+      environment and vends none. It is a fixture rather than a test app: no
+      suite targets it, and it has no cell of its own.
+
   mcp:
     description: "MCP stdio server: framing, dual-era handshake, tool schemas, tool contracts, event subscriptions, and identical behaviour from all three CLI launchers"
     per_app: false
@@ -202,7 +225,7 @@ features:
 # rust_core is the xa11y/tests/integ/ suite — separate from per-app compat suites.
 rust_core:
   app: accesskit
-  features: [compat, actions, events, screenshot]
+  features: [compat, actions, events, screenshot, shell]
   note: >
     Fast-path core validation. All tests are #[ignore] and run via `cargo xtask test-integ`.
     Platform-split event tests: events_linux.rs, events_macos.rs, events_windows.rs.
@@ -294,6 +317,23 @@ gaps:
     affects:
       apps: [tauri]
       features: [input_sim]
+
+  - id: shell_panel_only_in_rust_integ
+    description: >
+      The Linux desktop-panel fixture (test-apps/panel/panel.py) is launched
+      by scripts/run_integ_tests.sh only, so the Rust integ suite is the one
+      place a Linux `panel` surface is asserted to exist. The per-app
+      harness (scripts/run_app_suite.sh) brings up Xvfb with no panel, so the
+      shell tests in tests/suites/cli/test_mcp.py assert enumeration shape
+      there rather than a found surface — on macOS and Windows those same
+      tests do require the desktop's shell UI to be listed. Adding the panel
+      to the per-app harness would also put an extra process in every app
+      listing those suites read, which is why it stops at the Rust suite.
+    severity: low
+    workaround: "xa11y/tests/integ/shell.rs asserts the Linux panel surface end-to-end"
+    affects:
+      features: [shell]
+      language: cli
 
   - id: js_input_sim_per_app
     description: >

--- a/tests/suites/cli/test_mcp.py
+++ b/tests/suites/cli/test_mcp.py
@@ -315,6 +315,44 @@ SHELL_KINDS = {
 }
 
 
+# What the desktop this suite runs on must vend, per platform. The point is
+# that an empty listing fails here rather than passing as a quietly narrower
+# run: every shell assertion below used to sit behind a guard an empty listing
+# satisfied, so `list_shell_surfaces` returning `[]` on all three platforms
+# would have kept the whole file green (issue #383).
+#
+# * Windows — explorer.exe owns a `Shell_TrayWnd` taskbar in every interactive
+#   session, the same session property the UIA tests already rely on.
+# * macOS — the Dock and Finder always own windows in a live session; the AX
+#   backend says as much itself, treating an empty CGWindowList as a failed
+#   call rather than an empty desktop. Which *kinds* get listed depends on
+#   what is frontmost, so only presence is asserted here; the menu bar itself
+#   is pinned in xa11y/tests/integ/shell.rs.
+# * Linux — the app suites run on a bare Xvfb display, where nothing vends a
+#   `window-type:dock` frame. The Rust integ suite launches one
+#   (test-apps/panel/panel.py) and asserts strictly there instead.
+REQUIRED_SHELL_KINDS = {"taskbar"} if sys.platform == "win32" else set()
+SHELL_UI_EXPECTED = sys.platform in ("darwin", "win32")
+
+# A kind this platform's backend cannot classify at all: macOS never produces
+# a taskbar, and neither Windows nor Linux produces a menu bar. The miss-path
+# tests target it so the surface they ask for is absent by construction rather
+# than absent because nothing was listed.
+IMPOSSIBLE_SHELL_KIND = "taskbar" if sys.platform == "darwin" else "menu_bar"
+
+
+def _assert_shell_ui_is_listed(surfaces: list[dict]) -> None:
+    """Fail if the desktop owns shell UI the listing didn't report."""
+    kinds = sorted(s["kind"] for s in surfaces)
+    if SHELL_UI_EXPECTED:
+        assert surfaces, (
+            f"{sys.platform} owns shell UI, so an empty listing means the "
+            "platform classifier matched nothing"
+        )
+    for kind in sorted(REQUIRED_SHELL_KINDS):
+        assert kind in kinds, f"expected a {kind} surface; listed: {kinds}"
+
+
 def _surfaces(mcp) -> list[dict]:
     """The `shell` listing, as rows of {kind, name, pid}."""
     result = mcp.call_tool("shell")["result"]
@@ -324,11 +362,20 @@ def _surfaces(mcp) -> list[dict]:
     return structured["surfaces"]
 
 
+def test_the_shell_listing_reports_the_surfaces_this_desktop_owns(mcp):
+    """The claim the tool exists for, and the one an empty listing would hide.
+
+    See `REQUIRED_SHELL_KINDS` for what each platform owes and why.
+    """
+    _assert_shell_ui_is_listed(_surfaces(mcp))
+
+
 def test_shell_lists_surfaces_the_other_tools_can_target(mcp):
     """Every row must be usable as a `shell` argument without translation.
 
-    No assertion on *which* surfaces exist: that is the runner's desktop, not
-    a property of the tool. A headless Linux cell legitimately reports none.
+    No assertion on *which* surfaces exist here: that is the runner's desktop,
+    not a property of the tool. That the desktop's own shell UI is among them
+    is the test above.
     """
     for surface in _surfaces(mcp):
         assert surface["kind"] in SHELL_KINDS, surface
@@ -382,39 +429,64 @@ def test_an_unknown_shell_kind_names_the_kinds_that_exist(mcp):
 
 
 def test_targeting_a_surface_that_is_not_there_reports_what_is(mcp):
-    """Tenet 6 on the shell: the candidate list is the way out of the miss."""
-    present = {s["kind"] for s in _surfaces(mcp)}
-    absent = sorted(SHELL_KINDS - present)
-    if not absent:
-        pytest.skip("this desktop vends every shell surface kind")
+    """Tenet 6 on the shell: the candidate list is the way out of the miss.
 
-    result = mcp.call_tool("find", {"selector": "*", "shell": absent[0]})["result"]
+    The target is a kind this backend cannot classify at all, so the miss is
+    the same one on every runner — and on a desktop that owns shell UI the
+    candidate list has to name it, which is what an empty listing used to make
+    vacuously true.
+    """
+    surfaces = _surfaces(mcp)
+    _assert_shell_ui_is_listed(surfaces)
+    present = {s["kind"] for s in surfaces}
+    assert IMPOSSIBLE_SHELL_KIND not in present, (
+        f"{sys.platform} listed a {IMPOSSIBLE_SHELL_KIND} surface, which its "
+        f"backend has no branch for: {sorted(present)}"
+    )
+
+    result = mcp.call_tool("find", {"selector": "*", "shell": IMPOSSIBLE_SHELL_KIND})[
+        "result"
+    ]
     assert result["isError"] is True
     structured = result["structuredContent"]
     assert structured["kind"] == "no_match"
-    assert absent[0] in structured["message"], structured["message"]
+    assert IMPOSSIBLE_SHELL_KIND in structured["message"], structured["message"]
     if present:
         candidates = " ".join(structured["diagnosis"]["candidates"])
         assert any(kind in candidates for kind in present), candidates
 
 
 def test_find_can_search_a_listed_shell_surface(mcp):
-    """The claim the feature exists for: a surface is an ordinary search root."""
+    """The claim the feature exists for: a surface is an ordinary search root.
+
+    The target is a kind this platform must vend where there is one, so the
+    search runs against real shell UI rather than against whatever happened to
+    be listed. Only a desktop that owes no surface at all (Linux here) can
+    reach the skip.
+    """
     surfaces = _surfaces(mcp)
+    _assert_shell_ui_is_listed(surfaces)
     if not surfaces:
         pytest.skip("this desktop vends no shell surfaces")
     kinds = [s["kind"] for s in surfaces]
     unique = next((k for k in kinds if kinds.count(k) == 1), None)
-    if unique is None:
+    required = next((k for k in sorted(REQUIRED_SHELL_KINDS) if kinds.count(k) == 1), None)
+    target = required or unique
+    if target is None:
         pytest.skip("every listed surface shares its kind with another")
 
-    result = mcp.call_tool("find", {"selector": "*", "limit": 1, "shell": unique})["result"]
+    result = mcp.call_tool("find", {"selector": "*", "limit": 1, "shell": target})["result"]
     if result["isError"]:
-        # An empty surface is a legitimate answer; a rejected target is not.
+        # An empty surface is a legitimate answer for whatever this desktop
+        # happens to run; it is not one for the shell UI the platform owes,
+        # which always has a tree under it.
+        assert target != required, (
+            f"the {target} surface matched nothing: {result['structuredContent']}"
+        )
         assert result["structuredContent"]["kind"] == "no_match", result["structuredContent"]
         return
     structured = result["structuredContent"]
-    assert structured["shell"]["kind"] == unique
+    assert structured["shell"]["kind"] == target
     assert "application" not in structured, "a taskbar is not an application"
 
 
@@ -1119,12 +1191,17 @@ def test_shell_lists_surfaces_in_tab_separated_columns(entry_point):
     assert result.returncode == 0, result.stderr
     lines = [line for line in result.stdout.splitlines() if line]
     if lines == ["No shell surfaces found."]:
+        # An empty listing is a real answer on a desktop that owns no shell
+        # UI, and a regression on one that does — so it is checked, not
+        # returned past (issue #383).
+        _assert_shell_ui_is_listed([])
         return
     for line in lines:
         kind, pid, name = line.split("\t")
         assert kind in SHELL_KINDS, line
         assert pid == "-" or pid.isdigit(), line
         assert name, line
+    _assert_shell_ui_is_listed([{"kind": line.split("\t")[0]} for line in lines])
 
 
 def test_shell_and_app_are_mutually_exclusive_from_every_launcher(entry_point):
@@ -1144,19 +1221,22 @@ def test_an_unknown_shell_kind_is_a_usage_error_listing_the_kinds(entry_point):
 
 
 def test_a_missing_shell_surface_is_an_operation_failure_not_a_usage_error(entry_point):
-    """The invocation was well-formed; the surface simply is not on screen."""
+    """The invocation was well-formed; the surface simply is not on screen.
+
+    Targets the kind this backend cannot classify, so the exit code being
+    tested comes from a miss that every runner reproduces rather than from
+    whichever kinds this desktop happens to be short of.
+    """
     listing = _run(entry_point, "shell")
     assert listing.returncode == 0, listing.stderr
     present = {
         line.split("\t")[0] for line in listing.stdout.splitlines() if "\t" in line
     }
-    absent = sorted(SHELL_KINDS - present)
-    if not absent:
-        pytest.skip("this desktop vends every shell surface kind")
+    assert IMPOSSIBLE_SHELL_KIND not in present, listing.stdout
 
-    result = _run(entry_point, "find", "*", "--shell", absent[0])
+    result = _run(entry_point, "find", "*", "--shell", IMPOSSIBLE_SHELL_KIND)
     assert result.returncode == 1, result.stdout
-    assert absent[0] in result.stderr, result.stderr
+    assert IMPOSSIBLE_SHELL_KIND in result.stderr, result.stderr
 
 
 # ── Event subscriptions ──────────────────────────────────────────────────────

--- a/xa11y/tests/integ/mod.rs
+++ b/xa11y/tests/integ/mod.rs
@@ -9,6 +9,10 @@
 //! * `multi_window` — multi-window scenarios: opening a second top-level
 //!   window, the `active` state following window focus, and the #304/#305
 //!   foreground/enumeration behaviour with two windows of one process.
+//! * `shell` — OS shell surfaces (taskbar, menu bar, panel): the end-to-end
+//!   evidence that each platform's classifier matches a real surface, with
+//!   the per-platform requirement stated in the file rather than skipped
+//!   when the listing comes back empty.
 //! * `errors` — error paths on the query/wait surface: selector misses,
 //!   invalid selectors, `wait_*` timeouts, auto-wait timeouts, unknown
 //!   actions, invalid action data.
@@ -23,6 +27,7 @@ pub mod actions;
 pub mod errors;
 pub mod multi_window;
 pub mod screenshot;
+pub mod shell;
 pub mod tree;
 
 #[cfg(target_os = "macos")]

--- a/xa11y/tests/integ/shell.rs
+++ b/xa11y/tests/integ/shell.rs
@@ -1,0 +1,376 @@
+//! Shell-surface integration tests — the end-to-end evidence that each
+//! platform's classifier matches something real.
+//!
+//! Every other file in this suite drives the AccessKit test app. This one
+//! drives the desktop the tests are running on: the surfaces are the OS's,
+//! and the classifiers are three hand-written tables of magic constants —
+//! window class names on Windows, AX attribute names on macOS, an AT-SPI
+//! attribute on Linux.
+//!
+//! The rule the whole file is built around is that **an empty enumeration
+//! fails**. Issue #383 is the reason it needs stating: the coverage that
+//! existed for shell surfaces would have stayed green if
+//! `list_shell_surfaces` had returned an empty vec on all three platforms,
+//! because every assertion sat behind a guard that an empty listing
+//! satisfied. [`REQUIRED_KINDS`] names, per platform, the surface the desktop
+//! these tests run on *must* vend; anything less is a failure, never a skip.
+//!
+//! What makes each platform's requirement true:
+//!
+//! * **macOS** — `AXFocusedApplication` → `AXMenuBar`. Something is always
+//!   frontmost in a live session, and an AppKit app always has a menu bar.
+//! * **Windows** — the `Shell_TrayWnd` taskbar, which explorer.exe owns in
+//!   every interactive session. The hosted `windows-latest` runner has one;
+//!   that is the same session property the UIA event tests already rely on.
+//! * **Linux** — nothing on a bare Xvfb display vends a `window-type:dock`
+//!   frame, so `scripts/run_integ_tests.sh` launches one:
+//!   `test-apps/panel/panel.py`, a GTK3 dock window. The fixture is part of
+//!   the harness precisely so this requirement can be unconditional here.
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    #[cfg(target_os = "macos")]
+    use xa11y::AppExt;
+    use xa11y::{Error, ShellSurface, ShellSurfaceExt, ShellSurfaceKind};
+
+    /// The surface kinds the desktop under test must vend. See the module
+    /// docs for why each one holds.
+    #[cfg(target_os = "macos")]
+    const REQUIRED_KINDS: &[ShellSurfaceKind] = &[ShellSurfaceKind::MenuBar];
+    #[cfg(target_os = "windows")]
+    const REQUIRED_KINDS: &[ShellSurfaceKind] = &[ShellSurfaceKind::Taskbar];
+    #[cfg(target_os = "linux")]
+    const REQUIRED_KINDS: &[ShellSurfaceKind] = &[ShellSurfaceKind::Panel];
+
+    /// A kind this platform's backend cannot emit at all, used to check the
+    /// miss path. Each backend classifies a fixed set — macOS never produces
+    /// a taskbar, and neither Windows nor Linux produces a menu bar — so this
+    /// is absent by construction rather than by whatever happens to be open.
+    #[cfg(target_os = "macos")]
+    const IMPOSSIBLE_KIND: ShellSurfaceKind = ShellSurfaceKind::Taskbar;
+    #[cfg(not(target_os = "macos"))]
+    const IMPOSSIBLE_KIND: ShellSurfaceKind = ShellSurfaceKind::MenuBar;
+
+    /// How long to wait for a required surface. The shell is already up
+    /// before the suite starts; the budget covers a panel or taskbar that is
+    /// still registering with the accessibility bus.
+    const LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// The listing, or a panic carrying the enumeration failure. Every test
+    /// here starts from it, so it is never allowed to degrade to "no
+    /// surfaces".
+    fn listing() -> Vec<ShellSurface> {
+        ShellSurface::list().unwrap_or_else(|e| panic!("enumerating shell surfaces failed: {e}"))
+    }
+
+    /// `kind "name" (pid=N)` for each surface — what a failure message owes
+    /// the reader, since the desktop is not reproducible from the test file.
+    fn describe(surfaces: &[ShellSurface]) -> String {
+        if surfaces.is_empty() {
+            return "<none>".to_string();
+        }
+        surfaces
+            .iter()
+            .map(|s| format!("{} \"{}\" (pid={:?})", s.kind, s.name, s.pid))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    /// The load-bearing test: every kind this platform must vend is there.
+    ///
+    /// This is the one that fails when a classifier stops matching — a
+    /// renamed window class, an AX attribute that moved, a `window-type`
+    /// check that no longer fires. Nothing about it can pass on an empty
+    /// listing.
+    #[test]
+    #[ignore]
+    fn every_kind_this_desktop_must_vend_is_present() {
+        let surfaces = listing();
+        assert!(
+            !surfaces.is_empty(),
+            "no shell surfaces at all on a desktop that owns {:?}; the platform \
+             classifier matched nothing",
+            REQUIRED_KINDS
+        );
+        for &kind in REQUIRED_KINDS {
+            let matching: Vec<&ShellSurface> = surfaces.iter().filter(|s| s.kind == kind).collect();
+            assert_eq!(
+                matching.len(),
+                1,
+                "expected exactly one {kind} surface, found {}. Listing: {}",
+                matching.len(),
+                describe(&surfaces)
+            );
+        }
+    }
+
+    /// `by_kind` resolves each required kind, and resolves it to the same
+    /// surface the listing reported — the two entry points cannot disagree
+    /// about what is on the desktop.
+    #[test]
+    #[ignore]
+    fn by_kind_resolves_every_required_surface_the_listing_reports() {
+        let surfaces = listing();
+        for &kind in REQUIRED_KINDS {
+            let resolved = ShellSurface::by_kind(kind, LOOKUP_TIMEOUT).unwrap_or_else(|e| {
+                panic!(
+                    "by_kind({kind}) failed: {e}. Listing: {}",
+                    describe(&surfaces)
+                )
+            });
+            let listed = surfaces
+                .iter()
+                .find(|s| s.kind == kind)
+                .unwrap_or_else(|| panic!("{kind} resolved but is not in the listing"));
+            assert_eq!(resolved.name, listed.name, "{kind} name");
+            assert_eq!(resolved.pid, listed.pid, "{kind} pid");
+        }
+    }
+
+    /// Every row a caller might target has to be usable as one: a name to
+    /// recognise it by, an honest pid, and the kind stamped on the root so a
+    /// bare `Element` carries it too.
+    #[test]
+    #[ignore]
+    fn each_listed_surface_carries_the_fields_a_caller_targets_it_by() {
+        let surfaces = listing();
+        assert!(
+            !surfaces.is_empty(),
+            "the listing is empty, so this test would check nothing; \
+             this desktop owes {REQUIRED_KINDS:?}"
+        );
+
+        for surface in &surfaces {
+            assert!(
+                !surface.name.is_empty(),
+                "a surface a caller has to recognise needs a name: {surface:?}"
+            );
+            assert!(
+                surface.pid.is_none_or(|pid| pid > 0),
+                "pid must be absent or real, never 0: {surface:?}"
+            );
+            let root = surface.as_element();
+            assert_eq!(
+                root.raw.get("shell_kind").and_then(|v| v.as_str()),
+                Some(surface.kind.to_snake_case()),
+                "the surface root must carry its kind in `raw`: {surface:?}"
+            );
+        }
+    }
+
+    /// A surface root is an ordinary search root: it has children, it dumps,
+    /// and a locator rooted at it resolves. This is the claim the feature
+    /// exists for, asserted against a surface that must be there rather than
+    /// whichever one happened to be listed.
+    #[test]
+    #[ignore]
+    fn a_required_surface_root_searches_like_any_other_root() {
+        for &kind in REQUIRED_KINDS {
+            let surface = ShellSurface::by_kind(kind, LOOKUP_TIMEOUT)
+                .unwrap_or_else(|e| panic!("by_kind({kind}) failed: {e}"));
+
+            let children = surface
+                .children()
+                .unwrap_or_else(|e| panic!("{kind} children: {e}"));
+            assert!(
+                !children.is_empty(),
+                "the {kind} surface root reports no children; \
+                 the classifier matched a node with no tree under it"
+            );
+
+            let tree = surface
+                .tree(Some(3))
+                .unwrap_or_else(|e| panic!("{kind} tree: {e}"));
+            assert!(
+                !tree.children.is_empty(),
+                "the {kind} tree snapshot has no children"
+            );
+
+            let dump = surface
+                .dump(Some(2))
+                .unwrap_or_else(|e| panic!("{kind} dump: {e}"));
+            assert!(!dump.trim().is_empty(), "the {kind} dump is empty");
+
+            let all = surface
+                .locator("*")
+                .elements()
+                .unwrap_or_else(|e| panic!("{kind} locator(\"*\"): {e}"));
+            assert!(
+                !all.is_empty(),
+                "a locator rooted at the {kind} surface matched nothing"
+            );
+        }
+    }
+
+    /// The miss path, on a kind the backend cannot produce: it must say what
+    /// it was looking for and what it did see, not just that it failed
+    /// (tenet 6).
+    #[test]
+    #[ignore]
+    fn a_kind_this_platform_cannot_vend_reports_what_it_did_see() {
+        let surfaces = listing();
+        // ZERO: one attempt, no waiting — the kind is absent by construction.
+        let err = ShellSurface::by_kind(IMPOSSIBLE_KIND, Duration::ZERO).expect_err(
+            "this platform's backend cannot classify a surface as this kind, \
+             so the lookup must fail",
+        );
+        let Error::SelectorNotMatched {
+            selector,
+            diagnosis,
+        } = err
+        else {
+            panic!("expected SelectorNotMatched, got {err:?}");
+        };
+        assert_eq!(selector, format!("shell_surface[kind={IMPOSSIBLE_KIND}]"));
+
+        let diagnosis = diagnosis.expect("a terminal miss carries a diagnosis");
+        assert_eq!(
+            diagnosis.condition.as_deref(),
+            Some(format!("a {IMPOSSIBLE_KIND} shell surface").as_str())
+        );
+        let observed = diagnosis
+            .last_observed
+            .as_deref()
+            .expect("the miss must report what it last observed");
+        // The count itself is live — a flyout can open between the listing and
+        // the lookup — so what is asserted is that the miss counted *something*
+        // when the desktop had surfaces to count.
+        assert!(
+            observed.contains("other shell surface(s)"),
+            "the miss must say how many other surfaces it saw: {observed}"
+        );
+        assert!(
+            surfaces.is_empty() || !observed.contains("0 other shell surface(s)"),
+            "the listing had {} surface(s) but the miss reported none: {observed}",
+            surfaces.len()
+        );
+        // The candidate list is the way out of the miss: it must name the
+        // surfaces this desktop *does* vend.
+        let candidates = diagnosis.candidates.join(" ");
+        for &kind in REQUIRED_KINDS {
+            assert!(
+                candidates.contains(kind.to_snake_case()),
+                "the candidate list must name the {kind} surface that is present: \
+                 {candidates:?}"
+            );
+        }
+    }
+
+    // ── Per-platform contents ────────────────────────────────────────────
+
+    /// macOS: the menu bar surface is the frontmost application's, and its
+    /// menus are reachable through it.
+    ///
+    /// The pid check is what proves `AXFocusedApplication` was followed
+    /// rather than some other app's menu bar being picked up: the surface's
+    /// owner must be the app the system reports as foreground.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore]
+    fn the_menu_bar_surface_holds_the_frontmost_apps_menus() {
+        let menu_bar = ShellSurface::by_kind(ShellSurfaceKind::MenuBar, LOOKUP_TIMEOUT)
+            .unwrap_or_else(|e| panic!("no menu bar surface: {e}"));
+
+        let items = menu_bar
+            .locator("menu_item")
+            .elements()
+            .unwrap_or_else(|e| panic!("menu bar items: {e}"));
+        assert!(
+            !items.is_empty(),
+            "the menu bar surface holds no menu items; dump:\n{}",
+            menu_bar.dump(Some(2)).unwrap_or_default()
+        );
+
+        let frontmost = xa11y::App::foreground(LOOKUP_TIMEOUT)
+            .unwrap_or_else(|e| panic!("no foreground app: {e}"));
+        // Both sides being `None` would satisfy the comparison below while
+        // saying nothing, so the pid has to be real before it is compared.
+        assert!(
+            menu_bar.pid.is_some(),
+            "the menu bar surface reports no owning process: {menu_bar:?}"
+        );
+        assert_eq!(
+            menu_bar.pid, frontmost.pid,
+            "the menu bar surface must belong to the frontmost app ({}), not {:?}",
+            frontmost.name, menu_bar.name
+        );
+    }
+
+    /// Windows: the taskbar surface reaches the shell's own controls.
+    ///
+    /// No assertion on a particular button's name — those move between
+    /// Windows releases and locales — but a `Shell_TrayWnd` that yields no
+    /// buttons at all means the class matched something that is not the
+    /// taskbar, or that the surface root is not searchable.
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[ignore]
+    fn the_taskbar_surface_reaches_the_shells_own_buttons() {
+        let taskbar = ShellSurface::by_kind(ShellSurfaceKind::Taskbar, LOOKUP_TIMEOUT)
+            .unwrap_or_else(|e| panic!("no taskbar surface: {e}"));
+        assert!(
+            taskbar.pid.is_some_and(|pid| pid > 0),
+            "the taskbar is hosted by a real process (explorer.exe): {taskbar:?}"
+        );
+
+        let buttons = taskbar
+            .locator("button")
+            .elements()
+            .unwrap_or_else(|e| panic!("taskbar buttons: {e}"));
+        assert!(
+            !buttons.is_empty(),
+            "the taskbar surface holds no buttons; dump:\n{}",
+            taskbar.dump(Some(3)).unwrap_or_default()
+        );
+        assert!(
+            buttons.iter().any(|b| b.name.is_some()),
+            "every taskbar button is unnamed, so none is addressable by name: {:?}",
+            buttons.iter().map(|b| &b.role).collect::<Vec<_>>()
+        );
+    }
+
+    /// Linux: the panel surface is the harness's dock frame, and its widgets
+    /// are reachable through it.
+    ///
+    /// The name check is deliberate — matching *this* frame proves the
+    /// `window-type:dock` attribute was read off a real AT-SPI frame rather
+    /// than some other top-level being mistaken for a panel.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore]
+    fn the_panel_surface_is_the_harnesss_dock_frame() {
+        let panel =
+            ShellSurface::by_kind(ShellSurfaceKind::Panel, LOOKUP_TIMEOUT).unwrap_or_else(|e| {
+                panic!(
+                    "no panel surface: {e}. scripts/run_integ_tests.sh launches \
+                     test-apps/panel/panel.py for this test — is it running?"
+                )
+            });
+        assert_eq!(
+            panel.name, "xa11y-test-panel",
+            "the panel surface is the harness's dock frame"
+        );
+        assert!(
+            panel.pid.is_some_and(|pid| pid > 0),
+            "the panel frame belongs to the panel process: {panel:?}"
+        );
+
+        let button = panel
+            .locator("button[name=\"Panel Button\"]")
+            .element()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "the panel's own button is not reachable from the surface root: {e}\n{}",
+                    panel.dump(Some(3)).unwrap_or_default()
+                )
+            });
+        assert_eq!(button.name.as_deref(), Some("Panel Button"));
+        assert!(
+            button.actions.iter().any(|a| a == "press"),
+            "the panel button advertises no press action: {:?}",
+            button.actions
+        );
+    }
+}


### PR DESCRIPTION
Closes #383.

#377 shipped three hand-written shell classifiers keyed on magic constants and no end-to-end test that any of them ever matched. Every substantive assertion that existed sat behind a guard an empty listing satisfied, so `list_shell_surfaces` returning `Ok(vec[])` on all three platforms would have kept the suite green.

## `xa11y/tests/integ/shell.rs`

Six tests built around a per-platform `REQUIRED_KINDS` constant. An empty enumeration **fails**, never skips.

| Platform | What the desktop must vend | Why it holds |
|---|---|---|
| Windows | `Shell_TrayWnd` taskbar | explorer.exe owns one in every interactive session, the same session property the UIA event tests rely on |
| macOS | the frontmost app's menu bar | something is always frontmost in a live session, and an AppKit app always has a menu bar |
| Linux | a `window-type:dock` frame | supplied by the new panel fixture below |

- `every_kind_this_desktop_must_vend_is_present` — the load-bearing one.
- `by_kind_resolves_every_required_surface_the_listing_reports` — the two entry points cannot disagree about what is on the desktop.
- `each_listed_surface_carries_the_fields_a_caller_targets_it_by` — a name, an honest pid, and `shell_kind` stamped on the root.
- `a_required_surface_root_searches_like_any_other_root` — `children`, `tree`, `dump`, and a rooted `locator("*")`.
- `a_kind_this_platform_cannot_vend_reports_what_it_did_see` — targets a kind the backend has no branch for (taskbar on macOS, menu bar elsewhere), so the miss reproduces on every runner, and asserts the diagnosis names the surfaces that *are* there.
- Per-platform contents: macOS menu items plus a pid matching the frontmost app; Windows taskbar buttons reachable and at least one named; Linux the panel's own button, advertising `press`.

## The Linux fixture

The issue called for a panel in the Xvfb image. Instead of `xfce4-panel`, `test-apps/panel/panel.py` is a GTK 3 dock window — the smallest thing that produces a real `window-type:dock` AT-SPI frame. GTK 3 rather than GTK 4 because GTK 4 dropped window type hints and cannot express one.

`scripts/run_integ_tests.sh` launches it and **exits non-zero** when no GTK 3-capable Python is on the box, so the suite cannot quietly narrow itself. It probes for an interpreter that can import GTK 3 rather than taking the first `python3` on PATH: CI's `actions/setup-python` interpreter has no PyGObject while the system one does. The `Linux` job and `Containerfile.base` install `python3-gi gir1.2-gtk-3.0`.

## `tests/suites/cli/test_mcp.py`

The skips named in the issue are gone on the platforms whose cells own shell UI:

- the listing must be non-empty on macOS and Windows, and must contain a taskbar on Windows;
- `test_find_can_search_a_listed_shell_surface` searches the kind the platform owes rather than whichever kind happened to be listed;
- the CLI listing test checks the `No shell surfaces found.` branch instead of returning past it;
- both miss-path tests target the structurally impossible kind, so they no longer pass more easily the emptier the listing is.

## `tests/matrix.yaml`

A `shell` feature entry (there was none, so the coverage index did not know the feature existed), `shell` added to `rust_core.features`, and a `shell_panel_only_in_rust_integ` gap recording that the panel fixture stops at the Rust harness — adding it to the per-app harness would put an extra process into every app listing those suites read.

## Verification

Run on this Linux box:

- full Rust integ suite, 151 → **157 tests, all passing**, with the panel up;
- negative check: with the panel not running, all six shell tests **fail** rather than skip;
- CLI/MCP suite against the Qt app: every shell test passes, and the two remaining skips are the ones Linux cannot satisfy without a panel (the documented gap);
- `cargo fmt --check`, clippy `-D warnings`, `ruff check`, `tests/matrix_check.py`, the three docs checks, and Vale (0 errors across the README and 26 docs pages).

Not runnable here: the macOS and Windows bodies. They were type-checked by temporarily stripping the `cfg` gates and compiling on Linux; the `windows` job is the first real run of that half, and macOS stays a local-only run as it was before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tafa6FjgpoRFpTDGN9Z5P8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tafa6FjgpoRFpTDGN9Z5P8)_