### PR TITLE
Fix native tray menu discovery

### DIFF
--- a/docs/site/src/content/docs/reference/shell.mdx
+++ b/docs/site/src/content/docs/reference/shell.mdx
@@ -48,7 +48,7 @@ process's `AXSystemDialog` window, whose enumeration contract differs from a
 status item's shown menu. Windows leaves Notification Center out because its
 window class is also used by ordinary UWP apps, and separating them takes a
 process-image lookup the backend does not perform. An absent surface is
-honest; a misclassified application window is not.
+honest. A misclassified application window is not.
 
 The `unknown` kind is a reserved fallback, so a shell window some future
 backend cannot classify degrades to reachable-but-untagged instead of

--- a/docs/site/src/content/docs/reference/shell.mdx
+++ b/docs/site/src/content/docs/reference/shell.mdx
@@ -33,7 +33,7 @@ spelling in Rust, Python, JavaScript, the CLI, and MCP.
 | `panel` | *(none)* | *(none)* | Each AT-SPI frame carrying `window-type:dock`. One surface per frame, so a panel and a dock row are two surfaces. |
 | `dock` | *(none)* | The Dock process's application element. | *(none)* |
 | `desktop` | The `SysListView32` desktop list view, reached as `Progman` → `SHELLDLL_DefView` → `SysListView32`. A shell without that chain contributes no `desktop` surface. | Finder's desktop scroll area. | *(none)* |
-| `flyout` | The tray overflow, Quick Settings, and shell context-menu popups, while open. | *(none)*, not in v1. | *(none)* |
+| `flyout` | The tray overflow, Quick Settings, and native popup menus, while open. | A native status-item menu exposed through `AXShownMenuUIElement`, while open. | *(none)* |
 | `unknown` | *(none)* | *(none)* | *(none)* |
 
 A cell reading *(none)* means the platform vends no such surface. `list()` on
@@ -42,14 +42,13 @@ with `SelectorNotMatched` naming what was found instead. Windows has no
 per-process tray hosting, so tray icons live inside the `taskbar` and `flyout`
 surfaces rather than under `status_items`.
 
-Two of the empty cells are a scoping decision rather than a platform gap.
-macOS emits no `flyout` in v1: an opened Control Center or Notification
-Center panel is a shell process's `AXSystemDialog` window, whose enumeration
-contract differs from every other macOS surface. Windows leaves the
-Notification Center out of its `flyout` set, because its window class is the
-one ordinary UWP apps also use and separating them takes a process-image
-lookup the backend does not perform. An absent surface is honest; a
-misclassified application window is not.
+Some omitted flyouts are a scoping decision rather than a platform gap. On
+macOS, an opened Control Center or Notification Center panel is a shell
+process's `AXSystemDialog` window, whose enumeration contract differs from a
+status item's shown menu. Windows leaves Notification Center out because its
+window class is also used by ordinary UWP apps, and separating them takes a
+process-image lookup the backend does not perform. An absent surface is
+honest; a misclassified application window is not.
 
 The `unknown` kind is a reserved fallback, so a shell window some future
 backend cannot classify degrades to reachable-but-untagged instead of
@@ -74,8 +73,9 @@ string the way you handle an unknown role.
 
 `pid` reports the process the platform attributes the surface to, which is not
 always the process that drew the icon you are looking at. On macOS it is the
-true owner. On Windows it is the host process (`explorer.exe`), because UIA
-carries no per-icon owner. On Linux it is the panel process.
+true owner. On Windows it is the process hosting the surface: a native popup's
+owner, or the shell host (`explorer.exe`) for taskbar and tray-icon elements
+because UIA carries no per-icon owner. On Linux it is the panel process.
 
 The surface root also carries its kind in its raw platform attributes, under
 the key `shell_kind`, so it shows up in `tree()` and `dump()` output and reads

--- a/scripts/run_integ_tests_windows.ps1
+++ b/scripts/run_integ_tests_windows.ps1
@@ -20,11 +20,18 @@ if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 Write-Host "Launching xa11y-test-app..."
 $testApp = Start-Process -FilePath ".\target\debug\xa11y-test-app.exe" -ArgumentList "--headless" -PassThru -WindowStyle Hidden
 
-# Wait for accessibility registration
-Write-Host "Waiting for test app to register..."
-Start-Sleep -Seconds 3
-
+$testExit = 1
+$trayFixture = $null
 try {
+    Write-Host "Launching native notification-area fixture..."
+    # Windows PowerShell hosts the .NET Framework WinForms implementation;
+    # its legacy ContextMenu is backed by a native HMENU/#32768 popup.
+    $trayFixture = Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-File", ".\test-apps\windows-tray\app.ps1" -PassThru -WindowStyle Hidden
+
+    # Wait for accessibility registration
+    Write-Host "Waiting for test app and tray fixture to register..."
+    Start-Sleep -Seconds 3
+
     # 3. Run integration tests
     Write-Host "Running integration tests..."
     if ($testFilter) {
@@ -38,6 +45,10 @@ try {
     Write-Host "Cleaning up..."
     Stop-Process -Id $testApp.Id -Force -ErrorAction SilentlyContinue
     Wait-Process -Id $testApp.Id -Timeout 5 -ErrorAction SilentlyContinue
+    if ($null -ne $trayFixture) {
+        Stop-Process -Id $trayFixture.Id -Force -ErrorAction SilentlyContinue
+        Wait-Process -Id $trayFixture.Id -Timeout 5 -ErrorAction SilentlyContinue
+    }
 }
 
 Write-Host "=== Integration tests finished (exit code: $testExit) ==="

--- a/scripts/run_integ_tests_windows.ps1
+++ b/scripts/run_integ_tests_windows.ps1
@@ -16,17 +16,20 @@ Write-Host "Building workspace..."
 cargo build --workspace 2>&1 | Write-Host
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-# 2. Launch the test application
-Write-Host "Launching xa11y-test-app..."
-$testApp = Start-Process -FilePath ".\target\debug\xa11y-test-app.exe" -ArgumentList "--headless" -PassThru -WindowStyle Hidden
-
 $testExit = 1
 $trayFixture = $null
+$testApp = $null
 try {
+    # 2. Launch the background fixture before the test app. PowerShell can
+    # briefly become the foreground process as it initializes WinForms; the
+    # test app must launch last to preserve the harness's foreground contract.
     Write-Host "Launching native notification-area fixture..."
     # Windows PowerShell hosts the .NET Framework WinForms implementation;
     # its legacy ContextMenu is backed by a native HMENU/#32768 popup.
     $trayFixture = Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile", "-File", ".\test-apps\windows-tray\app.ps1" -PassThru -WindowStyle Hidden
+
+    Write-Host "Launching xa11y-test-app..."
+    $testApp = Start-Process -FilePath ".\target\debug\xa11y-test-app.exe" -ArgumentList "--headless" -PassThru -WindowStyle Hidden
 
     # Wait for accessibility registration
     Write-Host "Waiting for test app and tray fixture to register..."
@@ -43,8 +46,10 @@ try {
 } finally {
     # 4. Cleanup
     Write-Host "Cleaning up..."
-    Stop-Process -Id $testApp.Id -Force -ErrorAction SilentlyContinue
-    Wait-Process -Id $testApp.Id -Timeout 5 -ErrorAction SilentlyContinue
+    if ($null -ne $testApp) {
+        Stop-Process -Id $testApp.Id -Force -ErrorAction SilentlyContinue
+        Wait-Process -Id $testApp.Id -Timeout 5 -ErrorAction SilentlyContinue
+    }
     if ($null -ne $trayFixture) {
         Stop-Process -Id $trayFixture.Id -Force -ErrorAction SilentlyContinue
         Wait-Process -Id $trayFixture.Id -Timeout 5 -ErrorAction SilentlyContinue

--- a/test-apps/cocoa/main.swift
+++ b/test-apps/cocoa/main.swift
@@ -29,6 +29,8 @@ if let path = pidFile {
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     var window: NSWindow!
+    var statusItem: NSStatusItem!
+    var statusMenu: NSMenu!
 
     func applicationDidFinishLaunching(_: Notification) {
         let contentRect = NSRect(x: 0, y: 0, width: 700, height: 800)
@@ -44,6 +46,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if headless {
             NSApp.setActivationPolicy(.accessory)
         }
+
+        // A genuine NSStatusItem fixture for shell-surface integration tests.
+        // Its menu is deliberately opened from an ordinary app button below:
+        // AXPress must return before AppKit enters menu tracking, so the test
+        // process remains free to enumerate AXShownMenuUIElement.
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem.button?.title = "XA"
+        statusItem.button?.setAccessibilityLabel("xa11y status fixture")
+        statusMenu = NSMenu(title: "xa11y status menu")
+        let statusAction = NSMenuItem(
+            title: "xa11y Status Action",
+            action: #selector(AppDelegate.onStatusAction),
+            keyEquivalent: ""
+        )
+        statusAction.target = self
+        statusMenu.addItem(statusAction)
+        statusItem.menu = statusMenu
 
         let scroll = NSScrollView(frame: contentRect)
         scroll.hasVerticalScroller = true
@@ -84,6 +103,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         cancelButton.setAccessibilityLabel("Cancel")
         cancelButton.isEnabled = false
         btnBox.addSubview(cancelButton)
+
+        let openStatusMenuButton = NSButton(frame: NSRect(x: 280, y: 20, width: 180, height: 32))
+        openStatusMenuButton.bezelStyle = .rounded
+        openStatusMenuButton.title = "Open Status Menu"
+        openStatusMenuButton.setAccessibilityLabel("Open Status Menu")
+        openStatusMenuButton.action = #selector(AppDelegate.onOpenStatusMenuPressed)
+        openStatusMenuButton.target = self
+        btnBox.addSubview(openStatusMenuButton)
 
         // ── Checkboxes ───────────────────────────────────────────────────
         let chkBox = NSBox(frame: NSRect(x: 12, y: y - 100, width: 656, height: 100))
@@ -349,6 +376,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func onOKPressed() {
         cancelButton.isEnabled = true
+    }
+
+    @objc func onOpenStatusMenuPressed() {
+        // Enter menu tracking after AXPress has returned to its caller. Opening
+        // synchronously here would block that accessibility request until the
+        // menu closes, leaving no opportunity for the test to inspect it.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.statusItem.button?.performClick(nil)
+        }
+    }
+
+    @objc func onStatusAction() {
+        // The integration test presses this real NSMenuItem to close the menu.
     }
 
     @objc func onSubmitPressed() {

--- a/test-apps/cocoa/main.swift
+++ b/test-apps/cocoa/main.swift
@@ -382,7 +382,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Enter menu tracking after AXPress has returned to its caller. Opening
         // synchronously here would block that accessibility request until the
         // menu closes, leaving no opportunity for the test to inspect it.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+        // One second keeps the menu's nested tracking loop clear of the AX
+        // request/response window on slower hosted runners.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             self?.statusItem.button?.performClick(nil)
         }
     }

--- a/test-apps/cocoa/main.swift
+++ b/test-apps/cocoa/main.swift
@@ -385,7 +385,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // One second keeps the menu's nested tracking loop clear of the AX
         // request/response window on slower hosted runners.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            self?.statusItem.button?.performClick(nil)
+            guard let self, let button = self.statusItem.button else { return }
+            // Open the actual NSMenu explicitly. performClick is allowed to be
+            // ignored for a synthetic event on hosted macOS sessions even
+            // though the status button remains accessibility-visible.
+            self.statusMenu.popUp(positioning: nil, at: .zero, in: button)
         }
     }
 

--- a/test-apps/cocoa/main.swift
+++ b/test-apps/cocoa/main.swift
@@ -50,8 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // A genuine NSStatusItem fixture for shell-surface integration tests.
         // The test locates and pointer-clicks this actual menu-bar element.
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        statusItem.button?.title = "XA"
-        statusItem.button?.setAccessibilityLabel("xa11y status fixture")
+        statusItem.button?.title = "xa11y status fixture"
         statusMenu = NSMenu(title: "xa11y status menu")
         let statusAction = NSMenuItem(
             title: "xa11y Status Action",

--- a/test-apps/cocoa/main.swift
+++ b/test-apps/cocoa/main.swift
@@ -48,9 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // A genuine NSStatusItem fixture for shell-surface integration tests.
-        // Its menu is deliberately opened from an ordinary app button below:
-        // AXPress must return before AppKit enters menu tracking, so the test
-        // process remains free to enumerate AXShownMenuUIElement.
+        // The test locates and pointer-clicks this actual menu-bar element.
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem.button?.title = "XA"
         statusItem.button?.setAccessibilityLabel("xa11y status fixture")
@@ -103,14 +101,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         cancelButton.setAccessibilityLabel("Cancel")
         cancelButton.isEnabled = false
         btnBox.addSubview(cancelButton)
-
-        let openStatusMenuButton = NSButton(frame: NSRect(x: 280, y: 20, width: 180, height: 32))
-        openStatusMenuButton.bezelStyle = .rounded
-        openStatusMenuButton.title = "Open Status Menu"
-        openStatusMenuButton.setAccessibilityLabel("Open Status Menu")
-        openStatusMenuButton.action = #selector(AppDelegate.onOpenStatusMenuPressed)
-        openStatusMenuButton.target = self
-        btnBox.addSubview(openStatusMenuButton)
 
         // ── Checkboxes ───────────────────────────────────────────────────
         let chkBox = NSBox(frame: NSRect(x: 12, y: y - 100, width: 656, height: 100))
@@ -376,21 +366,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func onOKPressed() {
         cancelButton.isEnabled = true
-    }
-
-    @objc func onOpenStatusMenuPressed() {
-        // Enter menu tracking after AXPress has returned to its caller. Opening
-        // synchronously here would block that accessibility request until the
-        // menu closes, leaving no opportunity for the test to inspect it.
-        // One second keeps the menu's nested tracking loop clear of the AX
-        // request/response window on slower hosted runners.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            guard let self, let button = self.statusItem.button else { return }
-            // Open the actual NSMenu explicitly. performClick is allowed to be
-            // ignored for a synthetic event on hosted macOS sessions even
-            // though the status button remains accessibility-visible.
-            self.statusMenu.popUp(positioning: nil, at: .zero, in: button)
-        }
     }
 
     @objc func onStatusAction() {

--- a/test-apps/windows-tray/app.ps1
+++ b/test-apps/windows-tray/app.ps1
@@ -1,0 +1,30 @@
+# Native Windows notification-area fixture for shell-surface integration tests.
+#
+# The legacy WinForms ContextMenu wraps a Win32 HMENU, so opening it creates
+# the system #32768 popup window used by native tray applications. NotifyIcon
+# registers with Explorer's real notification area; Windows may place a newly
+# registered icon in the visible row or in the real overflow flyout.
+
+$ErrorActionPreference = "Stop"
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$menu = [System.Windows.Forms.ContextMenu]::new()
+[void]$menu.MenuItems.Add("xa11y tray action one")
+[void]$menu.MenuItems.Add("xa11y tray action two")
+
+$icon = [System.Windows.Forms.NotifyIcon]::new()
+$icon.Icon = [System.Drawing.SystemIcons]::Application
+$icon.Text = "xa11y tray fixture"
+$icon.ContextMenu = $menu
+$icon.Visible = $true
+
+try {
+    [System.Windows.Forms.Application]::Run()
+}
+finally {
+    $icon.Visible = $false
+    $icon.Dispose()
+    $menu.Dispose()
+}

--- a/tests/matrix.yaml
+++ b/tests/matrix.yaml
@@ -39,6 +39,10 @@ apps:
 
   cocoa:
     platforms: [macos]
+    notes: >
+      Includes a genuine NSStatusItem and NSMenu fixture. The Python shell
+      integration test opens that menu and requires its visible NSMenuItem to
+      be reachable through a flyout surface.
 
   tauri:
     platforms: [linux, macos, windows]
@@ -185,6 +189,9 @@ features:
       `window-type:dock` frame. That declaration is the feature: #377 shipped
       three hand-written classifiers whose whole test suite would have stayed
       green if enumeration had returned nothing on every platform (#383).
+      The Windows Rust suite also right-clicks a real notification-area
+      control and requires the resulting native popup's visible menu items to
+      be reachable through a `flyout` surface.
       The Linux frame comes from test-apps/panel/panel.py, a GTK3 dock window
       the Rust integ harness launches — a bare Xvfb display has no desktop
       environment and vends none. It is a fixture rather than a test app: no

--- a/tests/matrix.yaml
+++ b/tests/matrix.yaml
@@ -189,9 +189,10 @@ features:
       `window-type:dock` frame. That declaration is the feature: #377 shipped
       three hand-written classifiers whose whole test suite would have stayed
       green if enumeration had returned nothing on every platform (#383).
-      The Windows Rust suite also right-clicks a real notification-area
-      control and requires the resulting native popup's visible menu items to
-      be reachable through a `flyout` surface.
+      The Windows Rust harness registers a native NotifyIcon in Explorer's
+      real notification area. The suite right-clicks that taskbar or overflow
+      icon and requires its native popup's visible menu items to be reachable
+      through a `flyout` surface.
       The Linux frame comes from test-apps/panel/panel.py, a GTK3 dock window
       the Rust integ harness launches — a bare Xvfb display has no desktop
       environment and vends none. It is a fixture rather than a test app: no

--- a/tests/suites/python/test_shell.py
+++ b/tests/suites/python/test_shell.py
@@ -30,9 +30,15 @@ def test_cocoa_status_item_menu_is_a_flyout(app_name, app):
                 break
             time.sleep(0.1)
 
+        status_items = next(
+            surface
+            for surface in xa11y.ShellSurface.list()
+            if surface.kind == "status_items" and surface.pid == app.pid
+        )
         assert len(flyouts) == 1, (
             "the Cocoa fixture opened a native status menu, but no flyout was "
-            f"reported for pid {app.pid}; surfaces={xa11y.ShellSurface.list()!r}"
+            f"reported for pid {app.pid}; surfaces={xa11y.ShellSurface.list()!r}; "
+            f"status tree:\n{status_items.dump(max_depth=6)}"
         )
 
         action = flyouts[0].locator('menu_item[name="xa11y Status Action"]').element()

--- a/tests/suites/python/test_shell.py
+++ b/tests/suites/python/test_shell.py
@@ -15,7 +15,13 @@ def test_cocoa_status_item_menu_is_a_flyout(app_name, app):
     if sys.platform != "darwin" or app_name != "cocoa":
         pytest.skip("the native NSStatusItem fixture belongs to the macOS Cocoa cell")
 
-    app.locator('button[name="Open Status Menu"]').press()
+    status_items = next(
+        surface
+        for surface in xa11y.ShellSurface.list()
+        if surface.kind == "status_items" and surface.pid == app.pid
+    )
+    status_icon = status_items.locator('[name="xa11y status fixture"]').element()
+    xa11y.input_sim().click(status_icon)
     menu_closed = False
     try:
         deadline = time.monotonic() + 5.0
@@ -30,11 +36,6 @@ def test_cocoa_status_item_menu_is_a_flyout(app_name, app):
                 break
             time.sleep(0.1)
 
-        status_items = next(
-            surface
-            for surface in xa11y.ShellSurface.list()
-            if surface.kind == "status_items" and surface.pid == app.pid
-        )
         assert len(flyouts) == 1, (
             "the Cocoa fixture opened a native status menu, but no flyout was "
             f"reported for pid {app.pid}; surfaces={xa11y.ShellSurface.list()!r}; "

--- a/tests/suites/python/test_shell.py
+++ b/tests/suites/python/test_shell.py
@@ -20,6 +20,10 @@ def test_cocoa_status_item_menu_is_a_flyout(app_name, app):
         for surface in xa11y.ShellSurface.list()
         if surface.kind == "status_items" and surface.pid == app.pid
     )
+    assert not any(
+        surface.kind == "flyout" and surface.pid == app.pid
+        for surface in xa11y.ShellSurface.list()
+    ), "the Cocoa fixture's closed status menu must not be listed as a flyout"
     status_icon = status_items.locator('[name="xa11y status fixture"]').element()
     xa11y.input_sim().click(status_icon)
     menu_closed = False

--- a/tests/suites/python/test_shell.py
+++ b/tests/suites/python/test_shell.py
@@ -1,0 +1,49 @@
+"""End-to-end shell-surface coverage requiring a native desktop fixture."""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import pytest
+
+import xa11y
+
+
+def test_cocoa_status_item_menu_is_a_flyout(app_name, app):
+    """An open, real NSStatusItem menu is discoverable outside the app tree."""
+    if sys.platform != "darwin" or app_name != "cocoa":
+        pytest.skip("the native NSStatusItem fixture belongs to the macOS Cocoa cell")
+
+    app.locator('button[name="Open Status Menu"]').press()
+    menu_closed = False
+    try:
+        deadline = time.monotonic() + 5.0
+        flyouts = []
+        while time.monotonic() < deadline:
+            flyouts = [
+                surface
+                for surface in xa11y.ShellSurface.list()
+                if surface.kind == "flyout" and surface.pid == app.pid
+            ]
+            if flyouts:
+                break
+            time.sleep(0.1)
+
+        assert len(flyouts) == 1, (
+            "the Cocoa fixture opened a native status menu, but no flyout was "
+            f"reported for pid {app.pid}; surfaces={xa11y.ShellSurface.list()!r}"
+        )
+
+        action = flyouts[0].locator('menu_item[name="xa11y Status Action"]').element()
+        assert action.visible is True
+        action.press()
+        menu_closed = True
+    finally:
+        # Dismiss the system-modal menu even when discovery itself regresses,
+        # so one failure cannot poison the rest of the shared Cocoa app run.
+        if not menu_closed:
+            try:
+                xa11y.input_sim().press("Escape")
+            except xa11y.XA11yError:
+                pass  # Preserve the discovery failure if cleanup also fails.

--- a/xa11y-core/src/shell.rs
+++ b/xa11y-core/src/shell.rs
@@ -216,9 +216,11 @@ pub struct ShellSurface {
     /// the platform vends no name for the root.
     pub name: String,
     /// Owning process where the platform reports one honestly. On macOS this
-    /// is always the true owner. On Windows it is the *host* (explorer.exe /
-    /// ShellHost.exe) because UIA carries no per-icon owner — documented as
-    /// the host, never faked. On Linux it is the panel process.
+    /// is always the true owner. On Windows it is the process that hosts the
+    /// surface: explorer.exe / ShellHost.exe for shell chrome, or the owning
+    /// application for a native popup menu. UIA carries no per-icon owner, so
+    /// taskbar and tray-icon elements still report their shell host, never a
+    /// guessed application. On Linux it is the panel process.
     pub pid: Option<u32>,
     /// The surface's root element data.
     pub data: ElementData,

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -3095,11 +3095,12 @@ impl MacOSProvider {
     /// `Flyout` roots.
     ///
     /// AppKit may keep a status-item menu permanently in `AXChildren`, even
-    /// while it is closed, and place it in `AXVisibleChildren` only while it
-    /// is open. Other implementations expose a detached menu through AppKit's
-    /// `AXShownMenu` or Carbon's `AXShownMenuUIElement`. Probe the owning
-    /// application, extras bar, and each direct status-item child because
-    /// those provider shapes vary across implementations.
+    /// while it is closed. An open attached menu either enters
+    /// `AXVisibleChildren` or gains its non-empty on-screen frame. Other
+    /// implementations expose a detached menu through AppKit's `AXShownMenu`
+    /// or Carbon's `AXShownMenuUIElement`. Probe the owning application,
+    /// extras bar, and each direct status-item child because those provider
+    /// shapes vary across implementations.
     ///
     /// Each probe carries the same per-element timeout as the rest of shell
     /// discovery. An app that does not answer contributes no flyout, matching
@@ -3125,13 +3126,25 @@ impl MacOSProvider {
                 let Some(_bound) = Self::shell_probe_bound(&provider) else {
                     continue;
                 };
-                let mut shown_menus: Vec<AXElement> =
-                    ax_element_array(provider.as_ptr(), "AXVisibleChildren")
-                        .into_iter()
-                        .filter(|child| {
-                            ax_string(child.as_ptr(), "AXRole").as_deref() == Some("AXMenu")
-                        })
-                        .collect();
+                let visible_children = ax_element_array(provider.as_ptr(), "AXVisibleChildren")
+                    .into_iter()
+                    .filter(|child| {
+                        ax_string(child.as_ptr(), "AXRole").as_deref() == Some("AXMenu")
+                    })
+                    .collect::<Vec<_>>();
+                let mut shown_menus = visible_children;
+                for attached_menu in ax_children(provider.as_ptr()).into_iter().filter(|child| {
+                    ax_string(child.as_ptr(), "AXRole").as_deref() == Some("AXMenu")
+                }) {
+                    let data = self.build_element_data(&attached_menu, status_data.pid);
+                    if data.states.visible
+                        && data
+                            .bounds
+                            .is_some_and(|bounds| bounds.width > 0 && bounds.height > 0)
+                    {
+                        shown_menus.push(attached_menu);
+                    }
+                }
                 for attribute in ["AXShownMenu", "AXShownMenuUIElement"] {
                     match probe_element_list_attr(provider.as_ptr(), attribute) {
                         ElementListProbe::Found(menus) => shown_menus.extend(menus),

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -458,9 +458,9 @@ enum ElementProbe {
     Unanswered(i32),
 }
 
-/// Outcome of reading an array-valued AX attribute whose members are
-/// accessibility elements.
-enum ElementArrayProbe {
+/// Outcome of reading an AX attribute containing one or more accessibility
+/// elements.
+enum ElementListProbe {
     Found(Vec<AXElement>),
     Absent,
     Unanswered,
@@ -494,11 +494,13 @@ fn probe_element_attr(element: AXUIElementRef, attribute: &str) -> ElementProbe 
     }
 }
 
-/// Read an AX attribute containing an array of accessibility elements.
+/// Read an AX attribute containing an accessibility element or an array of
+/// accessibility elements.
 ///
-/// `kAXShownMenuUIElementAttribute` uses this shape despite its singular
-/// name. Each returned member is retained before the owning array is released.
-fn probe_element_array_attr(element: AXUIElementRef, attribute: &str) -> ElementArrayProbe {
+/// AppKit's `AXShownMenu` is element-valued, while the Carbon
+/// `AXShownMenuUIElement` contract is array-valued. Each returned value is
+/// owned independently of the copied attribute value.
+fn probe_element_list_attr(element: AXUIElementRef, attribute: &str) -> ElementListProbe {
     let attr = CFString::new(attribute);
     let mut value: CFTypeRef = std::ptr::null();
     let err =
@@ -506,13 +508,14 @@ fn probe_element_array_attr(element: AXUIElementRef, attribute: &str) -> Element
     match err {
         AX_ERROR_SUCCESS => {
             if value.is_null() {
-                return ElementArrayProbe::Absent;
+                return ElementListProbe::Absent;
+            }
+            if unsafe { safe_cf_get_type_id(value) } != unsafe { safe_cf_array_get_type_id() } {
+                return ElementListProbe::Found(vec![AXElement::from_owned(
+                    value as AXUIElementRef,
+                )]);
             }
             let elements = unsafe {
-                if safe_cf_get_type_id(value) != safe_cf_array_get_type_id() {
-                    safe_cf_release(value);
-                    return ElementArrayProbe::Unanswered;
-                }
                 let count = safe_cf_array_get_count(value);
                 let mut elements = Vec::with_capacity(count as usize);
                 for i in 0..count {
@@ -525,13 +528,13 @@ fn probe_element_array_attr(element: AXUIElementRef, attribute: &str) -> Element
                 elements
             };
             if elements.is_empty() {
-                ElementArrayProbe::Absent
+                ElementListProbe::Absent
             } else {
-                ElementArrayProbe::Found(elements)
+                ElementListProbe::Found(elements)
             }
         }
-        AX_ERROR_ATTRIBUTE_UNSUPPORTED | AX_ERROR_NO_VALUE => ElementArrayProbe::Absent,
-        _ => ElementArrayProbe::Unanswered,
+        AX_ERROR_ATTRIBUTE_UNSUPPORTED | AX_ERROR_NO_VALUE => ElementListProbe::Absent,
+        _ => ElementListProbe::Unanswered,
     }
 }
 
@@ -3089,10 +3092,10 @@ impl MacOSProvider {
     ///
     /// AppKit does not put an open status-item menu in `AXChildren`, which is
     /// why walking either the owning app or its `AXExtrasMenuBar` cannot find
-    /// it. The accessibility API exposes that detached menu through
-    /// `AXShownMenuUIElement` on the object providing it. Probe the extras bar
-    /// and each of its direct status-item children because both shapes are
-    /// used by status-item implementations.
+    /// it. The accessibility API exposes that detached menu through AppKit's
+    /// `AXShownMenu` or Carbon's `AXShownMenuUIElement` on the object providing
+    /// it. Probe the extras bar and each of its direct status-item children
+    /// because both shapes are used by status-item implementations.
     ///
     /// Each probe carries the same per-element timeout as the rest of shell
     /// discovery. An app that does not answer contributes no flyout, matching
@@ -3110,26 +3113,29 @@ impl MacOSProvider {
             providers.extend(ax_children(extras.as_ptr()));
 
             for provider in providers {
-                let shown_menu = {
+                let mut shown_menus = Vec::new();
+                for attribute in ["AXShownMenu", "AXShownMenuUIElement"] {
                     let Some(_bound) = Self::shell_probe_bound(&provider) else {
                         continue;
                     };
-                    match probe_element_attr(provider.as_ptr(), "AXShownMenuUIElement") {
-                        ElementProbe::Found(menu) => menu,
-                        ElementProbe::Absent | ElementProbe::Unanswered(_) => continue,
+                    match probe_element_list_attr(provider.as_ptr(), attribute) {
+                        ElementListProbe::Found(menus) => shown_menus.extend(menus),
+                        ElementListProbe::Absent | ElementListProbe::Unanswered => {}
                     }
-                };
-
-                if seen_menus.iter().any(|menu| unsafe {
-                    safe_cf_equal(menu.as_ptr() as CFTypeRef, shown_menu.as_ptr() as CFTypeRef)
-                }) {
-                    continue;
                 }
 
-                let mut data = self.build_element_data(&shown_menu, status_data.pid);
-                data.name = status_data.name.clone();
-                seen_menus.push(shown_menu);
-                surfaces.push((ShellSurfaceKind::Flyout, data));
+                for shown_menu in shown_menus {
+                    if seen_menus.iter().any(|menu| unsafe {
+                        safe_cf_equal(menu.as_ptr() as CFTypeRef, shown_menu.as_ptr() as CFTypeRef)
+                    }) {
+                        continue;
+                    }
+
+                    let mut data = self.build_element_data(&shown_menu, status_data.pid);
+                    data.name = status_data.name.clone();
+                    seen_menus.push(shown_menu);
+                    surfaces.push((ShellSurfaceKind::Flyout, data));
+                }
             }
         }
 

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -407,8 +407,8 @@ fn ax_number_i64(element: AXUIElementRef, attribute: &str) -> Option<i64> {
     }
 }
 
-fn ax_children(element: AXUIElementRef) -> Vec<AXElement> {
-    let value = match ax_attr(element, "AXChildren") {
+fn ax_element_array(element: AXUIElementRef, attribute: &str) -> Vec<AXElement> {
+    let value = match ax_attr(element, attribute) {
         Some(v) => v,
         None => return vec![],
     };
@@ -456,6 +456,10 @@ enum ElementProbe {
     /// element / process is gone. Carries the AXError code so a caller that
     /// treats this as a failure can report which.
     Unanswered(i32),
+}
+
+fn ax_children(element: AXUIElementRef) -> Vec<AXElement> {
+    ax_element_array(element, "AXChildren")
 }
 
 /// Outcome of reading an AX attribute containing one or more accessibility
@@ -3090,13 +3094,12 @@ impl MacOSProvider {
     /// Native menus currently shown by status-item surfaces, as transient
     /// `Flyout` roots.
     ///
-    /// AppKit does not put an open status-item menu in `AXChildren`, which is
-    /// why walking either the owning app or its `AXExtrasMenuBar` cannot find
-    /// it. The accessibility API exposes that detached menu through AppKit's
-    /// `AXShownMenu` or Carbon's `AXShownMenuUIElement` on the object providing
-    /// it. Probe the owning application, extras bar, and each direct
-    /// status-item child because those provider shapes vary across AppKit and
-    /// Carbon implementations.
+    /// AppKit may keep a status-item menu permanently in `AXChildren`, even
+    /// while it is closed, and place it in `AXVisibleChildren` only while it
+    /// is open. Other implementations expose a detached menu through AppKit's
+    /// `AXShownMenu` or Carbon's `AXShownMenuUIElement`. Probe the owning
+    /// application, extras bar, and each direct status-item child because
+    /// those provider shapes vary across implementations.
     ///
     /// Each probe carries the same per-element timeout as the rest of shell
     /// discovery. An app that does not answer contributes no flyout, matching
@@ -3119,11 +3122,17 @@ impl MacOSProvider {
             providers.extend(ax_children(extras.as_ptr()));
 
             for provider in providers {
-                let mut shown_menus = Vec::new();
+                let Some(_bound) = Self::shell_probe_bound(&provider) else {
+                    continue;
+                };
+                let mut shown_menus: Vec<AXElement> =
+                    ax_element_array(provider.as_ptr(), "AXVisibleChildren")
+                        .into_iter()
+                        .filter(|child| {
+                            ax_string(child.as_ptr(), "AXRole").as_deref() == Some("AXMenu")
+                        })
+                        .collect();
                 for attribute in ["AXShownMenu", "AXShownMenuUIElement"] {
-                    let Some(_bound) = Self::shell_probe_bound(&provider) else {
-                        continue;
-                    };
                     match probe_element_list_attr(provider.as_ptr(), attribute) {
                         ElementListProbe::Found(menus) => shown_menus.extend(menus),
                         ElementListProbe::Absent | ElementListProbe::Unanswered => {}

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -3035,6 +3035,59 @@ impl MacOSProvider {
         surfaces
     }
 
+    /// Native menus currently shown by status-item surfaces, as transient
+    /// `Flyout` roots.
+    ///
+    /// AppKit does not put an open status-item menu in `AXChildren`, which is
+    /// why walking either the owning app or its `AXExtrasMenuBar` cannot find
+    /// it. The accessibility API exposes that detached menu through
+    /// `AXShownMenuUIElement` on the object providing it. Probe the extras bar
+    /// and each of its direct status-item children because both shapes are
+    /// used by status-item implementations.
+    ///
+    /// Each probe carries the same per-element timeout as the rest of shell
+    /// discovery. An app that does not answer contributes no flyout, matching
+    /// the documented failure policy of the status-item fan-out above.
+    fn shown_status_menu_surfaces(
+        &self,
+        status_items: &[(ShellSurfaceKind, ElementData)],
+    ) -> Result<Vec<(ShellSurfaceKind, ElementData)>> {
+        let mut surfaces = Vec::new();
+        let mut seen_menus: Vec<AXElement> = Vec::new();
+
+        for (_, status_data) in status_items {
+            let extras = self.get_cached(status_data.handle)?;
+            let mut providers = vec![extras.clone()];
+            providers.extend(ax_children(extras.as_ptr()));
+
+            for provider in providers {
+                let shown_menu = {
+                    let Some(_bound) = Self::shell_probe_bound(&provider) else {
+                        continue;
+                    };
+                    match probe_element_attr(provider.as_ptr(), "AXShownMenuUIElement") {
+                        ElementProbe::Found(menu) => menu,
+                        ElementProbe::Absent | ElementProbe::Unanswered(_) => continue,
+                    }
+                };
+
+                if seen_menus.iter().any(|menu| unsafe {
+                    safe_cf_equal(menu.as_ptr() as CFTypeRef, shown_menu.as_ptr() as CFTypeRef)
+                }) {
+                    continue;
+                }
+
+                let mut data = self.build_element_data(&shown_menu, status_data.pid);
+                data.name = status_data.name.clone();
+                seen_menus.push(shown_menu);
+                surfaces.push((ShellSurfaceKind::Flyout, data));
+            }
+        }
+
+        surfaces.sort_by_key(|(_, data)| data.pid);
+        Ok(surfaces)
+    }
+
     /// The Dock's application element, tagged `Dock`.
     ///
     /// Identified by the CGWindowList owner name, which is what the existing
@@ -3324,23 +3377,24 @@ impl Provider for MacOSProvider {
     }
 
     /// Enumerate the macOS shell surfaces: the frontmost application's menu
-    /// bar, each process's status items, the Dock, and Finder's desktop.
+    /// bar, each process's status items, the Dock, Finder's desktop, and
+    /// native status-item menus while they are open.
     ///
     /// Order is fixed — `menu_bar`, `status_items` by ascending pid, `dock`,
-    /// `desktop` — so repeated listings are comparable even though the
-    /// status-item scan fans out in parallel.
+    /// `desktop`, then open `flyout` menus by ascending pid — so repeated
+    /// listings are comparable even though the status-item scan fans out in
+    /// parallel.
     ///
     /// Reading is the whole of it: nothing here opens, closes, focuses, or
     /// presses anything, and the app-tree `AXMenuBar` filter (PROPOSAL §5) is
     /// untouched — these surfaces reach those elements through their own
     /// roots.
     ///
-    /// `Flyout` is deliberately not implemented on macOS in v1. The macOS
-    /// flyouts are shell processes' `AXSystemDialog` windows (an opened
-    /// Control Center or Notification Center panel), whose enumeration
-    /// contract differs from every other surface here — PROPOSAL §4 and the
-    /// §10-adjacent trade-offs leave it out rather than ship a kind that is
-    /// right on Windows and approximate here.
+    /// `Flyout` covers native status-item menus through the platform's
+    /// `AXShownMenuUIElement` relationship. Control Center and Notification
+    /// Center remain out of scope: those are shell processes'
+    /// `AXSystemDialog` windows, whose enumeration contract differs from the
+    /// status-item roots already available here.
     ///
     /// # Errors
     ///
@@ -3368,13 +3422,16 @@ impl Provider for MacOSProvider {
         if let Some(menu_bar) = self.menu_bar_surface(&apps)? {
             surfaces.push(menu_bar);
         }
-        surfaces.extend(self.status_item_surfaces(&apps));
+        let status_items = self.status_item_surfaces(&apps);
+        let shown_menus = self.shown_status_menu_surfaces(&status_items)?;
+        surfaces.extend(status_items);
         if let Some(dock) = self.dock_surface(&apps)? {
             surfaces.push(dock);
         }
         if let Some(desktop) = self.desktop_surface(&apps)? {
             surfaces.push(desktop);
         }
+        surfaces.extend(shown_menus);
         Ok(surfaces)
     }
 

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -3094,8 +3094,9 @@ impl MacOSProvider {
     /// why walking either the owning app or its `AXExtrasMenuBar` cannot find
     /// it. The accessibility API exposes that detached menu through AppKit's
     /// `AXShownMenu` or Carbon's `AXShownMenuUIElement` on the object providing
-    /// it. Probe the extras bar and each of its direct status-item children
-    /// because both shapes are used by status-item implementations.
+    /// it. Probe the owning application, extras bar, and each direct
+    /// status-item child because those provider shapes vary across AppKit and
+    /// Carbon implementations.
     ///
     /// Each probe carries the same per-element timeout as the rest of shell
     /// discovery. An app that does not answer contributes no flyout, matching
@@ -3110,6 +3111,11 @@ impl MacOSProvider {
         for (_, status_data) in status_items {
             let extras = self.get_cached(status_data.handle)?;
             let mut providers = vec![extras.clone()];
+            if let Some(pid) = status_data.pid {
+                providers.push(AXElement::from_owned(unsafe {
+                    safe_ax_create_application(pid as i32)
+                }));
+            }
             providers.extend(ax_children(extras.as_ptr()));
 
             for provider in providers {

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -3136,7 +3136,7 @@ impl MacOSProvider {
                 for attached_menu in ax_children(provider.as_ptr()).into_iter().filter(|child| {
                     ax_string(child.as_ptr(), "AXRole").as_deref() == Some("AXMenu")
                 }) {
-                    let data = self.build_element_data(&attached_menu, status_data.pid);
+                    let data = self.build_element_data(&attached_menu, status_data.pid)?;
                     if data.states.visible
                         && data
                             .bounds
@@ -3159,7 +3159,7 @@ impl MacOSProvider {
                         continue;
                     }
 
-                    let mut data = self.build_element_data(&shown_menu, status_data.pid);
+                    let mut data = self.build_element_data(&shown_menu, status_data.pid)?;
                     data.name = status_data.name.clone();
                     seen_menus.push(shown_menu);
                     surfaces.push((ShellSurfaceKind::Flyout, data));

--- a/xa11y-macos/src/ax.rs
+++ b/xa11y-macos/src/ax.rs
@@ -458,6 +458,14 @@ enum ElementProbe {
     Unanswered(i32),
 }
 
+/// Outcome of reading an array-valued AX attribute whose members are
+/// accessibility elements.
+enum ElementArrayProbe {
+    Found(Vec<AXElement>),
+    Absent,
+    Unanswered,
+}
+
 /// Read an attribute whose value is an `AXUIElement`, distinguishing "absent"
 /// from "unanswered" by AXError code.
 ///
@@ -483,6 +491,47 @@ fn probe_element_attr(element: AXUIElementRef, attribute: &str) -> ElementProbe 
         // timeout surfaces as), kAXErrorInvalidUIElement, an ObjC exception
         // caught by the wrapper — means we did not get an answer.
         _ => ElementProbe::Unanswered(err),
+    }
+}
+
+/// Read an AX attribute containing an array of accessibility elements.
+///
+/// `kAXShownMenuUIElementAttribute` uses this shape despite its singular
+/// name. Each returned member is retained before the owning array is released.
+fn probe_element_array_attr(element: AXUIElementRef, attribute: &str) -> ElementArrayProbe {
+    let attr = CFString::new(attribute);
+    let mut value: CFTypeRef = std::ptr::null();
+    let err =
+        ffi_copy_attribute_value(element, attr.as_concrete_TypeRef() as CFTypeRef, &mut value);
+    match err {
+        AX_ERROR_SUCCESS => {
+            if value.is_null() {
+                return ElementArrayProbe::Absent;
+            }
+            let elements = unsafe {
+                if safe_cf_get_type_id(value) != safe_cf_array_get_type_id() {
+                    safe_cf_release(value);
+                    return ElementArrayProbe::Unanswered;
+                }
+                let count = safe_cf_array_get_count(value);
+                let mut elements = Vec::with_capacity(count as usize);
+                for i in 0..count {
+                    let element = safe_cf_array_get_value(value, i);
+                    if !element.is_null() {
+                        elements.push(AXElement::from_borrowed(element));
+                    }
+                }
+                safe_cf_release(value);
+                elements
+            };
+            if elements.is_empty() {
+                ElementArrayProbe::Absent
+            } else {
+                ElementArrayProbe::Found(elements)
+            }
+        }
+        AX_ERROR_ATTRIBUTE_UNSUPPORTED | AX_ERROR_NO_VALUE => ElementArrayProbe::Absent,
+        _ => ElementArrayProbe::Unanswered,
     }
 }
 

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -1679,9 +1679,8 @@ impl Provider for WindowsProvider {
         let mut surfaces: Vec<(u8, ShellSurfaceKind, ElementData)> = Vec::new();
 
         for el in found {
-            let Some(class_name) = uia_cached_bstr(&el, UIA_ClassNamePropertyId) else {
-                continue;
-            };
+            let class_name = uia_cached_bstr(&el, UIA_ClassNamePropertyId).unwrap_or_default();
+            let control_type = uia_cached_i32(&el, UIA_ControlTypePropertyId);
 
             let (rank, kind) = match class_name.as_str() {
                 "Shell_TrayWnd" => (0u8, ShellSurfaceKind::Taskbar),
@@ -1735,6 +1734,13 @@ impl Provider for WindowsProvider {
                     if !on_screen {
                         continue;
                     }
+                    (2u8, ShellSurfaceKind::Flyout)
+                }
+                // Windows 11 shell controls do not consistently use the
+                // Win32 system-menu class. UIA's top-level Menu control type
+                // is the stable accessibility signal for those popup hosts;
+                // direct Raw View scope keeps ordinary in-app menus out.
+                _ if control_type == Some(UIA_MenuControlTypeId.0) => {
                     (2u8, ShellSurfaceKind::Flyout)
                 }
                 _ => continue,

--- a/xa11y-windows/src/uia.rs
+++ b/xa11y-windows/src/uia.rs
@@ -563,6 +563,56 @@ impl WindowsProvider {
         }
     }
 
+    /// Direct Raw View children of the UIA desktop root, with the batch cache
+    /// populated on every element.
+    ///
+    /// A `FindAllBuildCache(TreeScope_Children, ...)` query navigates Control
+    /// View even when the cache request itself uses a Raw View tree filter.
+    /// Native `#32768` popup-menu windows are not guaranteed to be control
+    /// elements, so the shell scan must navigate with `RawViewWalker` too.
+    fn raw_children_with_cache(
+        &self,
+        root: &IUIAutomationElement,
+    ) -> Result<Vec<IUIAutomationElement>> {
+        let mut current = match retry_transient(|| unsafe {
+            self.raw_walker
+                .GetFirstChildElementBuildCache(root, &self.batch_request)
+        }) {
+            Ok(element) => element,
+            Err(e) if e.code().is_ok() => return Ok(Vec::new()),
+            Err(e) => {
+                return Err(Error::Platform {
+                    code: i64::from(e.code().0),
+                    message: format!("RawViewWalker.GetFirstChildElementBuildCache failed: {e}"),
+                });
+            }
+        };
+        let mut children = Vec::new();
+
+        loop {
+            children.push(current.clone());
+            current = match retry_transient(|| unsafe {
+                self.raw_walker
+                    .GetNextSiblingElementBuildCache(&current, &self.batch_request)
+            }) {
+                Ok(element) => element,
+                Err(e) if e.code().is_ok() => break,
+                Err(e) => {
+                    return Err(Error::Platform {
+                        code: i64::from(e.code().0),
+                        message: format!(
+                            "RawViewWalker.GetNextSiblingElementBuildCache failed after {} \
+                             desktop child(ren): {e}",
+                            children.len()
+                        ),
+                    });
+                }
+            };
+        }
+
+        Ok(children)
+    }
+
     /// Extract a UIA element's RuntimeId as a `Vec<i32>` for use as a stable
     /// cross-call identity key. `GetRuntimeId` returns a SAFEARRAY of i32 that
     /// uniquely identifies an element within the UIA tree session — the only
@@ -1580,17 +1630,12 @@ impl Provider for WindowsProvider {
     /// Enumerate the Windows shell surfaces by classifying the UIA desktop
     /// root's **direct** children by class name.
     ///
-    /// [`get_children(None)`](Self::get_children) filters the same children to
-    /// `ControlType.Window`, which is exactly what hides the shell: every
-    /// surface below is a `Pane`. This walk therefore drops the control-type
-    /// filter (`TreeScope_Children` + `TrueCondition`) and keeps only the
-    /// classes it recognises. Note this is still the **Control View**, not the
-    /// Raw View: `FindAllBuildCache` walks the control view unless given
-    /// `RawViewWalker`. It works because every shell pane below is a control
-    /// element — a shell window with `IsControlElement=false` would be
-    /// invisible here, and would need the raw walker to reach. Anything else — ordinary app windows and their
-    /// panes — is skipped silently: it is not a shell surface, and it is
-    /// already reachable through `list_apps`.
+    /// [`get_children(None)`](Self::get_children) filters desktop children to
+    /// `ControlType.Window`, which hides the shell panes and native popup-menu
+    /// hosts. This scan walks the desktop root's direct **Raw View** children
+    /// and keeps only the classes it recognises. Anything else — ordinary app
+    /// windows and their panes — is skipped: it is not a shell surface, and it
+    /// is already reachable through `list_apps`.
     ///
     /// | Class name | Kind |
     /// |---|---|
@@ -1599,6 +1644,7 @@ impl Provider for WindowsProvider {
     /// | `TopLevelWindowForOverflowXamlIsland` | [`Flyout`](ShellSurfaceKind::Flyout) — the tray overflow |
     /// | `Microsoft.UI.Content.PopupWindowSiteBridge` | [`Flyout`](ShellSurfaceKind::Flyout) — a shell popup |
     /// | `ControlCenterWindow` | [`Flyout`](ShellSurfaceKind::Flyout) — Quick Settings, **only while its content is on screen** |
+    /// | `#32768` | [`Flyout`](ShellSurfaceKind::Flyout) — a native Win32 popup menu, while open |
     ///
     /// Two shell classes are deliberately *not* listed:
     ///
@@ -1626,19 +1672,13 @@ impl Provider for WindowsProvider {
     /// scan aborted.
     fn list_shell_surfaces(&self) -> Result<Vec<(ShellSurfaceKind, ElementData)>> {
         let root = uia_call(|| unsafe { self.automation.GetRootElement() })?;
-        let true_cond = uia_call(|| unsafe { self.automation.CreateTrueCondition() })?;
-        let found = uia_call(|| unsafe {
-            root.FindAllBuildCache(TreeScope_Children, &true_cond, &self.batch_request)
-        })?;
+        let found = self.raw_children_with_cache(&root)?;
 
         // (rank, kind, data) — rank groups the output; the stable sort below
         // keeps enumeration order within a group.
         let mut surfaces: Vec<(u8, ShellSurfaceKind, ElementData)> = Vec::new();
 
-        for i in 0..uia_len(&found) {
-            let Some(el) = uia_get(&found, i) else {
-                continue;
-            };
+        for el in found {
             let Some(class_name) = uia_cached_bstr(&el, UIA_ClassNamePropertyId) else {
                 continue;
             };
@@ -1650,7 +1690,13 @@ impl Provider for WindowsProvider {
                 // the flyout is open, so its presence is the open signal.
                 // The XAML popup site bridge behaves the same way.
                 "TopLevelWindowForOverflowXamlIsland"
-                | "Microsoft.UI.Content.PopupWindowSiteBridge" => (2u8, ShellSurfaceKind::Flyout),
+                | "Microsoft.UI.Content.PopupWindowSiteBridge"
+                // Win32 creates a top-level window of the system menu class
+                // for TrackPopupMenu-style menus. It exists only while the
+                // menu is open and exposes its commands as UIA menu items.
+                // Native notification-area menus use this path rather than
+                // either of the XAML popup hosts above.
+                | "#32768" => (2u8, ShellSurfaceKind::Flyout),
                 // Quick Settings is the exception: its host window persists as
                 // a desktop-root child after dismissal, keeping the bounds it
                 // had while open, and only its XAML content goes offscreen.

--- a/xa11y/tests/integ/shell.rs
+++ b/xa11y/tests/integ/shell.rs
@@ -343,12 +343,18 @@ mod tests {
     #[test]
     #[ignore]
     fn a_native_taskbar_popup_exposes_visible_menu_items_as_a_flyout() {
-        struct DismissMenu(xa11y::InputSim);
+        struct DismissMenu {
+            input: xa11y::InputSim,
+            app: xa11y::Element,
+        }
 
         impl Drop for DismissMenu {
             fn drop(&mut self) {
-                if let Err(e) = self.0.keyboard().press(xa11y::Key::Escape) {
+                if let Err(e) = self.input.keyboard().press(xa11y::Key::Escape) {
                     eprintln!("failed to dismiss the taskbar popup during cleanup: {e}");
+                }
+                if let Err(e) = self.app.focus() {
+                    eprintln!("failed to restore the test app's focus during cleanup: {e}");
                 }
             }
         }
@@ -376,7 +382,10 @@ mod tests {
             .mouse()
             .right_click(clock)
             .unwrap_or_else(|e| panic!("right-click the taskbar clock: {e}"));
-        let _dismiss = DismissMenu(input);
+        let _dismiss = DismissMenu {
+            input,
+            app: crate::integ::app_root().as_element(),
+        };
 
         let flyout = ShellSurface::by_kind(ShellSurfaceKind::Flyout, LOOKUP_TIMEOUT)
             .unwrap_or_else(|e| panic!("the open native taskbar menu was not listed: {e}"));

--- a/xa11y/tests/integ/shell.rs
+++ b/xa11y/tests/integ/shell.rs
@@ -344,7 +344,7 @@ mod tests {
     fn a_native_taskbar_popup_exposes_visible_menu_items_as_a_flyout() {
         struct DismissMenu {
             input: xa11y::InputSim,
-            app: xa11y::Element,
+            window: xa11y::Element,
         }
 
         impl Drop for DismissMenu {
@@ -354,8 +354,8 @@ mod tests {
                         eprintln!("failed to dismiss the {surface} during cleanup: {e}");
                     }
                 }
-                if let Err(e) = self.app.focus() {
-                    eprintln!("failed to restore the test app's focus during cleanup: {e}");
+                if let Err(e) = self.window.activate() {
+                    eprintln!("failed to reactivate the test app during cleanup: {e}");
                 }
             }
         }
@@ -387,15 +387,20 @@ mod tests {
             )
         });
 
+        let app = crate::integ::app_root();
+        let window = app
+            .windows()
+            .expect("enumerate the test app's windows for cleanup")
+            .into_iter()
+            .next()
+            .expect("the test app must have a window to reactivate during cleanup");
+
         let input = xa11y::input_sim().unwrap_or_else(|e| panic!("create input backend: {e}"));
         input
             .mouse()
             .right_click(&fixture_icon)
             .unwrap_or_else(|e| panic!("right-click the real notification icon: {e}"));
-        let _dismiss = DismissMenu {
-            input,
-            app: crate::integ::app_root().as_element(),
-        };
+        let _dismiss = DismissMenu { input, window };
 
         let deadline = std::time::Instant::now() + LOOKUP_TIMEOUT;
         loop {

--- a/xa11y/tests/integ/shell.rs
+++ b/xa11y/tests/integ/shell.rs
@@ -334,11 +334,10 @@ mod tests {
     /// Windows: a native context menu opened from the real notification area
     /// is discoverable as a flyout, including its actionable menu items.
     ///
-    /// The widest visible `SystemTrayIcon` is the clock/date control on the
-    /// Windows 11 taskbar. Its text is locale-dependent, so the test selects
-    /// it by the shell's stable automation id and geometry rather than its
-    /// English name. Right-clicking it opens a native `#32768` popup menu,
-    /// which is the window shape tray applications use too.
+    /// The Windows harness registers a real `NotifyIcon` with Explorer. A new
+    /// icon may land in the taskbar's visible tray row or its overflow, so the
+    /// test handles both placements before right-clicking it. Its legacy
+    /// WinForms `ContextMenu` is a native `#32768` Win32 popup.
     #[cfg(target_os = "windows")]
     #[test]
     #[ignore]
@@ -350,8 +349,10 @@ mod tests {
 
         impl Drop for DismissMenu {
             fn drop(&mut self) {
-                if let Err(e) = self.input.keyboard().press(xa11y::Key::Escape) {
-                    eprintln!("failed to dismiss the taskbar popup during cleanup: {e}");
+                for surface in ["native tray menu", "notification overflow"] {
+                    if let Err(e) = self.input.keyboard().press(xa11y::Key::Escape) {
+                        eprintln!("failed to dismiss the {surface} during cleanup: {e}");
+                    }
                 }
                 if let Err(e) = self.app.focus() {
                     eprintln!("failed to restore the test app's focus during cleanup: {e}");
@@ -361,47 +362,70 @@ mod tests {
 
         let taskbar = ShellSurface::by_kind(ShellSurfaceKind::Taskbar, LOOKUP_TIMEOUT)
             .unwrap_or_else(|e| panic!("no taskbar surface: {e}"));
-        let tray_controls = taskbar
-            .locator("button[stable_id='SystemTrayIcon'][visible='true']")
+        let mut fixture_icons = taskbar
+            .locator("[name*='xa11y tray fixture'][visible='true']")
             .elements()
-            .unwrap_or_else(|e| panic!("notification-area controls: {e}"));
-        let clock = tray_controls
-            .iter()
-            .filter_map(|element| element.bounds.map(|bounds| (element, bounds)))
-            .max_by_key(|(_, bounds)| bounds.width)
-            .map(|(element, _)| element)
-            .unwrap_or_else(|| {
-                panic!(
-                    "the real taskbar has no bounded visible SystemTrayIcon control; dump:\n{}",
-                    taskbar.dump(Some(5)).unwrap_or_default()
-                )
-            });
+            .unwrap_or_else(|e| panic!("search the real taskbar for the tray fixture: {e}"));
+
+        if fixture_icons.is_empty() {
+            taskbar
+                .locator("button[name='Show Hidden Icons']")
+                .press()
+                .unwrap_or_else(|e| panic!("open the real notification overflow: {e}"));
+            let overflow = ShellSurface::by_kind(ShellSurfaceKind::Flyout, LOOKUP_TIMEOUT)
+                .unwrap_or_else(|e| panic!("the notification overflow did not open: {e}"));
+            fixture_icons = overflow
+                .locator("[name*='xa11y tray fixture'][visible='true']")
+                .elements()
+                .unwrap_or_else(|e| panic!("search the notification overflow: {e}"));
+        }
+
+        let fixture_icon = fixture_icons.into_iter().next().unwrap_or_else(|| {
+            panic!(
+                "the harness's real NotifyIcon appeared in neither taskbar placement; dump:\n{}",
+                taskbar.dump(Some(5)).unwrap_or_default()
+            )
+        });
 
         let input = xa11y::input_sim().unwrap_or_else(|e| panic!("create input backend: {e}"));
         input
             .mouse()
-            .right_click(clock)
-            .unwrap_or_else(|e| panic!("right-click the taskbar clock: {e}"));
+            .right_click(&fixture_icon)
+            .unwrap_or_else(|e| panic!("right-click the real notification icon: {e}"));
         let _dismiss = DismissMenu {
             input,
             app: crate::integ::app_root().as_element(),
         };
 
-        let flyout = ShellSurface::by_kind(ShellSurfaceKind::Flyout, LOOKUP_TIMEOUT)
-            .unwrap_or_else(|e| panic!("the open native taskbar menu was not listed: {e}"));
-        let items = flyout
-            .locator("menu_item[visible='true']")
-            .elements()
-            .unwrap_or_else(|e| panic!("search the native taskbar menu: {e}"));
-        assert!(
-            !items.is_empty(),
-            "the open native taskbar menu exposes no visible menu items; dump:\n{}",
-            flyout.dump(Some(3)).unwrap_or_default()
-        );
-        assert!(
-            items.iter().any(|item| item.name.is_some()),
-            "the native taskbar menu has no addressable item: {items:?}"
-        );
+        let deadline = std::time::Instant::now() + LOOKUP_TIMEOUT;
+        loop {
+            let found = listing()
+                .into_iter()
+                .filter(|surface| surface.kind == ShellSurfaceKind::Flyout)
+                .find_map(|surface| {
+                    let items = surface
+                        .locator("menu_item[name*='xa11y tray action'][visible='true']")
+                        .elements()
+                        .unwrap_or_else(|e| panic!("search a listed flyout for tray items: {e}"));
+                    (items.len() == 2).then_some((surface, items))
+                });
+            if let Some((flyout, items)) = found {
+                assert!(
+                    items
+                        .iter()
+                        .all(|item| item.actions.iter().any(|a| a == "press")),
+                    "the native tray menu items are not actionable: {items:?}; dump:\n{}",
+                    flyout.dump(Some(3)).unwrap_or_default()
+                );
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the native tray menu never exposed its two visible menu items; listing: {}",
+                describe(&listing())
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
     }
 
     /// Linux: the panel surface is the harness's dock frame, and its widgets

--- a/xa11y/tests/integ/shell.rs
+++ b/xa11y/tests/integ/shell.rs
@@ -331,6 +331,70 @@ mod tests {
         );
     }
 
+    /// Windows: a native context menu opened from the real notification area
+    /// is discoverable as a flyout, including its actionable menu items.
+    ///
+    /// The widest visible `SystemTrayIcon` is the clock/date control on the
+    /// Windows 11 taskbar. Its text is locale-dependent, so the test selects
+    /// it by the shell's stable automation id and geometry rather than its
+    /// English name. Right-clicking it opens a native `#32768` popup menu,
+    /// which is the window shape tray applications use too.
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[ignore]
+    fn a_native_taskbar_popup_exposes_visible_menu_items_as_a_flyout() {
+        struct DismissMenu(xa11y::InputSim);
+
+        impl Drop for DismissMenu {
+            fn drop(&mut self) {
+                if let Err(e) = self.0.keyboard().press(xa11y::Key::Escape) {
+                    eprintln!("failed to dismiss the taskbar popup during cleanup: {e}");
+                }
+            }
+        }
+
+        let taskbar = ShellSurface::by_kind(ShellSurfaceKind::Taskbar, LOOKUP_TIMEOUT)
+            .unwrap_or_else(|e| panic!("no taskbar surface: {e}"));
+        let tray_controls = taskbar
+            .locator("button[stable_id='SystemTrayIcon'][visible='true']")
+            .elements()
+            .unwrap_or_else(|e| panic!("notification-area controls: {e}"));
+        let clock = tray_controls
+            .iter()
+            .filter_map(|element| element.bounds.map(|bounds| (element, bounds)))
+            .max_by_key(|(_, bounds)| bounds.width)
+            .map(|(element, _)| element)
+            .unwrap_or_else(|| {
+                panic!(
+                    "the real taskbar has no bounded visible SystemTrayIcon control; dump:\n{}",
+                    taskbar.dump(Some(5)).unwrap_or_default()
+                )
+            });
+
+        let input = xa11y::input_sim().unwrap_or_else(|e| panic!("create input backend: {e}"));
+        input
+            .mouse()
+            .right_click(clock)
+            .unwrap_or_else(|e| panic!("right-click the taskbar clock: {e}"));
+        let _dismiss = DismissMenu(input);
+
+        let flyout = ShellSurface::by_kind(ShellSurfaceKind::Flyout, LOOKUP_TIMEOUT)
+            .unwrap_or_else(|e| panic!("the open native taskbar menu was not listed: {e}"));
+        let items = flyout
+            .locator("menu_item[visible='true']")
+            .elements()
+            .unwrap_or_else(|e| panic!("search the native taskbar menu: {e}"));
+        assert!(
+            !items.is_empty(),
+            "the open native taskbar menu exposes no visible menu items; dump:\n{}",
+            flyout.dump(Some(3)).unwrap_or_default()
+        );
+        assert!(
+            items.iter().any(|item| item.name.is_some()),
+            "the native taskbar menu has no addressable item: {items:?}"
+        );
+    }
+
     /// Linux: the panel surface is the harness's dock frame, and its widgets
     /// are reachable through it.
     ///

--- a/xa11y/tests/integ/shell.rs
+++ b/xa11y/tests/integ/shell.rs
@@ -369,7 +369,7 @@ mod tests {
 
         if fixture_icons.is_empty() {
             taskbar
-                .locator("button[name='Show Hidden Icons']")
+                .locator("button[name*='Show Hidden Icons']")
                 .press()
                 .unwrap_or_else(|e| panic!("open the real notification overflow: {e}"));
             let overflow = ShellSurface::by_kind(ShellSurfaceKind::Flyout, LOOKUP_TIMEOUT)


### PR DESCRIPTION
Fixes #395

Rebased onto main after #394.

Root cause

- Windows requested Raw View properties but enumerated desktop children through a Control View FindAll traversal. Native Win32 popup menus are non-control top-level windows of class #32768, so they were absent before classification.
- macOS status-item menu representation varies by accessibility implementation. Current AppKit keeps the menu permanently attached in AXChildren and gives it an on-screen frame only while displayed; other AppKit/Carbon providers publish detached menus through AXShownMenu or AXShownMenuUIElement.

Fix

- Walk Windows desktop children with RawViewWalker plus the existing cache request, classify #32768 windows as transient flyouts, and also accept top-level Raw View UIA Menu roots.
- On macOS, recognize displayed attached AXMenu children by visible/on-screen state and probe the documented scalar/array shown-menu attributes for detached variants. Deduplicate the resulting native menu roots and expose them as transient flyouts.
- Document that Linux panel menus are not supported by this API because StatusNotifierItem menus use com.canonical.dbusmenu rather than AT-SPI.

Coverage

- The Windows harness registers a real NotifyIcon with Explorer. Its ignored integration test finds the icon in the taskbar or real notification overflow, right-clicks it, and requires both actionable items from its native HMENU/#32768 popup through a flyout. The overflow-button lookup accepts the accessible-name suffix Windows adds on some desktops.
- The macOS Cocoa fixture creates a real NSStatusItem/NSMenu. Its integration test asserts the closed menu is not a flyout, pointer-clicks the actual menu-bar item, then finds and presses the visible native NSMenuItem through the flyout.
- The existing Linux integration test continues to assert against the real GTK dock/panel fixture; transient StatusNotifierItem menus remain explicitly unsupported there.

Local verification

- cargo fmt --all -- --check
- cargo xtask check: Rust/unit/doc/JS checks pass; Python/ruff portions could not run because this host lacks pip, pytest, and ruff.
- Windows real-desktop harness: 152/161 full-suite tests passed. The tray test found the real Explorer overflow and fixture icon, then this elevated host rejected SendInput with Windows error 5. The other eight failures were foreground-lock/focus tests while ChatGPT owned foreground focus. CI runs the same harness in a normal-permission desktop session.